### PR TITLE
Add pattern for gitsha

### DIFF
--- a/src/linkml/git-provenance-schema.yaml
+++ b/src/linkml/git-provenance-schema.yaml
@@ -42,6 +42,7 @@ classes:
       - meta_id
     slot_usage:
       gitsha:
+        pattern: "^[0-9a-f]{40}$"
         description: >-
           SHA1 identifier of the commit object.
       meta_id:


### PR DESCRIPTION
I was curious why meta_id has it and not gitsha -- may be there is a reason? Asking as a PR