### PR TITLE
Introduce document-local object identification by a code

### DIFF
--- a/src/examples/datalad-dataset-components/ContainerSE-DataladDataset-minimal.json
+++ b/src/examples/datalad-dataset-components/ContainerSE-DataladDataset-minimal.json
@@ -1,8 +1,8 @@
 {
   "components": [
     {
-      "meta_id": "datalad:0b76362c-aa27-11ee-be29-b3b123281259",
       "meta_type": "dlccs:DataladDatasetSE",
+      "meta_id": "datalad:0b76362c-aa27-11ee-be29-b3b123281259",
       "uuid": "0b76362c-aa27-11ee-be29-b3b123281259"
     }
   ],

--- a/src/examples/datalad-dataset-components/ContainerSE-DataladDatasetVersion-linkage.json
+++ b/src/examples/datalad-dataset-components/ContainerSE-DataladDatasetVersion-linkage.json
@@ -1,22 +1,19 @@
 {
   "components": [
     {
-      "meta_id": "datalad:0b76362c-aa27-11ee-be29-b3b123281259",
       "meta_type": "dlccs:DataladDatasetSE",
+      "meta_id": "datalad:0b76362c-aa27-11ee-be29-b3b123281259",
       "uuid": "0b76362c-aa27-11ee-be29-b3b123281259"
     },
     {
-      "meta_id": "gitsha:558275f650574389dcbbf7cd8ab5046482473fc8",
       "meta_type": "dlccs:DataladDatasetVersionSE",
+      "meta_id": "gitsha:558275f650574389dcbbf7cd8ab5046482473fc8",
       "gitsha": "558275f650574389dcbbf7cd8ab5046482473fc8",
       "distribution": "gitsha:712f54082540c4f07f4f18e50fcd47e2ae9b95ed",
       "is_version_of": "datalad:0b76362c-aa27-11ee-be29-b3b123281259",
       "tree": "gitsha:712f54082540c4f07f4f18e50fcd47e2ae9b95ed",
       "was_generated_by": {
-        "was_associated_with": {
-          "name": "Jane Doe",
-          "email": "doe@example.com"
-        }
+        "was_associated_with": "doe@example.com"
       }
     }
   ],

--- a/src/examples/datalad-dataset-components/ContainerSE-DataladDatasetVersion-linkage.yaml
+++ b/src/examples/datalad-dataset-components/ContainerSE-DataladDatasetVersion-linkage.yaml
@@ -8,6 +8,4 @@ components:
     is_version_of: datalad:0b76362c-aa27-11ee-be29-b3b123281259
     tree: gitsha:712f54082540c4f07f4f18e50fcd47e2ae9b95ed
     was_generated_by:
-      was_associated_with:
-        name: Jane Doe
-        email: doe@example.com
+      was_associated_with: doe@example.com

--- a/src/examples/datalad-dataset-components/ContainerSE-DatasetWFiles.json
+++ b/src/examples/datalad-dataset-components/ContainerSE-DatasetWFiles.json
@@ -1,13 +1,13 @@
 {
   "components": [
     {
-      "meta_id": "datalad:0b76362c-aa27-11ee-be29-b3b123281259",
       "meta_type": "dlccs:DataladDatasetSE",
+      "meta_id": "datalad:0b76362c-aa27-11ee-be29-b3b123281259",
       "uuid": "0b76362c-aa27-11ee-be29-b3b123281259"
     },
     {
-      "meta_id": "gitsha:558275f650574389dcbbf7cd8ab5046482473fc8",
       "meta_type": "dlccs:DataladDatasetVersionSE",
+      "meta_id": "gitsha:558275f650574389dcbbf7cd8ab5046482473fc8",
       "gitsha": "558275f650574389dcbbf7cd8ab5046482473fc8",
       "distribution": "gitsha:712f54082540c4f07f4f18e50fcd47e2ae9b95ed",
       "has_annex_remote": [
@@ -16,15 +16,12 @@
       "is_version_of": "datalad:0b76362c-aa27-11ee-be29-b3b123281259",
       "tree": "gitsha:712f54082540c4f07f4f18e50fcd47e2ae9b95ed",
       "was_generated_by": {
-        "was_associated_with": {
-          "name": "Jane Doe",
-          "email": "doe@example.com"
-        }
+        "was_associated_with": "doe@example.com"
       }
     },
     {
-      "meta_id": "gitsha:712f54082540c4f07f4f18e50fcd47e2ae9b95ed",
       "meta_type": "dlccs:GitTreeSE",
+      "meta_id": "gitsha:712f54082540c4f07f4f18e50fcd47e2ae9b95ed",
       "gitsha": "712f54082540c4f07f4f18e50fcd47e2ae9b95ed",
       "qualified_part": [
         {
@@ -34,8 +31,8 @@
       ]
     },
     {
-      "meta_id": "gitsha:13ffd94a94e32f9482528fc65d59562b011f6f87",
       "meta_type": "dlccs:GitTreeSE",
+      "meta_id": "gitsha:13ffd94a94e32f9482528fc65d59562b011f6f87",
       "gitsha": "13ffd94a94e32f9482528fc65d59562b011f6f87",
       "qualified_part": [
         {
@@ -49,13 +46,13 @@
       ]
     },
     {
-      "meta_id": "gitsha:56094a33cf330fef5b375aa813fc4dc07147729f",
       "meta_type": "dlccs:GitBlobSE",
+      "meta_id": "gitsha:56094a33cf330fef5b375aa813fc4dc07147729f",
       "gitsha": "56094a33cf330fef5b375aa813fc4dc07147729f"
     },
     {
-      "meta_id": "annexkey:MD5E-s3425--32a617360d10e3dcbfdd0885e8d64ab8.bin",
       "meta_type": "dlccs:StableAnnexKeySE",
+      "meta_id": "annexkey:MD5E-s3425--32a617360d10e3dcbfdd0885e8d64ab8.bin",
       "qualified_access": [
         {
           "relation": "annex:7e0bf3e7-7d46-4093-813e-b4009826c3bf",
@@ -65,8 +62,8 @@
       "byte_size": 3425
     },
     {
-      "meta_id": "annex:7e0bf3e7-7d46-4093-813e-b4009826c3bf",
       "meta_type": "dlccs:AnnexRemoteSE",
+      "meta_id": "annex:7e0bf3e7-7d46-4093-813e-b4009826c3bf",
       "uuid": "7e0bf3e7-7d46-4093-813e-b4009826c3bf"
     }
   ],

--- a/src/examples/datalad-dataset-components/ContainerSE-DatasetWFiles.yaml
+++ b/src/examples/datalad-dataset-components/ContainerSE-DatasetWFiles.yaml
@@ -9,9 +9,7 @@ components:
     gitsha: 558275f650574389dcbbf7cd8ab5046482473fc8
     tree: gitsha:712f54082540c4f07f4f18e50fcd47e2ae9b95ed
     was_generated_by:
-      was_associated_with:
-        name: Jane Doe
-        email: doe@example.com
+      was_associated_with: doe@example.com
     is_version_of: datalad:0b76362c-aa27-11ee-be29-b3b123281259
     has_annex_remote:
       - annex:7e0bf3e7-7d46-4093-813e-b4009826c3bf

--- a/src/examples/datalad-dataset-components/ContainerSE-DatasetWSubdataset.json
+++ b/src/examples/datalad-dataset-components/ContainerSE-DatasetWSubdataset.json
@@ -1,8 +1,8 @@
 {
   "components": [
     {
-      "meta_id": "gitsha:558275f650574389dcbbf7cd8ab5046482473fc8",
       "meta_type": "dlccs:DataladDatasetVersionSE",
+      "meta_id": "gitsha:558275f650574389dcbbf7cd8ab5046482473fc8",
       "gitsha": "558275f650574389dcbbf7cd8ab5046482473fc8",
       "distribution": "gitsha:712f54082540c4f07f4f18e50fcd47e2ae9b95ed",
       "has_part": [
@@ -10,28 +10,22 @@
       ],
       "tree": "gitsha:712f54082540c4f07f4f18e50fcd47e2ae9b95ed",
       "was_generated_by": {
-        "was_associated_with": {
-          "name": "Jane Doe",
-          "email": "doe@example.com"
-        }
+        "was_associated_with": "doe@example.com"
       }
     },
     {
-      "meta_id": "gitsha:d956832059a7837ad31e60a84ec1399b3460e0e3",
       "meta_type": "dlccs:DataladDatasetVersionSE",
+      "meta_id": "gitsha:d956832059a7837ad31e60a84ec1399b3460e0e3",
       "gitsha": "d956832059a7837ad31e60a84ec1399b3460e0e3",
       "distribution": "gitsha:0dc0410fd3328c608ca8d89802fb0f9f4a84abf9",
       "tree": "gitsha:0dc0410fd3328c608ca8d89802fb0f9f4a84abf9",
       "was_generated_by": {
-        "was_associated_with": {
-          "name": "John Doe",
-          "email": "jdoe@example.com"
-        }
+        "was_associated_with": "jdoe@example.com"
       }
     },
     {
-      "meta_id": "gitsha:712f54082540c4f07f4f18e50fcd47e2ae9b95ed",
       "meta_type": "dlccs:GitTreeSE",
+      "meta_id": "gitsha:712f54082540c4f07f4f18e50fcd47e2ae9b95ed",
       "gitsha": "712f54082540c4f07f4f18e50fcd47e2ae9b95ed",
       "qualified_part": [
         {

--- a/src/examples/datalad-dataset-components/ContainerSE-DatasetWSubdataset.yaml
+++ b/src/examples/datalad-dataset-components/ContainerSE-DatasetWSubdataset.yaml
@@ -8,18 +8,14 @@ components:
       # the DataladDatasetVersion instance is the part
       - gitsha:d956832059a7837ad31e60a84ec1399b3460e0e3
     was_generated_by:
-      was_associated_with:
-        name: Jane Doe
-        email: doe@example.com
+      was_associated_with: doe@example.com
   # (sub)dataset version
   - meta_id: gitsha:d956832059a7837ad31e60a84ec1399b3460e0e3
     meta_type: dlccs:DataladDatasetVersionSE
     gitsha: d956832059a7837ad31e60a84ec1399b3460e0e3
     tree: gitsha:0dc0410fd3328c608ca8d89802fb0f9f4a84abf9
     was_generated_by:
-      was_associated_with:
-        name: John Doe
-        email: jdoe@example.com
+      was_associated_with: jdoe@example.com
   # root tree of (super)dataset version
   - meta_id: gitsha:712f54082540c4f07f4f18e50fcd47e2ae9b95ed
     meta_type: dlccs:GitTreeSE

--- a/src/examples/datalad-dataset-components/ContainerSE-multiversion-dataset.json
+++ b/src/examples/datalad-dataset-components/ContainerSE-multiversion-dataset.json
@@ -1,0 +1,47 @@
+{
+  "components": [
+    {
+      "meta_type": "dlccs:DataladDatasetSE",
+      "meta_id": "datalad:0b76362c-aa27-11ee-be29-b3b123281259",
+      "uuid": "0b76362c-aa27-11ee-be29-b3b123281259"
+    },
+    {
+      "meta_type": "dlccs:DataladDatasetVersionSE",
+      "meta_id": "gitsha:558275f650574389dcbbf7cd8ab5046482473fc8",
+      "gitsha": "558275f650574389dcbbf7cd8ab5046482473fc8",
+      "distribution": "gitsha:712f54082540c4f07f4f18e50fcd47e2ae9b95ed",
+      "is_version_of": "datalad:0b76362c-aa27-11ee-be29-b3b123281259",
+      "tree": "gitsha:712f54082540c4f07f4f18e50fcd47e2ae9b95ed",
+      "was_derived_from": [
+        "gitsha:2a1c3934a5df1bb05ad76b4827eabd1cd5a20c8e"
+      ],
+      "was_generated_by": {
+        "was_associated_with": "doe@example.com",
+        "was_informed_by": {
+          "was_associated_with": "doe@example.com"
+        }
+      }
+    },
+    {
+      "meta_type": "dlccs:DataladDatasetVersionSE",
+      "meta_id": "gitsha:2a1c3934a5df1bb05ad76b4827eabd1cd5a20c8e",
+      "gitsha": "2a1c3934a5df1bb05ad76b4827eabd1cd5a20c8e",
+      "distribution": "gitsha:8a8780defb4c422766b2c29e6ac62bff06ced7c5",
+      "is_version_of": "datalad:0b76362c-aa27-11ee-be29-b3b123281259",
+      "tree": "gitsha:8a8780defb4c422766b2c29e6ac62bff06ced7c5",
+      "was_generated_by": {
+        "was_associated_with": "doe@example.com",
+        "was_informed_by": {
+          "was_associated_with": "doe@example.com"
+        }
+      }
+    },
+    {
+      "meta_type": "dlccs:GitUserAgentSE",
+      "meta_code": "doe@example.com",
+      "name": "Jane Doe",
+      "email": "doe@example.com"
+    }
+  ],
+  "@type": "ContainerSE"
+}

--- a/src/examples/datalad-dataset-components/ContainerSE-multiversion-dataset.yaml
+++ b/src/examples/datalad-dataset-components/ContainerSE-multiversion-dataset.yaml
@@ -1,0 +1,28 @@
+components:
+  - meta_id: datalad:0b76362c-aa27-11ee-be29-b3b123281259
+    meta_type: dlccs:DataladDatasetSE
+    uuid: 0b76362c-aa27-11ee-be29-b3b123281259
+  - meta_id: gitsha:558275f650574389dcbbf7cd8ab5046482473fc8
+    meta_type: dlccs:DataladDatasetVersionSE
+    gitsha: 558275f650574389dcbbf7cd8ab5046482473fc8
+    is_version_of: datalad:0b76362c-aa27-11ee-be29-b3b123281259
+    tree: gitsha:712f54082540c4f07f4f18e50fcd47e2ae9b95ed
+    was_derived_from:
+      - gitsha:2a1c3934a5df1bb05ad76b4827eabd1cd5a20c8e
+    was_generated_by:
+      was_associated_with: doe@example.com
+      was_informed_by:
+        was_associated_with: doe@example.com
+  - meta_id: gitsha:2a1c3934a5df1bb05ad76b4827eabd1cd5a20c8e
+    meta_type: dlccs:DataladDatasetVersionSE
+    gitsha: 2a1c3934a5df1bb05ad76b4827eabd1cd5a20c8e
+    is_version_of: datalad:0b76362c-aa27-11ee-be29-b3b123281259
+    tree: gitsha:8a8780defb4c422766b2c29e6ac62bff06ced7c5
+    was_generated_by:
+      was_associated_with: doe@example.com
+      was_informed_by:
+        was_associated_with: doe@example.com
+  - meta_code: doe@example.com
+    meta_type: dlccs:GitUserAgentSE
+    name: Jane Doe
+    email: doe@example.com

--- a/src/examples/datalad-dataset-components/DataladDatasetSE-minimal.json
+++ b/src/examples/datalad-dataset-components/DataladDatasetSE-minimal.json
@@ -1,6 +1,6 @@
 {
-  "meta_id": "datalad:0b76362c-aa27-11ee-be29-b3b123281259",
   "meta_type": "dlccs:DataladDatasetSE",
+  "meta_id": "datalad:0b76362c-aa27-11ee-be29-b3b123281259",
   "uuid": "0b76362c-aa27-11ee-be29-b3b123281259",
   "@type": "DataladDatasetSE"
 }

--- a/src/examples/datalad-dataset-components/DataladDatasetVersionSE-commitprops.json
+++ b/src/examples/datalad-dataset-components/DataladDatasetVersionSE-commitprops.json
@@ -1,6 +1,6 @@
 {
-  "meta_id": "gitsha:558275f650574389dcbbf7cd8ab5046482473fc8",
   "meta_type": "dlccs:DataladDatasetVersionSE",
+  "meta_id": "gitsha:558275f650574389dcbbf7cd8ab5046482473fc8",
   "gitsha": "558275f650574389dcbbf7cd8ab5046482473fc8",
   "distribution": "gitsha:712f54082540c4f07f4f18e50fcd47e2ae9b95ed",
   "tree": "gitsha:712f54082540c4f07f4f18e50fcd47e2ae9b95ed",
@@ -8,15 +8,9 @@
     "gitsha:a52963ce19a3e3628e9976555ffc8c422b29f054"
   ],
   "was_generated_by": {
-    "was_associated_with": {
-      "name": "Jane Doe",
-      "email": "doe@example.com"
-    },
+    "was_associated_with": "doe@example.com",
     "was_informed_by": {
-      "was_associated_with": {
-        "name": "Jane Doe",
-        "email": "doe@example.com"
-      }
+      "was_associated_with": "doe@example.com"
     }
   },
   "description": "This message describes the changes done for this particular Dataset version.\n",

--- a/src/examples/datalad-dataset-components/DataladDatasetVersionSE-commitprops.yaml
+++ b/src/examples/datalad-dataset-components/DataladDatasetVersionSE-commitprops.yaml
@@ -11,13 +11,9 @@ was_generated_by:
   # we cannot declare a datetime here, without causing validation
   # issues: https://github.com/linkml/linkml/issues/1806
   #ended_at: 2002-05-30T09:30:10+06:00
-  was_associated_with:
-    name: Jane Doe
-    email: doe@example.com
+  was_associated_with: doe@example.com
   was_informed_by:
     # we cannot declare a datetime here, without causing validation
     # issues: https://github.com/linkml/linkml/issues/1806
     #ended_at: 2001-02-28T18:27:04+02:00
-    was_associated_with:
-      name: Jane Doe
-      email: doe@example.com
+    was_associated_with: doe@example.com

--- a/src/linkml/ontology/schema_utils.yaml
+++ b/src/linkml/ontology/schema_utils.yaml
@@ -9,16 +9,37 @@ prefixes:
   dlco: https://concepts.datalad.org/ontology/
   linkml: https://w3id.org/linkml/
 imports:
-  - linkml:types
+  - ../ontology/types
 default_prefix: dlco
 
 
 slots:
+  meta_code:
+    identifier: true
+    range: Code
+    description: >-
+      Context-constraint unique identifier of a metadata object.
+      In contrast to `meta_id`, this identifier is not globally
+      unique, but its uniqueness guarantees are limited to a single
+      metadata document. This is analog to a relative IRI `@id`
+      specification in JSON-LD that needs to be expanded with
+      an appropriate (document) `@base` URI to become globally
+      unique.
+    exact_mappings:
+      - dcterms:identifier
+      - schema:identifier
+    see_also:
+      - https://concepts.datalad.org/ontology/meta_id/
   meta_id:
     identifier: true
     description: >-
-      Unique identifier of a metadata object.
+      Globally unique identifier of a metadata object.
     range: uriorcurie
+    exact_mappings:
+      - dcterms:identifier
+      - schema:identifier
+    see_also:
+      - https://concepts.datalad.org/ontology/meta_code/
   meta_type:
     designates_type: true
     description: >-

--- a/src/linkml/ontology/types.yaml
+++ b/src/linkml/ontology/types.yaml
@@ -5,9 +5,23 @@ prefixes:
   dlco: https://concepts.datalad.org/ontology/
   schema: http://schema.org/
   xsd: http://www.w3.org/2001/XMLSchema#
+imports:
+  - linkml:types
 default_prefix: dlco
 
 types:
+  Code:
+    typeof: string
+    description: >-
+      An identifier that is encoded in a string.  This is used to represent
+      identifiers that are not URIs, but are encoded as strings.  For example,
+      a person's social security number is an encoded identifier.
+    annotations:
+      prefix: "@base"
+      percent_encoded: true
+    notes:
+      - this is an un(der)documented feature that has been lifted from https://github.com/linkml/linkml-runtime/pull/223, refer to https://github.com/psychoinformatics-de/datalad-concepts/issues/66
+
   EmailAddress:
     uri: dlco:EmailAddress
     base: str

--- a/src/linkml/schemas/datalad-dataset-components.yaml
+++ b/src/linkml/schemas/datalad-dataset-components.yaml
@@ -9,7 +9,7 @@ description: |
   has a simple structure with minimal property nesting.
 
   Each object is of type `ComponentSE`, a class that has two required slots:
-  `meta_id` and `meta_type`. The former must be a unique object identifier,
+  `meta_id|code` and `meta_type`. The former must be a unique object identifier,
   and the latter must identify a subclass of `ComponentSE` that the object
   represents. Both value must be given as a CURIE.
 
@@ -74,11 +74,27 @@ classes:
     description: >-
       Base class for any recognized dataset component type. This class
       should never be used directly, only its subclasses.
+
+  GloballyUniqueSE:
+    class_uri: dlccs:GloballyUniqueSE
+    is_a: ComponentSE
+    description: >-
+      Schema element for an object that is globally uniquely identified
+      with a URI or CURIE.
     slots:
       - meta_id
 
-  GitTrackedSE:
+  DocumentUniqueSE:
+    class_uri: dlccs:DocumentUniqueSE
     is_a: ComponentSE
+    description: >-
+      Schema element for an object that is uniquely identified within a
+      metadata document by some code.
+    slots:
+      - meta_code
+
+  GitTrackedSE:
+    is_a: GloballyUniqueSE
     description: >-
       Representation for any resource tracked by Git, thereby having a unique
       `gitsha`-based identifier.
@@ -117,7 +133,7 @@ classes:
 
   AnnexRemoteSE:
     class_uri: dlccs:AnnexRemoteSE
-    is_a: ComponentSE
+    is_a: GloballyUniqueSE
     mixins:
       - AnnexRemote
     description: >-
@@ -199,7 +215,7 @@ classes:
         #any_of:
         #  - range: GitTrackedSE
         #  - range: StableAnnexKeySE
-        range: ComponentSE
+        range: GloballyUniqueSE
     todos:
       - figure out why a union range specification is not working
 
@@ -210,10 +226,38 @@ classes:
       - Committing
     description: >-
       Schema element for a `Committing`.
+    slot_usage:
+      was_associated_with:
+        inlined: False
+        range: GitUserAgentSE
+      was_informed_by:
+        range: CommitAuthoringSE
+
+  CommitAuthoringSE:
+    class_uri: dlccs:CommitAuthoringSE
+    is_a: SchemaElement
+    mixins:
+      - CommitAuthoring
+    description: >-
+      Schema element for a `CommitAuthoring`.
+    slot_usage:
+      was_associated_with:
+        inlined: False
+        range: GitUserAgentSE
+
+  GitUserAgentSE:
+    class_uri: dlccs:GitUserAgentSE
+    is_a: DocumentUniqueSE
+    mixins:
+      - GitUserAgent
+    slots:
+      - meta_code
+    description: >-
+      Schema element for a `GitUserAgent`.
 
   DataladDatasetSE:
     class_uri: dlccs:DataladDatasetSE
-    is_a: ComponentSE
+    is_a: GloballyUniqueSE
     description: >-
       Schema element for a `DataladDataset`.
     see_also: 
@@ -236,7 +280,7 @@ classes:
 
   StableAnnexKeySE:
     class_uri: dlccs:StableAnnexKeySE
-    is_a: ComponentSE
+    is_a: GloballyUniqueSE
     mixins:
       - StableAnnexKey
     description: >-

--- a/tests/datalad-dataset-components-schema/validation/ContainerSE.valid.cfg.yaml
+++ b/tests/datalad-dataset-components-schema/validation/ContainerSE.valid.cfg.yaml
@@ -3,6 +3,7 @@ target_class: ContainerSE
 data_sources:
   - src/examples/datalad-dataset-components/ContainerSE-DataladDataset-minimal.yaml
   - src/examples/datalad-dataset-components/ContainerSE-DataladDatasetVersion-linkage.yaml
+  - src/examples/datalad-dataset-components/ContainerSE-multiversion-dataset.yaml
   - src/examples/datalad-dataset-components/ContainerSE-DatasetWFiles.yaml
   - src/examples/datalad-dataset-components/ContainerSE-DatasetWSubdataset.yaml
 plugins:


### PR DESCRIPTION
This implements the approach identified by @jsheunis in #66.

Specifically, the combination of a new type `Code` and a new `schema_utils` slot `meta_code` enable the identification and referencing of metadata objects without the need for a globally unique identifier (see the documentation of the respective ontology additions).

The new capability is demo'd on `GitUserAgent` description in the `datalad-dataset-components` schema. Here the email is used a document-constrained identification code. A new `multiversion-dataset` example has been added to showcase a complete example of this.

In the `datalad-dataset-components` schema itself, the key `ComponentSE` class has been subclassed twice for objects with a full URI identifier and for an identifier code. This way both object types can be used in the same metadata document. Moreover, the class derivations clearly show which identification schema is used for which object type. This approach likely needs to be generalized further and eventually moved into `schema_utils`.

Closes #66