### PR TITLE
Introduce for `SchemaElement` base class

### DIFF
--- a/src/linkml/ontology/schema_utils.yaml
+++ b/src/linkml/ontology/schema_utils.yaml
@@ -43,3 +43,12 @@ classes:
     slot_usage:
       meta_type:
         required: true
+
+  SchemaElement:
+    class_uri: dlco:SchemaElement
+    description: >-
+      Base class for schema elements. These are classes that add
+      structure-defining properties to classes that implement
+      ontology concepts.
+    comments:
+      - Derived classes should carry the name suffix `SE` to allow for intuitive naming while avoiding name conflicts with ontology concept classes

--- a/src/linkml/schemas/datalad-dataset-components.yaml
+++ b/src/linkml/schemas/datalad-dataset-components.yaml
@@ -54,6 +54,7 @@ imports:
 classes:
   ContainerSE:
     class_uri: dlccs:ContainerSE
+    is_a: SchemaElement
     description: >-
       A container for dataset component objects.
     tree_root: true
@@ -67,6 +68,7 @@ classes:
 
   ComponentSE:
     class_uri: dlccs:ComponentSE
+    is_a: SchemaElement
     mixins:
       - HasRequiredMetaTypeDesignator
     description: >-
@@ -92,6 +94,7 @@ classes:
 
   QualifiedGitTrackedPartSE:
     class_uri: dlccs:QualifiedGitTrackedPartSE
+    is_a: SchemaElement
     mixins:
       - QualifiedPart
     description: >-
@@ -103,6 +106,7 @@ classes:
 
   QualifiedAnnexAccessSE:
     class_uri: dlccs:QualifiedAnnexAccessSE
+    is_a: SchemaElement
     mixins:
       - QualifiedAnnexAccess
     description: >-
@@ -182,6 +186,7 @@ classes:
 
   FilesystemDirectoryItemSE:
     class_uri: dlccs:FilesystemDirectoryItemSE
+    is_a: SchemaElement
     mixins:
       - FilesystemDirectoryItem
     description: >-
@@ -200,6 +205,7 @@ classes:
 
   CommittingSE:
     class_uri: dlccs:CommittingSE
+    is_a: SchemaElement
     mixins:
       - Committing
     description: >-


### PR DESCRIPTION
Mainly to neatly associate schema element classes with this concept/approach, and to have a place to attach related documentation too.