### PR TITLE
Expand checks

### DIFF
--- a/.github/workflows/model-checks.yml
+++ b/.github/workflows/model-checks.yml
@@ -1,4 +1,4 @@
-name: Linter
+name: Model checks
 
 on:
   push:
@@ -22,6 +22,6 @@ jobs:
         run: |
           pip install -r requirements.txt
 
-      - name: Lint
+      - name: Run checks
         run: |
-          make lint
+          make check

--- a/src/linkml/data-access-schema.yaml
+++ b/src/linkml/data-access-schema.yaml
@@ -11,6 +11,7 @@ description: >-
 prefixes:
   dlco: https://concepts.datalad.org/ontology/
   schema: http://schema.org/
+  linkml: https://w3id.org/linkml/
 imports:
   - types
   - typing

--- a/src/linkml/datalad-datasets.yaml
+++ b/src/linkml/datalad-datasets.yaml
@@ -5,6 +5,7 @@ name: datalad-datasets
 prefixes:
   dlco: https://concepts.datalad.org/ontology/
   dct: http://purl.org/dc/terms/
+  rdfs: http://www.w3.org/2000/01/rdf-schema#
 imports:
   - datasets
   - types
@@ -17,6 +18,15 @@ slots:
     description: >-
       Unique identifier.
     range: string
+
+  name:
+    description: >-
+      Name of the item or entity.
+    range: string
+    exact_mappings:
+      - schema:name
+      - rdfs:label
+
 
 enums:
   DirectoryItemType:
@@ -134,15 +144,17 @@ classes:
     description: >-
       An item in a directory. Assigns a name and other properties to some
       content.
-    attributes:
+    slots:
+      - name
+    slot_usage:
       name:
-        range: string
         description: >-
           Name of a directory item.
         # TODO this should (hopefully) mean that the value is unique
         # within a particular context, not globally, but instead here
         # within a single directory
         identifier: true
+    attributes:
       type:
         description: >-
           Identifier of the item type.
@@ -206,6 +218,12 @@ classes:
       - HasTypeDesignator
     description: >-
       Agent representation in a Git context
+    slots:
+      - name
+    slot_usage:
+      name:
+        description: >-
+          Full name of the agent
     attributes:
       # TODO others could use ORCID
       id:
@@ -213,8 +231,6 @@ classes:
           Place holder for an actual description
         identifier: true
         string_serialization: "{name} <{email}>"
-        range: string
-      name:
         range: string
       email:
         description: >-

--- a/src/linkml/datalad-datasets.yaml
+++ b/src/linkml/datalad-datasets.yaml
@@ -9,6 +9,7 @@ imports:
   - datasets
   - types
   - typing
+default_prefix: dlco
 
 slots:
   id:

--- a/src/linkml/datasets.yaml
+++ b/src/linkml/datasets.yaml
@@ -10,6 +10,7 @@ prefixes:
   linkml: https://w3id.org/linkml/
 imports:
   - linkml:types
+default_prefix: dlco
 
 slots:
   version_label:

--- a/src/linkml/typing.yaml
+++ b/src/linkml/typing.yaml
@@ -4,7 +4,7 @@ title: Utilities for metadata type designation and inference
 description: >-
   TODO
 prefixes:
-  dlco: https://concepts.datalad.org/typing/
+  dlco: https://concepts.datalad.org/ontology/
 imports:
   - types
   - linkml:types


### PR DESCRIPTION
Now convert each schema also in various different formats. These conversions are not suitable as test per-se, as they only issues warnings. We introduce a contraption that will make them fail, if they produce any output on stderr. By default this will be warnings of more critical issues.

This is useful, because no linkml checker actually tests all testable aspects.