### PR TITLE
Simplified class names for qualified relation pattern

### DIFF
--- a/src/linkml/ontology/git-annex.yaml
+++ b/src/linkml/ontology/git-annex.yaml
@@ -41,7 +41,7 @@ classes:
       - Add support for remote (not key) specific parameters. `DataService` only
         has `endpoint_url`
 
-  QualifiedAnnexAccess:
+  AnnexAccess:
     is_a: QualifiedAccess
     description: >-
       An association class for attaching additional information to an
@@ -71,7 +71,7 @@ classes:
       - name
     slot_usage:
       qualified_access:
-        range: QualifiedAnnexAccess
+        range: AnnexAccess
     see_also:
       - https://git-annex.branchable.com/internals/key_format/
       - https://git-annex.branchable.com/backends/

--- a/src/linkml/ontology/schema_objects.yaml
+++ b/src/linkml/ontology/schema_objects.yaml
@@ -76,25 +76,25 @@ classes:
         equals_expression: '"gitsha:" + {gitsha}'
         pattern: "^gitsha:[0-9a-f]{40}$"
 
-  QualifiedGitShaIDedPartObject:
-    class_uri: dlco:QualifiedGitShaIDedPartObject
+  GitShaIDedPartObject:
+    class_uri: dlco:GitShaIDedPartObject
     is_a: MetadataObject
     mixins:
       - QualifiedPart
     description: >-
-      Metadata object for a [QualifiedPart](https://concepts.datalad.org/ontology/QualifiedPart).
-      Every part is represented by a [GitShaIDedObject](https://concepts.datalad.org/ontology/GitShaIDedObject).
+      Metadata object for a [QualifiedPart](https://concepts.datalad.org/ontology/QualifiedPart),
+      where the part is a [GitShaIDedObject](https://concepts.datalad.org/ontology/GitShaIDedObject).
     slot_usage:
       relation:
         range: GitShaIDedObject
 
-  QualifiedAnnexAccessObject:
-    class_uri: dlco:QualifiedAnnexAccessObject
+  AnnexAccessObject:
+    class_uri: dlco:AnnexAccessObject
     is_a: MetadataObject
     mixins:
-      - QualifiedAnnexAccess
+      - AnnexAccess
     description: >-
-      Metadata object for a [QualifiedAnnexAccess](https://concepts.datalad.org/ontology/QualifiedAnnexAccess).
+      Metadata object for a [AnnexAccess](https://concepts.datalad.org/ontology/AnnexAccess).
     slot_usage:
       relation:
         range: AnnexRemoteObject
@@ -135,7 +135,7 @@ classes:
         range: DataladDatasetObject
       qualified_part:
         multivalued: true
-        range: QualifiedGitShaIDedPartObject
+        range: GitShaIDedPartObject
       tree:
         multivalued: false
         range: GitTreeObject
@@ -245,4 +245,4 @@ classes:
     slot_usage:
       qualified_access:
         multivalued: true
-        range: QualifiedAnnexAccessObject
+        range: AnnexAccessObject

--- a/src/linkml/schemas/datalad-dataset-components.yaml
+++ b/src/linkml/schemas/datalad-dataset-components.yaml
@@ -107,25 +107,25 @@ classes:
         equals_expression: '"gitsha:" + {gitsha}'
         pattern: "^gitsha:[0-9a-f]{40}$"
 
-  QualifiedGitShaIDedPartObject:
-    class_uri: dlco:QualifiedGitShaIDedPartObject
+  GitShaIDedPartObject:
+    class_uri: dlco:GitShaIDedPartObject
     is_a: MetadataObject
     mixins:
       - QualifiedPart
     description: >-
-      Metadata object for a `QualifiedPart`. Every part is represented by
+      Metadata object for a `QualifiedPart`, where the part is
       a `GitShaIDedObject`.
     slot_usage:
       relation:
         range: GitShaIDedObject
 
-  QualifiedAnnexAccessObject:
-    class_uri: dlco:QualifiedAnnexAccessObject
+  AnnexAccessObject:
+    class_uri: dlco:AnnexAccessObject
     is_a: MetadataObject
     mixins:
-      - QualifiedAnnexAccess
+      - AnnexAccess
     description: >-
-      Metadata object for a `QualifiedAnnexAccess`.
+      Metadata object for a `AnnexAccess`.
     slot_usage:
       relation:
         range: AnnexRemoteObject
@@ -172,7 +172,7 @@ classes:
         inlined: true
         inlined_as_list: true
         multivalued: true
-        range: QualifiedGitShaIDedPartObject
+        range: GitShaIDedPartObject
       tree:
         inlined: false
         multivalued: false
@@ -291,4 +291,4 @@ classes:
         inlined: true
         inlined_as_list: true
         multivalued: true
-        range: QualifiedAnnexAccessObject
+        range: AnnexAccessObject


### PR DESCRIPTION
The object representing a specific qualified relation typically has another semantic aspect that is sufficient for distinguishing from other concept, with no need to carry a `Qualified` prefix around.

For example an object representing a `Part` relationship can simply say what is relevant for that specific relationship, e.g. `GitShaIDedPart`. It does not add any information to call it `QualifiedGitShaIDedPart`.