### PR TITLE
Adds a `dataset-version` schema example for the datacite-based "national gallery dataset"

### DIFF
--- a/src/examples/dataset-version/DatasetVersionObject-datacite-nationalgallery.json
+++ b/src/examples/dataset-version/DatasetVersionObject-datacite-nationalgallery.json
@@ -1,0 +1,139 @@
+{
+  "distribution": {
+    "meta_type": "dlco:FileContainerObject",
+    "meta_code": "./",
+    "has_part": [
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "99e832c69bce072ec0485fd1118eba88",
+        "byte_size": 13555452,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "99e832c69bce072ec0485fd1118eba88"
+        },
+        "download_url": "https://research.ng-london.org.uk/scientific/env/External%20Environmental%20Data%202010-2020%20National%20Gallery%20V1.0.json"
+      }
+    ],
+    "license": "licenses:CC-BY-4.0",
+    "qualified_part": [
+      {
+        "relation": "99e832c69bce072ec0485fd1118eba88",
+        "name": "External Environmental Data 2010-2020 National Gallery V1.0.json"
+      }
+    ]
+  },
+  "identifier": [
+    "https://doi.org/10.82433/9184-dy35"
+  ],
+  "was_attributed_to": [
+    {
+      "meta_code": "NG",
+      "meta_type": "dlco:OrganizationObject",
+      "name": "National Gallery"
+    },
+    {
+      "meta_code": "jpadfield",
+      "meta_type": "dlco:ResearchContributorObject",
+      "name": "Joseph Padfield",
+      "affiliation": "National Gallery",
+      "orcid": "0000-0002-2572-6428"
+    },
+    {
+      "meta_code": "BFD",
+      "meta_type": "dlco:OrganizationObject",
+      "name": "Building Facilities Department, National Gallery"
+    }
+  ],
+  "qualified_attribution": [
+    {
+      "agent": "NG",
+      "had_role": [
+        "marcrel:cre",
+        "marcrel:pbl"
+      ]
+    },
+    {
+      "agent": "jpadfield",
+      "had_role": [
+        "marcrel:aut"
+      ]
+    },
+    {
+      "agent": "BFD",
+      "had_role": [
+        "marcrel:col"
+      ]
+    }
+  ],
+  "qualified_relation": [
+    {
+      "entity": "h2020_871034",
+      "had_role": [
+        "schema:funding"
+      ]
+    },
+    {
+      "entity": "padfield_zenodo",
+      "had_role": [
+        "CiTO:isDocumentedBy"
+      ]
+    },
+    {
+      "entity": "padfield_vandyke_carr",
+      "had_role": [
+        "CiTO:supports"
+      ]
+    },
+    {
+      "entity": "harrison_etal",
+      "had_role": [
+        "CiTO:isSupportedBy"
+      ]
+    }
+  ],
+  "relation": [
+    {
+      "meta_code": "h2020_871034",
+      "meta_type": "dlco:GrantObject",
+      "identifier": "871034",
+      "sponsor": {
+        "name": "H2020 Excellent Science"
+      },
+      "name": "Integrating Platforms for the European Research Infrastructure ON Heritage Science",
+      "cites_as_authority": "https://cordis.europa.eu/project/id/871034"
+    },
+    {
+      "meta_code": "padfield_zenodo",
+      "meta_type": "dlco:PublicationObject",
+      "citation": "\"Padfield, J. (2008, September 14). Web based presentation tools for environmental data used in The National Gallery. The 18th Annual International Association of Museum Facility Administrators (IAMFA), London. Zenodo. https://doi.org/10.5281/zenodo.7629200\"",
+      "doi": "https://doi.org/10.5281/zenodo.7629200"
+    },
+    {
+      "meta_code": "padfield_vandyke_carr",
+      "meta_type": "dlco:PublicationObject",
+      "citation": "\"J. Padfield, S. Vandyke and D. Carr, 'Improving our Environment', published March 2013. http://www.nationalgallery.org.uk/paintings/research/improving-our-environment.\"",
+      "url": "http://www.nationalgallery.org.uk/paintings/research/improving-our-environment"
+    },
+    {
+      "meta_code": "harrison_etal",
+      "meta_type": "dlco:PublicationObject",
+      "citation": "\"Lynne Harrison, Catherine Higgitt & Joseph Padfield (2018) Finding Common Ground: The Role of Preventive Conservation in Response to the Expectations of Contemporary Audiences at the National Gallery, London, Studies in Conservation, 63:sup1, 101-107, DOI: 10.1080/00393630.2018.1504449\"",
+      "doi": "https://doi.org/10.1080/00393630.2018.1504449"
+    }
+  ],
+  "description": "The National Gallery houses one of the greatest ‒ and most visited ‒ collections of Western European painting, often welcoming more than 6 million visitors a year. The Scientific Department researches the history of materials and techniques and their degradation mechanisms (fading, darkening, etc.), through analysis using a range of micro-analytical and imaging methods. It also works in the fields of preventive conservation and environmental management of galleries (monitoring, lighting, vibration), as well as the development of a wide range of new instruments and methods (both analytical and imaging) for technical examination of artworks, most often in collaboration with universities. The examination of the environmental conditions within The National Gallery began soon after it was established in 1824. Early concerns often related to dust and pollution. The first electronic data logger, recording light levels, was introduced in 1975, with the regular logging of temperature and relative humidity followed soon after. Today the Gallery has hundreds of sensors, monitoring the environmental conditions in over hundreds of locations, 24/7. The National Gallery currently archives millions of environmental readings every year, which are used to monitor the Gallery conditions ensuring the on-going care of the collections. These readings are also used to examine long term environmental trends, manage additional events, and within the planning and management of preventive conservation work and research at the National Gallery. The National Gallery Environmental Database is an internal, bespoke system which has been developed, over the last 20 years, to act as an archive for all of these environmental readings. This dataset contains a selected range of the data gathered from a few of the external sensors that have been used to monitor ambient light levels, temperature, relative humidity and air moisture content 24 hours a day, 7 days a week over the last two decades.",
+  "keyword": [
+    "FOS: Earth and related environmental sciences",
+    "temperature",
+    "relative humidity",
+    "illuminance",
+    "moisture content",
+    "Environmental monitoring"
+  ],
+  "landing_page": "https://research.ng-london.org.uk/scientific/env",
+  "modified": "2024-01-02",
+  "name": "external-environmental-data",
+  "title": "External Environmental Data, 2010-2020, National Gallery",
+  "version": "1.0",
+  "@type": "DatasetVersionObject"
+}

--- a/src/examples/dataset-version/DatasetVersionObject-datacite-nationalgallery.yaml
+++ b/src/examples/dataset-version/DatasetVersionObject-datacite-nationalgallery.yaml
@@ -1,0 +1,132 @@
+name: external-environmental-data
+title: External Environmental Data, 2010-2020, National Gallery
+description: >-
+  The National Gallery houses one of the greatest ‒ and most visited
+  ‒ collections of Western European painting, often welcoming more than
+  6 million visitors a year. The Scientific Department researches the
+  history of materials and techniques and their degradation mechanisms
+  (fading, darkening, etc.), through analysis using a range of micro-analytical
+  and imaging methods. It also works in the fields of preventive conservation
+  and environmental management of galleries (monitoring, lighting, vibration),
+  as well as the development of a wide range of new instruments and methods
+  (both analytical and imaging) for technical examination of artworks, most
+  often in collaboration with universities. The examination of the environmental
+  conditions within The National Gallery began soon after it was established
+  in 1824. Early concerns often related to dust and pollution. The first
+  electronic data logger, recording light levels, was introduced in 1975,
+  with the regular logging of temperature and relative humidity followed
+  soon after. Today the Gallery has hundreds of sensors, monitoring the
+  environmental conditions in over hundreds of locations, 24/7. The National
+  Gallery currently archives millions of environmental readings every year,
+  which are used to monitor the Gallery conditions ensuring the on-going
+  care of the collections. These readings are also used to examine long term
+  environmental trends, manage additional events, and within the planning
+  and management of preventive conservation work and research at the
+  National Gallery. The National Gallery Environmental Database is an
+  internal, bespoke system which has been developed, over the last 20 years,
+  to act as an archive for all of these environmental readings. This
+  dataset contains a selected range of the data gathered from a few of the
+  external sensors that have been used to monitor ambient light levels,
+  temperature, relative humidity and air moisture content 24 hours a day,
+  7 days a week over the last two decades.
+landing_page: https://research.ng-london.org.uk/scientific/env
+version: 1.0
+modified: 2024-01-02
+keyword:
+  - "FOS: Earth and related environmental sciences"
+  - temperature
+  - relative humidity
+  - illuminance
+  - moisture content
+  - Environmental monitoring
+identifier:
+  - https://doi.org/10.82433/9184-dy35
+was_attributed_to:
+  - meta_type: dlco:OrganizationObject
+    meta_code: NG
+    name: National Gallery
+  - meta_type: dlco:ResearchContributorObject
+    meta_code: jpadfield
+    name: Joseph Padfield
+    orcid: 0000-0002-2572-6428
+    affiliation: National Gallery
+  - meta_type: dlco:OrganizationObject
+    meta_code: BFD
+    name: Building Facilities Department, National Gallery
+qualified_attribution:
+  - agent: NG
+    had_role:
+      - marcrel:cre
+      - marcrel:pbl
+  - agent: jpadfield
+    had_role:
+      - marcrel:aut
+  - agent: BFD
+    had_role:
+      - marcrel:col
+relation:
+  - meta_type: dlco:GrantObject
+    meta_code: h2020_871034
+    name: "Integrating Platforms for the European Research Infrastructure ON Heritage Science"
+    identifier: '871034'
+    sponsor:
+      name: H2020 Excellent Science
+    cites_as_authority: https://cordis.europa.eu/project/id/871034
+  - meta_type: dlco:PublicationObject
+    meta_code: padfield_zenodo
+    citation: >-
+      "Padfield, J. (2008, September 14). Web based presentation tools
+      for environmental data used in The National Gallery. The 18th Annual
+      International Association of Museum Facility Administrators (IAMFA),
+      London. Zenodo. https://doi.org/10.5281/zenodo.7629200"
+    doi: https://doi.org/10.5281/zenodo.7629200
+  - meta_type: dlco:PublicationObject
+    meta_code: padfield_vandyke_carr
+    citation: >-
+      "J. Padfield, S. Vandyke and D. Carr, 'Improving our Environment', published
+      March 2013. http://www.nationalgallery.org.uk/paintings/research/improving-our-environment."
+    url: http://www.nationalgallery.org.uk/paintings/research/improving-our-environment
+  - meta_type: dlco:PublicationObject
+    meta_code: harrison_etal
+    citation: >-
+      "Lynne Harrison, Catherine Higgitt & Joseph Padfield (2018) Finding Common
+      Ground: The Role of Preventive Conservation in Response to the Expectations
+      of Contemporary Audiences at the National Gallery, London, Studies in
+      Conservation, 63:sup1, 101-107, DOI: 10.1080/00393630.2018.1504449"
+    doi: https://doi.org/10.1080/00393630.2018.1504449
+  # - meta_type: dlco:PublicationObject
+  #   meta_code: env
+  #   citation: >-
+  #     """
+  #   url: https://research.ng-london.org.uk/scientific/env/
+qualified_relation:
+  - had_role:
+      - schema:funding
+    entity: h2020_871034
+  - had_role:
+      - CiTO:isDocumentedBy
+    entity: padfield_zenodo
+  - had_role:
+      - CiTO:supports
+    entity: padfield_vandyke_carr
+  - had_role:
+      - CiTO:isSupportedBy
+    entity: harrison_etal
+  # - had_role:
+  #     - CiTO:isCitedAsDataSourceBy
+  #   entity: env
+distribution:
+  meta_type: dlco:FileContainerObject
+  meta_code: ./
+  license: licenses:CC-BY-4.0
+  has_part:
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 99e832c69bce072ec0485fd1118eba88
+      byte_size: 13555452
+      checksum:
+        algorithm: md5
+        digest: 99e832c69bce072ec0485fd1118eba88
+      download_url: https://research.ng-london.org.uk/scientific/env/External%20Environmental%20Data%202010-2020%20National%20Gallery%20V1.0.json
+  qualified_part:
+    - name: "External Environmental Data 2010-2020 National Gallery V1.0.json"
+      relation: 99e832c69bce072ec0485fd1118eba88


### PR DESCRIPTION
With this example data, a datacite metadata record is converted to be compliant with the dataset-version schema. The dataset described by the datacite record is known as the 'External Environmental Data' dataset from the British National Gallery. See https://api.test.datacite.org/dois/10.82433/9184-DY35\?publisher\=true\&affiliation\=true.

Mappings that were not straightforward:
- The datacite record had no intuitive choice for the `name` property of a `DatasetVersionObject`
- `keyword`s were taken from `record["data"]["attributes"]["subjects"]`
- the record has a DOI with value 10.82433/9184-dy35; however, https://doi.org/10.82433/9184-dy35 does not resolve. It still seems to be the only viable identifier in the record though (e.g. `record["data"]["attributes"]["identifiers"] = []`)
- `modified` was taken from the date part of `record["data"]["attributes"]["updated"]` which has value `"2024-01-02T20:15:20.000Z"`
- `landing_page` was taken from the most relevant source in the `record["data"]["attributes"]["relatedIdentifiers"]` list
- The record has a couple of relations aren't exact matches for available ones in the citation ontology:
  - used `cito:supports` for `isSupplementTo`
  - used `cito:isSupportedBy` for `IsSupplementedBy`
-  Had a challenge figuring out what `metatype` would be ascribed to an entity that has a resource type of `InteractiveResource` in the datacite record, and is identified by a URL. `Organizations/Persons` and `Publications` were easy, in this case the relation is to an online page, essentially. This part of the data example (the entity and the relation) is commented out.

Some issues were encountered when trying to validate the example locally. However, when I ran validation on the penguin dataset locally, i received the same errors. And these errors do not show up on the CI, so perhaps this issue is related to my run environment...

```
linkml-validate --target-class DatasetVersionObject -s src/linkml/schemas/dataset-version.yaml src/examples/dataset-version/DatasetVersionObject-penguins.yaml
[ERROR] [src/examples/dataset-version/DatasetVersionObject-penguins.yaml/0] datetime.date(2020, 7, 16) is not of type 'string' in /modified
Traceback (most recent call last):
  File "/Users/jsheunis/opt/miniconda3/envs/dlconcepts/lib/python3.11/site-packages/referencing/_core.py", line 266, in pointer
    contents = contents[segment]  # type: ignore[reportUnknownArgumentType]
               ~~~~~~~~^^^^^^^^^
KeyError: 'Agent'
```