### PR TITLE
Adds a dataset-version example for the dataverseNL 'real-time multi-echo fmri' dataset

### DIFF
--- a/src/examples/dataset-version/DatasetVersionObject-dataverse-rtmefmri.json
+++ b/src/examples/dataset-version/DatasetVersionObject-dataverse-rtmefmri.json
@@ -1,0 +1,21865 @@
+{
+  "custom_licenses": {
+    "customlicenses:humanhealthdata": {
+      "meta_id": "customlicenses:humanhealthdata",
+      "identifier": "https://dataverse.nl/api/datasets/:persistentId/versions/1.4/customlicense?persistentId=doi:10.34894/R1TNL8",
+      "license_text": "<h2>Data user agreement for accessing limited human health data</h2>\n <br>\n<i><b>By clicking \"Accept\", I agree to the terms presented below.</b></i>\n <br><br>\n<p>I request access to the <i><b>rt-me-fMRI</b></i> dataset collected in the DataverseNL digital repository as deposited by researchers at\n    (1) the Electrical Engineering department, Eindhoven University of Technology, (2) Kempenhaeghe, and (3) Philips\n    Research, co-located at Eindhoven, The Netherlands, and hereinafter referred to as the \"research institution\".\n<p>\n\n<p>By accepting this agreement, I become the <a\n        href=\"https://ec.europa.eu/info/law/law-topic/data-protection/reform/rules-business-and-organisations/obligations/controller-processor/what-data-controller-or-data-processor_en\">data\n        controller</a> (as defined under the European General Data Protection Regulation, i.e. the GDPR) of the data\n    that I process for my own purposes and means, and am responsible that I process these data under the following\n    terms:</p>\n<ol>\n    <li>I will comply with all relevant rules and regulations imposed by my institution and my government. This\n        agreement never has prevalence over existing general data protection regulations that are applicable in my\n        country.</li>\n    <li>I will not attempt to establish or retrieve the identity of the study participants. I will not link these data\n        to any other database in a way that could provide identifying information. I shall not request the\n        pseudonymisation key that would link these data to an individual's personal information, nor will I accept any\n        additional information about individual participants under this Data Use Agreement.</li>\n    <li>I will not redistribute these data or share access to these data with others, unless they have independently\n        applied and been granted access to these data, i.e., signed this Data Use Agreement. This includes individuals\n        in my institution.</li>\n    <li>I will reference the specific source of the accessed data when publicly presenting any results or algorithms\n        that benefited from their use:\n        <ul>\n            <li>Papers, book chapters, books, posters, oral presentations, and all other presentations of results\n                derived from the data should acknowledge the origin of the data as follows: \"Data were provided (in\n                part) by the Electrical Engineering Department, Eindhoven University of Technology, The Netherlands and\n                Kempenhaeghe Epilepsy Center, Heeze, The Netherlands”.</li>\n            <li>Authors of publications or presentations using the data should cite relevant publications describing the\n                methods developed and used by the research institution to acquire and process the data. The specific\n                publications that are appropriate to cite in any given study will depend on what the data were used and\n                for what purposes. When applicable, a list of publications will be included in the collection.</li>\n            <li>Neither the entities that constitute the research institution, nor the researchers that provide this\n                data will be liable for any results and/or derived data. They shall not be included as an author of\n                publications or presentations without consent.</li>\n        </ul>\n    </li>\n    <li>Failure to comply with this agreement will result in, but not limited to, termination of my privileges to access\n        these data.</li>\n    <li>This agreement is governed by Dutch law.</li>\n</ol>"
+    }
+  },
+  "distribution": {
+    "meta_type": "dlco:FileContainerObject",
+    "meta_code": "./",
+    "has_part": [
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "7d63a6dd379b3b81574e31240433e008",
+        "byte_size": 1455,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "7d63a6dd379b3b81574e31240433e008"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46664"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a88a2b8ad2cdf158c3b1ee84ecdbbbf9",
+        "byte_size": 39,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a88a2b8ad2cdf158c3b1ee84ecdbbbf9"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46709"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "derivatives/",
+        "qualified_part": [
+          {
+            "relation": "derivatives/fmrwhy-dash/",
+            "name": "fmrwhy-dash"
+          },
+          {
+            "relation": "derivatives/fmrwhy-qc/",
+            "name": "fmrwhy-qc"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "derivatives/fmrwhy-dash/",
+        "qualified_part": [
+          {
+            "relation": "a88a2b8ad2cdf158c3b1ee84ecdbbbf9",
+            "name": "fmrwhy-dash.txt"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "738eead953d79c5f494795ef91b453ee",
+        "byte_size": 37,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "738eead953d79c5f494795ef91b453ee"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46710"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "derivatives/fmrwhy-qc/",
+        "qualified_part": [
+          {
+            "relation": "738eead953d79c5f494795ef91b453ee",
+            "name": "fmrwhy-qc.txt"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "0a25e5c0225e9bd18c62a560df470980",
+        "byte_size": 238,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "0a25e5c0225e9bd18c62a560df470980"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46663"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1abb42c68887b4c075e710f0ae8ce855",
+        "byte_size": 1429,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1abb42c68887b4c075e710f0ae8ce855"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46708"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "678f2832b684bbc90d501dc603868bff",
+        "byte_size": 20736352,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "678f2832b684bbc90d501dc603868bff"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45615"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-001/",
+        "qualified_part": [
+          {
+            "relation": "sub-001/anat/",
+            "name": "anat"
+          },
+          {
+            "relation": "sub-001/func/",
+            "name": "func"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-001/anat/",
+        "qualified_part": [
+          {
+            "relation": "678f2832b684bbc90d501dc603868bff",
+            "name": "sub-001_T1w.nii"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "89c161237e848b41add3ac5d2b500c75",
+        "byte_size": 1041,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "89c161237e848b41add3ac5d2b500c75"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45363"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-001/func/",
+        "qualified_part": [
+          {
+            "relation": "89c161237e848b41add3ac5d2b500c75",
+            "name": "sub-001_task-emotionProcessing_echo-1_bold.json"
+          },
+          {
+            "relation": "78fb2c0f46963569767ae895ff76f8d4",
+            "name": "sub-001_task-emotionProcessing_echo-1_bold.nii"
+          },
+          {
+            "relation": "56a5078e8d1434e4da6f19b995263b63",
+            "name": "sub-001_task-emotionProcessing_echo-2_bold.json"
+          },
+          {
+            "relation": "5760b7656006d37965ae3125490c1eaf",
+            "name": "sub-001_task-emotionProcessing_echo-2_bold.nii"
+          },
+          {
+            "relation": "f30db156c93de5390c73c9b9272c58f0",
+            "name": "sub-001_task-emotionProcessing_echo-3_bold.json"
+          },
+          {
+            "relation": "797986659433a9da8ec3f7b6e46aeb54",
+            "name": "sub-001_task-emotionProcessing_echo-3_bold.nii"
+          },
+          {
+            "relation": "a2736a06b0d65a9a7d8a8405c38bfd5d",
+            "name": "sub-001_task-emotionProcessing_events.tsv.gz"
+          },
+          {
+            "relation": "daf928b2860acd3705f08a1d44c986d7",
+            "name": "sub-001_task-emotionProcessingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "8e5e4295a677afbe4fff1e88a44edf40",
+            "name": "sub-001_task-emotionProcessingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "718e2607b88161aa7da96441811bb668",
+            "name": "sub-001_task-emotionProcessingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "6a42e577d5b33591d34706aed5dab54b",
+            "name": "sub-001_task-emotionProcessingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "7a667113b3daa985b748a6f8eacfb15c",
+            "name": "sub-001_task-emotionProcessingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "a345b63a7f2164c7b2304c466cbab8df",
+            "name": "sub-001_task-emotionProcessingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "80bbaaffae6ffa4103c5142fb17d7c2a",
+            "name": "sub-001_task-emotionProcessingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "c004321667c23b1902e25b22b27ae012",
+            "name": "sub-001_task-emotionProcessingImagined_physio.json"
+          },
+          {
+            "relation": "cf755584ecd4e3c1f6e48fccbb30463e",
+            "name": "sub-001_task-emotionProcessingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "f6d422020cde7f1acc387ba8aa45f319",
+            "name": "sub-001_task-emotionProcessing_physio.json"
+          },
+          {
+            "relation": "3e39a50cff3dae3e85b58288d9867e12",
+            "name": "sub-001_task-emotionProcessing_physio.tsv.gz"
+          },
+          {
+            "relation": "07322a7494441559e5cdd20a57a4d8cf",
+            "name": "sub-001_task-fingerTapping_echo-1_bold.json"
+          },
+          {
+            "relation": "8c5ded113bbccd377cefd38edd154d5b",
+            "name": "sub-001_task-fingerTapping_echo-1_bold.nii"
+          },
+          {
+            "relation": "da5ab166644f570d8fa956457a9bbf47",
+            "name": "sub-001_task-fingerTapping_echo-2_bold.json"
+          },
+          {
+            "relation": "b82b687193271c8151bcbacfbe3e7626",
+            "name": "sub-001_task-fingerTapping_echo-2_bold.nii"
+          },
+          {
+            "relation": "425e116b054dd72925d970f0fb2c3176",
+            "name": "sub-001_task-fingerTapping_echo-3_bold.json"
+          },
+          {
+            "relation": "addf94f0e75a499d1736cc63387b394d",
+            "name": "sub-001_task-fingerTapping_echo-3_bold.nii"
+          },
+          {
+            "relation": "43a708b1b704c30226923f2b6ab380b6",
+            "name": "sub-001_task-fingerTapping_events.tsv.gz"
+          },
+          {
+            "relation": "920db66c4c9552efbec84fb65ae9c363",
+            "name": "sub-001_task-fingerTappingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "82f169c348b851b4ad009442086d6acd",
+            "name": "sub-001_task-fingerTappingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "02724a22a11885cdf51dacd30b870456",
+            "name": "sub-001_task-fingerTappingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "58655ea820a6fb46d19d0666b767439c",
+            "name": "sub-001_task-fingerTappingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "bec034b87f61d4e21c24209c75b25897",
+            "name": "sub-001_task-fingerTappingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "12d17d0ec3dc7e9d90e75516ea6a26e1",
+            "name": "sub-001_task-fingerTappingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "933088364ebb3346e825dd3f929bed11",
+            "name": "sub-001_task-fingerTappingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "b1842207924fca982fb1fc24d76bc312",
+            "name": "sub-001_task-fingerTappingImagined_physio.json"
+          },
+          {
+            "relation": "30cbe40f3eff986588253335007b44b1",
+            "name": "sub-001_task-fingerTappingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "2a064003e1080fb234c6a87d301677eb",
+            "name": "sub-001_task-fingerTapping_physio.json"
+          },
+          {
+            "relation": "fd983bb7f0aacfd1c82a4cc66291ece7",
+            "name": "sub-001_task-fingerTapping_physio.tsv.gz"
+          },
+          {
+            "relation": "8afd88b03a88b24ecf64f84ae52e8846",
+            "name": "sub-001_task-rest_run-1_echo-1_bold.json"
+          },
+          {
+            "relation": "44e4f216d13068469c80e71f8527a2e6",
+            "name": "sub-001_task-rest_run-1_echo-1_bold.nii"
+          },
+          {
+            "relation": "b72be0db59010c4ec993396099b3482c",
+            "name": "sub-001_task-rest_run-1_echo-2_bold.json"
+          },
+          {
+            "relation": "0eaaf587c1ec3e2c62727bb1c990b46a",
+            "name": "sub-001_task-rest_run-1_echo-2_bold.nii"
+          },
+          {
+            "relation": "0c304cbaed62715915e922fa8bb5ec2a",
+            "name": "sub-001_task-rest_run-1_echo-3_bold.json"
+          },
+          {
+            "relation": "9b6b87f2d7b292fb432b8b0f55c1d1a8",
+            "name": "sub-001_task-rest_run-1_echo-3_bold.nii"
+          },
+          {
+            "relation": "8b1fe1885567392c664bd283bcff1d2e",
+            "name": "sub-001_task-rest_run-1_physio.json"
+          },
+          {
+            "relation": "e5f5aae66346cc2b6eab06147ea076a6",
+            "name": "sub-001_task-rest_run-1_physio.tsv.gz"
+          },
+          {
+            "relation": "9b028ce4d5801195fefff15bc1b5768e",
+            "name": "sub-001_task-rest_run-2_echo-1_bold.json"
+          },
+          {
+            "relation": "31c95eed2391907357fde714b47e54d0",
+            "name": "sub-001_task-rest_run-2_echo-1_bold.nii"
+          },
+          {
+            "relation": "4a0d83ee1a3782f528eca56303895eca",
+            "name": "sub-001_task-rest_run-2_echo-2_bold.json"
+          },
+          {
+            "relation": "0058bec35f3a53a169011571dc4a8a01",
+            "name": "sub-001_task-rest_run-2_echo-2_bold.nii"
+          },
+          {
+            "relation": "739448e73206d3da7cd20bd564457af6",
+            "name": "sub-001_task-rest_run-2_echo-3_bold.json"
+          },
+          {
+            "relation": "354671b079f219299fee7457c9d673e8",
+            "name": "sub-001_task-rest_run-2_echo-3_bold.nii"
+          },
+          {
+            "relation": "0ffd5218f0f1686afa4dc8143dbc7a3b",
+            "name": "sub-001_task-rest_run-2_physio.json"
+          },
+          {
+            "relation": "498f80810fc869ca053aa3ee4f27d538",
+            "name": "sub-001_task-rest_run-2_physio.tsv.gz"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "78fb2c0f46963569767ae895ff76f8d4",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "78fb2c0f46963569767ae895ff76f8d4"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45312"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "56a5078e8d1434e4da6f19b995263b63",
+        "byte_size": 1041,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "56a5078e8d1434e4da6f19b995263b63"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46262"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5760b7656006d37965ae3125490c1eaf",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5760b7656006d37965ae3125490c1eaf"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45604"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f30db156c93de5390c73c9b9272c58f0",
+        "byte_size": 1041,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f30db156c93de5390c73c9b9272c58f0"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46333"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "797986659433a9da8ec3f7b6e46aeb54",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "797986659433a9da8ec3f7b6e46aeb54"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45650"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a2736a06b0d65a9a7d8a8405c38bfd5d",
+        "byte_size": 1880,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a2736a06b0d65a9a7d8a8405c38bfd5d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46584"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "daf928b2860acd3705f08a1d44c986d7",
+        "byte_size": 1049,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "daf928b2860acd3705f08a1d44c986d7"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46265"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8e5e4295a677afbe4fff1e88a44edf40",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8e5e4295a677afbe4fff1e88a44edf40"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45505"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "718e2607b88161aa7da96441811bb668",
+        "byte_size": 1049,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "718e2607b88161aa7da96441811bb668"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45334"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6a42e577d5b33591d34706aed5dab54b",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6a42e577d5b33591d34706aed5dab54b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45456"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "7a667113b3daa985b748a6f8eacfb15c",
+        "byte_size": 1049,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "7a667113b3daa985b748a6f8eacfb15c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45704"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a345b63a7f2164c7b2304c466cbab8df",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a345b63a7f2164c7b2304c466cbab8df"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45487"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "80bbaaffae6ffa4103c5142fb17d7c2a",
+        "byte_size": 142,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "80bbaaffae6ffa4103c5142fb17d7c2a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46660"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c004321667c23b1902e25b22b27ae012",
+        "byte_size": 142,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c004321667c23b1902e25b22b27ae012"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45381"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "cf755584ecd4e3c1f6e48fccbb30463e",
+        "byte_size": 488347,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "cf755584ecd4e3c1f6e48fccbb30463e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45767"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f6d422020cde7f1acc387ba8aa45f319",
+        "byte_size": 142,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f6d422020cde7f1acc387ba8aa45f319"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45694"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "3e39a50cff3dae3e85b58288d9867e12",
+        "byte_size": 494035,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "3e39a50cff3dae3e85b58288d9867e12"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45996"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "07322a7494441559e5cdd20a57a4d8cf",
+        "byte_size": 1036,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "07322a7494441559e5cdd20a57a4d8cf"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45425"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8c5ded113bbccd377cefd38edd154d5b",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8c5ded113bbccd377cefd38edd154d5b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46431"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "da5ab166644f570d8fa956457a9bbf47",
+        "byte_size": 1036,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "da5ab166644f570d8fa956457a9bbf47"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45999"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b82b687193271c8151bcbacfbe3e7626",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b82b687193271c8151bcbacfbe3e7626"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45897"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "425e116b054dd72925d970f0fb2c3176",
+        "byte_size": 1036,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "425e116b054dd72925d970f0fb2c3176"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46441"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "addf94f0e75a499d1736cc63387b394d",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "addf94f0e75a499d1736cc63387b394d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46514"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "43a708b1b704c30226923f2b6ab380b6",
+        "byte_size": 131,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "43a708b1b704c30226923f2b6ab380b6"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46590"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "920db66c4c9552efbec84fb65ae9c363",
+        "byte_size": 1041,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "920db66c4c9552efbec84fb65ae9c363"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45681"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "82f169c348b851b4ad009442086d6acd",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "82f169c348b851b4ad009442086d6acd"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45115"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "02724a22a11885cdf51dacd30b870456",
+        "byte_size": 1041,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "02724a22a11885cdf51dacd30b870456"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45991"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "58655ea820a6fb46d19d0666b767439c",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "58655ea820a6fb46d19d0666b767439c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45672"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "bec034b87f61d4e21c24209c75b25897",
+        "byte_size": 1041,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "bec034b87f61d4e21c24209c75b25897"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46223"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "12d17d0ec3dc7e9d90e75516ea6a26e1",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "12d17d0ec3dc7e9d90e75516ea6a26e1"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45860"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "933088364ebb3346e825dd3f929bed11",
+        "byte_size": 146,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "933088364ebb3346e825dd3f929bed11"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46646"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b1842207924fca982fb1fc24d76bc312",
+        "byte_size": 142,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b1842207924fca982fb1fc24d76bc312"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46303"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "30cbe40f3eff986588253335007b44b1",
+        "byte_size": 495447,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "30cbe40f3eff986588253335007b44b1"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46166"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2a064003e1080fb234c6a87d301677eb",
+        "byte_size": 142,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2a064003e1080fb234c6a87d301677eb"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45577"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "fd983bb7f0aacfd1c82a4cc66291ece7",
+        "byte_size": 488065,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "fd983bb7f0aacfd1c82a4cc66291ece7"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45746"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8afd88b03a88b24ecf64f84ae52e8846",
+        "byte_size": 1028,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8afd88b03a88b24ecf64f84ae52e8846"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45610"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "44e4f216d13068469c80e71f8527a2e6",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "44e4f216d13068469c80e71f8527a2e6"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45273"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b72be0db59010c4ec993396099b3482c",
+        "byte_size": 1028,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b72be0db59010c4ec993396099b3482c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45228"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "0eaaf587c1ec3e2c62727bb1c990b46a",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "0eaaf587c1ec3e2c62727bb1c990b46a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46020"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "0c304cbaed62715915e922fa8bb5ec2a",
+        "byte_size": 1028,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "0c304cbaed62715915e922fa8bb5ec2a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45254"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "9b6b87f2d7b292fb432b8b0f55c1d1a8",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "9b6b87f2d7b292fb432b8b0f55c1d1a8"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46098"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8b1fe1885567392c664bd283bcff1d2e",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8b1fe1885567392c664bd283bcff1d2e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45180"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e5f5aae66346cc2b6eab06147ea076a6",
+        "byte_size": 447241,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e5f5aae66346cc2b6eab06147ea076a6"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45102"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "9b028ce4d5801195fefff15bc1b5768e",
+        "byte_size": 1028,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "9b028ce4d5801195fefff15bc1b5768e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46015"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "31c95eed2391907357fde714b47e54d0",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "31c95eed2391907357fde714b47e54d0"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46082"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4a0d83ee1a3782f528eca56303895eca",
+        "byte_size": 1028,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4a0d83ee1a3782f528eca56303895eca"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46512"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "0058bec35f3a53a169011571dc4a8a01",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "0058bec35f3a53a169011571dc4a8a01"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46426"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "739448e73206d3da7cd20bd564457af6",
+        "byte_size": 1028,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "739448e73206d3da7cd20bd564457af6"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46177"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "354671b079f219299fee7457c9d673e8",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "354671b079f219299fee7457c9d673e8"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45119"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "0ffd5218f0f1686afa4dc8143dbc7a3b",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "0ffd5218f0f1686afa4dc8143dbc7a3b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45945"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "498f80810fc869ca053aa3ee4f27d538",
+        "byte_size": 489156,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "498f80810fc869ca053aa3ee4f27d538"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46281"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f97f4f4adcf76fb6d5d22c3ead8488a6",
+        "byte_size": 20736352,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f97f4f4adcf76fb6d5d22c3ead8488a6"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46216"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-002/",
+        "qualified_part": [
+          {
+            "relation": "sub-002/anat/",
+            "name": "anat"
+          },
+          {
+            "relation": "sub-002/func/",
+            "name": "func"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-002/anat/",
+        "qualified_part": [
+          {
+            "relation": "f97f4f4adcf76fb6d5d22c3ead8488a6",
+            "name": "sub-002_T1w.nii"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "cf7d2a3f3e619ec6608d54e76f95df61",
+        "byte_size": 1039,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "cf7d2a3f3e619ec6608d54e76f95df61"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45495"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-002/func/",
+        "qualified_part": [
+          {
+            "relation": "cf7d2a3f3e619ec6608d54e76f95df61",
+            "name": "sub-002_task-emotionProcessing_echo-1_bold.json"
+          },
+          {
+            "relation": "d4242276c9dee9f7e7971bba128270ad",
+            "name": "sub-002_task-emotionProcessing_echo-1_bold.nii"
+          },
+          {
+            "relation": "9c7736a4a9e4222eec3c03a5f9aa1549",
+            "name": "sub-002_task-emotionProcessing_echo-2_bold.json"
+          },
+          {
+            "relation": "2ecebc86b99f59b0bed9377a09516955",
+            "name": "sub-002_task-emotionProcessing_echo-2_bold.nii"
+          },
+          {
+            "relation": "0a080ec8ad2f4941fd8b8104a4ea0370",
+            "name": "sub-002_task-emotionProcessing_echo-3_bold.json"
+          },
+          {
+            "relation": "647534a55fd905146ba11e854be1b527",
+            "name": "sub-002_task-emotionProcessing_echo-3_bold.nii"
+          },
+          {
+            "relation": "33e05c7294222071648be193f2c8e658",
+            "name": "sub-002_task-emotionProcessing_events.tsv.gz"
+          },
+          {
+            "relation": "35cd1eee55bbc9c48667230c83d8b415",
+            "name": "sub-002_task-emotionProcessingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "5406f3e37283de3226136a4848fb8e92",
+            "name": "sub-002_task-emotionProcessingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "e202428748d8dc5f95d1081f9a1408ab",
+            "name": "sub-002_task-emotionProcessingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "3b570804931e64328f99f1d95fec8aef",
+            "name": "sub-002_task-emotionProcessingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "66da6541ad9ee098040d6a5cc2b8ca12",
+            "name": "sub-002_task-emotionProcessingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "3bc569cbc0a2f29c913bc9578899cc0c",
+            "name": "sub-002_task-emotionProcessingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "db82d76d3330ec3990c4af83e938d87c",
+            "name": "sub-002_task-emotionProcessingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "80adcff0f946010d4b877fb4efc8caef",
+            "name": "sub-002_task-emotionProcessingImagined_physio.json"
+          },
+          {
+            "relation": "e6ef5142cec6da41a411e0a89d97d824",
+            "name": "sub-002_task-emotionProcessingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "d74e8747cc4889f1de5df37aab11c55f",
+            "name": "sub-002_task-emotionProcessing_physio.json"
+          },
+          {
+            "relation": "187c2fba563a2fa2b941de43f70dd61a",
+            "name": "sub-002_task-emotionProcessing_physio.tsv.gz"
+          },
+          {
+            "relation": "21709237f7b3492a22c8b7ab28f7e19b",
+            "name": "sub-002_task-fingerTapping_echo-1_bold.json"
+          },
+          {
+            "relation": "fc63662a4dc71495b97f7de2dd2c8a0f",
+            "name": "sub-002_task-fingerTapping_echo-1_bold.nii"
+          },
+          {
+            "relation": "57c2423318daf74f152041ef0781b26a",
+            "name": "sub-002_task-fingerTapping_echo-2_bold.json"
+          },
+          {
+            "relation": "031af3d3b88dc94e5118bdd92363290d",
+            "name": "sub-002_task-fingerTapping_echo-2_bold.nii"
+          },
+          {
+            "relation": "83f8efcda5d35afcf51caa1bdf235f28",
+            "name": "sub-002_task-fingerTapping_echo-3_bold.json"
+          },
+          {
+            "relation": "2d1663374ca312b50e3a0c3382787c48",
+            "name": "sub-002_task-fingerTapping_echo-3_bold.nii"
+          },
+          {
+            "relation": "f888ebecc08f0a7b3bfcb3fd74e59e65",
+            "name": "sub-002_task-fingerTapping_events.tsv.gz"
+          },
+          {
+            "relation": "4936ee6da36541314819583b3da319b4",
+            "name": "sub-002_task-fingerTappingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "beab4fec941e693a8059141ab16ee6eb",
+            "name": "sub-002_task-fingerTappingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "958c43a8868b916df6ad06a35d0871ef",
+            "name": "sub-002_task-fingerTappingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "dcc7227a72c483e546ed72567decd240",
+            "name": "sub-002_task-fingerTappingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "ac1d6b1751abccbe064ecc2eaa72b91e",
+            "name": "sub-002_task-fingerTappingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "d52160b2aca2cbd22144a3c76ab2c5a4",
+            "name": "sub-002_task-fingerTappingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "ba6099cd9c3ba2ea89c6e01e47e7a1b6",
+            "name": "sub-002_task-fingerTappingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "455ab639907f79b81120e9bb5e262c51",
+            "name": "sub-002_task-fingerTappingImagined_physio.json"
+          },
+          {
+            "relation": "0e703d0254167656d9fd8319eda8631a",
+            "name": "sub-002_task-fingerTappingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "623fd32c3abaf5045866a9f257041a24",
+            "name": "sub-002_task-fingerTapping_physio.json"
+          },
+          {
+            "relation": "221ab54e3cd08b6f9036ec41b083d336",
+            "name": "sub-002_task-fingerTapping_physio.tsv.gz"
+          },
+          {
+            "relation": "3761f3d617dd7ba60e81d2601ef59947",
+            "name": "sub-002_task-rest_run-1_echo-1_bold.json"
+          },
+          {
+            "relation": "ecb90665078449c064d070accf6cd7e8",
+            "name": "sub-002_task-rest_run-1_echo-1_bold.nii"
+          },
+          {
+            "relation": "3fc98b2caa94ee94cd2ad78c9aa3f78c",
+            "name": "sub-002_task-rest_run-1_echo-2_bold.json"
+          },
+          {
+            "relation": "8b8690d3f6d670bf191eadd8e01119dd",
+            "name": "sub-002_task-rest_run-1_echo-2_bold.nii"
+          },
+          {
+            "relation": "36354f68d03ea100abfa17db08d24e07",
+            "name": "sub-002_task-rest_run-1_echo-3_bold.json"
+          },
+          {
+            "relation": "b690270b545ea0fdf0ff5327fa10b8b9",
+            "name": "sub-002_task-rest_run-1_echo-3_bold.nii"
+          },
+          {
+            "relation": "2cd78841361d665f5661ca7678500942",
+            "name": "sub-002_task-rest_run-1_physio.json"
+          },
+          {
+            "relation": "9ee6308ef60143c844e94849b76b811d",
+            "name": "sub-002_task-rest_run-1_physio.tsv.gz"
+          },
+          {
+            "relation": "69f53a4bedb42b1f612883b8afd7497b",
+            "name": "sub-002_task-rest_run-2_echo-1_bold.json"
+          },
+          {
+            "relation": "7138afaaa1a1d3a6d816621d832799b1",
+            "name": "sub-002_task-rest_run-2_echo-1_bold.nii"
+          },
+          {
+            "relation": "22cb9852e9c9d955d7365b1448728357",
+            "name": "sub-002_task-rest_run-2_echo-2_bold.json"
+          },
+          {
+            "relation": "79fa20148b1630ffb08992beab303b2b",
+            "name": "sub-002_task-rest_run-2_echo-2_bold.nii"
+          },
+          {
+            "relation": "27ae4e73617361c270ecc71101f3cddd",
+            "name": "sub-002_task-rest_run-2_echo-3_bold.json"
+          },
+          {
+            "relation": "005456b77cd14cd08bd60b082f35b26d",
+            "name": "sub-002_task-rest_run-2_echo-3_bold.nii"
+          },
+          {
+            "relation": "1f75cd2288e414151a8e07e2efa99a5d",
+            "name": "sub-002_task-rest_run-2_physio.json"
+          },
+          {
+            "relation": "2853087ae72d9e2dc2ac40e4c7d8231c",
+            "name": "sub-002_task-rest_run-2_physio.tsv.gz"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d4242276c9dee9f7e7971bba128270ad",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d4242276c9dee9f7e7971bba128270ad"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45238"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "9c7736a4a9e4222eec3c03a5f9aa1549",
+        "byte_size": 1039,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "9c7736a4a9e4222eec3c03a5f9aa1549"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45879"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2ecebc86b99f59b0bed9377a09516955",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2ecebc86b99f59b0bed9377a09516955"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45411"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "0a080ec8ad2f4941fd8b8104a4ea0370",
+        "byte_size": 1039,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "0a080ec8ad2f4941fd8b8104a4ea0370"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46342"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "647534a55fd905146ba11e854be1b527",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "647534a55fd905146ba11e854be1b527"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45836"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "33e05c7294222071648be193f2c8e658",
+        "byte_size": 1896,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "33e05c7294222071648be193f2c8e658"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46552"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "35cd1eee55bbc9c48667230c83d8b415",
+        "byte_size": 1048,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "35cd1eee55bbc9c48667230c83d8b415"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46021"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5406f3e37283de3226136a4848fb8e92",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5406f3e37283de3226136a4848fb8e92"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46121"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e202428748d8dc5f95d1081f9a1408ab",
+        "byte_size": 1048,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e202428748d8dc5f95d1081f9a1408ab"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45741"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "3b570804931e64328f99f1d95fec8aef",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "3b570804931e64328f99f1d95fec8aef"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45437"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "66da6541ad9ee098040d6a5cc2b8ca12",
+        "byte_size": 1048,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "66da6541ad9ee098040d6a5cc2b8ca12"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46314"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "3bc569cbc0a2f29c913bc9578899cc0c",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "3bc569cbc0a2f29c913bc9578899cc0c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45094"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "db82d76d3330ec3990c4af83e938d87c",
+        "byte_size": 176,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "db82d76d3330ec3990c4af83e938d87c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46595"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "80adcff0f946010d4b877fb4efc8caef",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "80adcff0f946010d4b877fb4efc8caef"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45889"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e6ef5142cec6da41a411e0a89d97d824",
+        "byte_size": 485217,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e6ef5142cec6da41a411e0a89d97d824"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45485"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d74e8747cc4889f1de5df37aab11c55f",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d74e8747cc4889f1de5df37aab11c55f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45420"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "187c2fba563a2fa2b941de43f70dd61a",
+        "byte_size": 498781,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "187c2fba563a2fa2b941de43f70dd61a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46124"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "21709237f7b3492a22c8b7ab28f7e19b",
+        "byte_size": 1035,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "21709237f7b3492a22c8b7ab28f7e19b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45415"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "fc63662a4dc71495b97f7de2dd2c8a0f",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "fc63662a4dc71495b97f7de2dd2c8a0f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45660"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "57c2423318daf74f152041ef0781b26a",
+        "byte_size": 1035,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "57c2423318daf74f152041ef0781b26a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45975"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "031af3d3b88dc94e5118bdd92363290d",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "031af3d3b88dc94e5118bdd92363290d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46503"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "83f8efcda5d35afcf51caa1bdf235f28",
+        "byte_size": 1035,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "83f8efcda5d35afcf51caa1bdf235f28"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45339"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2d1663374ca312b50e3a0c3382787c48",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2d1663374ca312b50e3a0c3382787c48"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45380"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f888ebecc08f0a7b3bfcb3fd74e59e65",
+        "byte_size": 165,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f888ebecc08f0a7b3bfcb3fd74e59e65"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46617"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4936ee6da36541314819583b3da319b4",
+        "byte_size": 1044,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4936ee6da36541314819583b3da319b4"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45253"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "beab4fec941e693a8059141ab16ee6eb",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "beab4fec941e693a8059141ab16ee6eb"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45622"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "958c43a8868b916df6ad06a35d0871ef",
+        "byte_size": 1044,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "958c43a8868b916df6ad06a35d0871ef"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45605"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "dcc7227a72c483e546ed72567decd240",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "dcc7227a72c483e546ed72567decd240"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46293"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ac1d6b1751abccbe064ecc2eaa72b91e",
+        "byte_size": 1044,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ac1d6b1751abccbe064ecc2eaa72b91e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45107"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d52160b2aca2cbd22144a3c76ab2c5a4",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d52160b2aca2cbd22144a3c76ab2c5a4"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46154"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ba6099cd9c3ba2ea89c6e01e47e7a1b6",
+        "byte_size": 178,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ba6099cd9c3ba2ea89c6e01e47e7a1b6"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46607"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "455ab639907f79b81120e9bb5e262c51",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "455ab639907f79b81120e9bb5e262c51"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45705"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "0e703d0254167656d9fd8319eda8631a",
+        "byte_size": 507693,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "0e703d0254167656d9fd8319eda8631a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45330"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "623fd32c3abaf5045866a9f257041a24",
+        "byte_size": 142,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "623fd32c3abaf5045866a9f257041a24"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45159"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "221ab54e3cd08b6f9036ec41b083d336",
+        "byte_size": 506416,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "221ab54e3cd08b6f9036ec41b083d336"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45496"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "3761f3d617dd7ba60e81d2601ef59947",
+        "byte_size": 1027,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "3761f3d617dd7ba60e81d2601ef59947"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46470"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ecb90665078449c064d070accf6cd7e8",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ecb90665078449c064d070accf6cd7e8"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45757"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "3fc98b2caa94ee94cd2ad78c9aa3f78c",
+        "byte_size": 1027,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "3fc98b2caa94ee94cd2ad78c9aa3f78c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45327"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8b8690d3f6d670bf191eadd8e01119dd",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8b8690d3f6d670bf191eadd8e01119dd"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46288"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "36354f68d03ea100abfa17db08d24e07",
+        "byte_size": 1027,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "36354f68d03ea100abfa17db08d24e07"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45708"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b690270b545ea0fdf0ff5327fa10b8b9",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b690270b545ea0fdf0ff5327fa10b8b9"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46159"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2cd78841361d665f5661ca7678500942",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2cd78841361d665f5661ca7678500942"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45160"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "9ee6308ef60143c844e94849b76b811d",
+        "byte_size": 450745,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "9ee6308ef60143c844e94849b76b811d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45256"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "69f53a4bedb42b1f612883b8afd7497b",
+        "byte_size": 1027,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "69f53a4bedb42b1f612883b8afd7497b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45661"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "7138afaaa1a1d3a6d816621d832799b1",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "7138afaaa1a1d3a6d816621d832799b1"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45110"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "22cb9852e9c9d955d7365b1448728357",
+        "byte_size": 1027,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "22cb9852e9c9d955d7365b1448728357"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46277"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "79fa20148b1630ffb08992beab303b2b",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "79fa20148b1630ffb08992beab303b2b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46128"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "27ae4e73617361c270ecc71101f3cddd",
+        "byte_size": 1027,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "27ae4e73617361c270ecc71101f3cddd"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45164"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "005456b77cd14cd08bd60b082f35b26d",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "005456b77cd14cd08bd60b082f35b26d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45981"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1f75cd2288e414151a8e07e2efa99a5d",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1f75cd2288e414151a8e07e2efa99a5d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45553"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2853087ae72d9e2dc2ac40e4c7d8231c",
+        "byte_size": 467796,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2853087ae72d9e2dc2ac40e4c7d8231c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45992"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a525adfda11e7a413d064b83351014f7",
+        "byte_size": 20736352,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a525adfda11e7a413d064b83351014f7"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45171"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-003/",
+        "qualified_part": [
+          {
+            "relation": "sub-003/anat/",
+            "name": "anat"
+          },
+          {
+            "relation": "sub-003/func/",
+            "name": "func"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-003/anat/",
+        "qualified_part": [
+          {
+            "relation": "a525adfda11e7a413d064b83351014f7",
+            "name": "sub-003_T1w.nii"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4518a04d528ff9af69b75633417073c4",
+        "byte_size": 1039,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4518a04d528ff9af69b75633417073c4"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46311"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-003/func/",
+        "qualified_part": [
+          {
+            "relation": "4518a04d528ff9af69b75633417073c4",
+            "name": "sub-003_task-emotionProcessing_echo-1_bold.json"
+          },
+          {
+            "relation": "f41afd8250988c7601d688addb9b7102",
+            "name": "sub-003_task-emotionProcessing_echo-1_bold.nii"
+          },
+          {
+            "relation": "2050d7c945bee0a6caad609e7b74dac9",
+            "name": "sub-003_task-emotionProcessing_echo-2_bold.json"
+          },
+          {
+            "relation": "75efa8502c5c44e3912929c0b57565d7",
+            "name": "sub-003_task-emotionProcessing_echo-2_bold.nii"
+          },
+          {
+            "relation": "0608ebbb657942ffc976be8dbbb931fc",
+            "name": "sub-003_task-emotionProcessing_echo-3_bold.json"
+          },
+          {
+            "relation": "44c62c76a20eba67bf4787d00a4531e6",
+            "name": "sub-003_task-emotionProcessing_echo-3_bold.nii"
+          },
+          {
+            "relation": "01db1c4a5194d11f29dcf290cde45ef1",
+            "name": "sub-003_task-emotionProcessing_events.tsv.gz"
+          },
+          {
+            "relation": "e4dd082be4ec8c3c60c1a0baf5b61bf7",
+            "name": "sub-003_task-emotionProcessingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "4176db44d86095450d06d787ce620b2b",
+            "name": "sub-003_task-emotionProcessingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "198f071835eb54f9a23d4ab8019c2a37",
+            "name": "sub-003_task-emotionProcessingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "4694b2571463007ae3cc175a3cc7eb17",
+            "name": "sub-003_task-emotionProcessingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "25f2bdb1dcf0a366013718a654a3504a",
+            "name": "sub-003_task-emotionProcessingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "4d5b995c9938fbe15bdd2c49fbff6c61",
+            "name": "sub-003_task-emotionProcessingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "46cb2364d901e50f1364f9e96d37d972",
+            "name": "sub-003_task-emotionProcessingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "9d39fcc727462332da8bf2677ac02842",
+            "name": "sub-003_task-emotionProcessingImagined_physio.json"
+          },
+          {
+            "relation": "25cfd7f2e211d2182d54007c2133058d",
+            "name": "sub-003_task-emotionProcessingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "7671d986969005f3924a49b68375ffb8",
+            "name": "sub-003_task-emotionProcessing_physio.json"
+          },
+          {
+            "relation": "ecb4728f450c6dded958d78386553632",
+            "name": "sub-003_task-emotionProcessing_physio.tsv.gz"
+          },
+          {
+            "relation": "da47e50192f9bc1ff023b1298ab6c4c1",
+            "name": "sub-003_task-fingerTapping_echo-1_bold.json"
+          },
+          {
+            "relation": "e011d174c5ef1c6a243b69866d76acbc",
+            "name": "sub-003_task-fingerTapping_echo-1_bold.nii"
+          },
+          {
+            "relation": "2f9ee78f5ed4b03f3093558524ed7977",
+            "name": "sub-003_task-fingerTapping_echo-2_bold.json"
+          },
+          {
+            "relation": "c5dc421a2ce1cdf989da7c282db5ec0c",
+            "name": "sub-003_task-fingerTapping_echo-2_bold.nii"
+          },
+          {
+            "relation": "a6a3e3505d46a8cdc0760ffa179fc7e4",
+            "name": "sub-003_task-fingerTapping_echo-3_bold.json"
+          },
+          {
+            "relation": "b06d2d248db37901b035e19e9a560fa9",
+            "name": "sub-003_task-fingerTapping_echo-3_bold.nii"
+          },
+          {
+            "relation": "1b2fd317345b898fa22d1ab9e44c2dad",
+            "name": "sub-003_task-fingerTapping_events.tsv.gz"
+          },
+          {
+            "relation": "6dc91b045886ce1681b5dcf11d07e0f3",
+            "name": "sub-003_task-fingerTappingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "c54e7e640293282594de0d16cfe2d813",
+            "name": "sub-003_task-fingerTappingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "fa1e47cf0f9b847994d20ece5d4b8c1b",
+            "name": "sub-003_task-fingerTappingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "20f42887282f4bf87fc9d76aa1578102",
+            "name": "sub-003_task-fingerTappingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "4eaffe9798a630e7f7b35d94adc5681e",
+            "name": "sub-003_task-fingerTappingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "7408815811cc6083fcf63a2417e1bec2",
+            "name": "sub-003_task-fingerTappingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "d5a6c6f4589c8b5db4625150aec8c27e",
+            "name": "sub-003_task-fingerTappingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "0e4d96ff2b8b767e68f04bc62a704b4c",
+            "name": "sub-003_task-fingerTappingImagined_physio.json"
+          },
+          {
+            "relation": "3be50c6940c311ae26c2dc7f4c7df108",
+            "name": "sub-003_task-fingerTappingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "4f920e3548a8b17edcf2c5cd02393156",
+            "name": "sub-003_task-fingerTapping_physio.json"
+          },
+          {
+            "relation": "b1c827674e51653497a3a54541e36313",
+            "name": "sub-003_task-fingerTapping_physio.tsv.gz"
+          },
+          {
+            "relation": "17ae93a36f0bc5af4b6d6e0634864632",
+            "name": "sub-003_task-rest_run-1_echo-1_bold.json"
+          },
+          {
+            "relation": "db701d264ea88dffe4a47a207ab850a2",
+            "name": "sub-003_task-rest_run-1_echo-1_bold.nii"
+          },
+          {
+            "relation": "36be4c278f402df7ee8f7a3724d9e010",
+            "name": "sub-003_task-rest_run-1_echo-2_bold.json"
+          },
+          {
+            "relation": "2d4f35a104e2be5af5ce8a15519e9aac",
+            "name": "sub-003_task-rest_run-1_echo-2_bold.nii"
+          },
+          {
+            "relation": "50ad11f44d3f985bfe270667b6b093b9",
+            "name": "sub-003_task-rest_run-1_echo-3_bold.json"
+          },
+          {
+            "relation": "038053e3e4ddf25cf8576219507dfaa3",
+            "name": "sub-003_task-rest_run-1_echo-3_bold.nii"
+          },
+          {
+            "relation": "10a7e7a80ed4aab38196fad3ff89c291",
+            "name": "sub-003_task-rest_run-1_physio.json"
+          },
+          {
+            "relation": "c53d254a96bd5c6f8b6229ae8e5a4417",
+            "name": "sub-003_task-rest_run-1_physio.tsv.gz"
+          },
+          {
+            "relation": "08472211cbfcf501142274f13c8eb449",
+            "name": "sub-003_task-rest_run-2_echo-1_bold.json"
+          },
+          {
+            "relation": "fab75720328ab13511b6d397b211b948",
+            "name": "sub-003_task-rest_run-2_echo-1_bold.nii"
+          },
+          {
+            "relation": "5179d897d306c52b209d691c35415f5c",
+            "name": "sub-003_task-rest_run-2_echo-2_bold.json"
+          },
+          {
+            "relation": "2c6b0d65245c1f5955ce5ccb6b5ec789",
+            "name": "sub-003_task-rest_run-2_echo-2_bold.nii"
+          },
+          {
+            "relation": "2a98a2e0a158a9af593918d54340973c",
+            "name": "sub-003_task-rest_run-2_echo-3_bold.json"
+          },
+          {
+            "relation": "51a412ffa50f35b4eddc4784d392814c",
+            "name": "sub-003_task-rest_run-2_echo-3_bold.nii"
+          },
+          {
+            "relation": "6ac1a20148d2ae8984c099e033fd0c35",
+            "name": "sub-003_task-rest_run-2_physio.json"
+          },
+          {
+            "relation": "80f50906952e9c32795e83eb0cb3abaf",
+            "name": "sub-003_task-rest_run-2_physio.tsv.gz"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f41afd8250988c7601d688addb9b7102",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f41afd8250988c7601d688addb9b7102"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46493"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2050d7c945bee0a6caad609e7b74dac9",
+        "byte_size": 1039,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2050d7c945bee0a6caad609e7b74dac9"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45149"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "75efa8502c5c44e3912929c0b57565d7",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "75efa8502c5c44e3912929c0b57565d7"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45435"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "0608ebbb657942ffc976be8dbbb931fc",
+        "byte_size": 1039,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "0608ebbb657942ffc976be8dbbb931fc"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45566"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "44c62c76a20eba67bf4787d00a4531e6",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "44c62c76a20eba67bf4787d00a4531e6"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45834"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "01db1c4a5194d11f29dcf290cde45ef1",
+        "byte_size": 1858,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "01db1c4a5194d11f29dcf290cde45ef1"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46626"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e4dd082be4ec8c3c60c1a0baf5b61bf7",
+        "byte_size": 1049,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e4dd082be4ec8c3c60c1a0baf5b61bf7"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46097"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4176db44d86095450d06d787ce620b2b",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4176db44d86095450d06d787ce620b2b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45633"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "198f071835eb54f9a23d4ab8019c2a37",
+        "byte_size": 1049,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "198f071835eb54f9a23d4ab8019c2a37"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45412"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4694b2571463007ae3cc175a3cc7eb17",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4694b2571463007ae3cc175a3cc7eb17"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45646"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "25f2bdb1dcf0a366013718a654a3504a",
+        "byte_size": 1049,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "25f2bdb1dcf0a366013718a654a3504a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45282"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4d5b995c9938fbe15bdd2c49fbff6c61",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4d5b995c9938fbe15bdd2c49fbff6c61"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45783"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "46cb2364d901e50f1364f9e96d37d972",
+        "byte_size": 176,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "46cb2364d901e50f1364f9e96d37d972"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46620"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "9d39fcc727462332da8bf2677ac02842",
+        "byte_size": 142,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "9d39fcc727462332da8bf2677ac02842"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46060"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "25cfd7f2e211d2182d54007c2133058d",
+        "byte_size": 493322,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "25cfd7f2e211d2182d54007c2133058d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45599"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "7671d986969005f3924a49b68375ffb8",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "7671d986969005f3924a49b68375ffb8"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45883"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ecb4728f450c6dded958d78386553632",
+        "byte_size": 512614,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ecb4728f450c6dded958d78386553632"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45872"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "da47e50192f9bc1ff023b1298ab6c4c1",
+        "byte_size": 1037,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "da47e50192f9bc1ff023b1298ab6c4c1"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45990"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e011d174c5ef1c6a243b69866d76acbc",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e011d174c5ef1c6a243b69866d76acbc"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45432"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2f9ee78f5ed4b03f3093558524ed7977",
+        "byte_size": 1037,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2f9ee78f5ed4b03f3093558524ed7977"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45732"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c5dc421a2ce1cdf989da7c282db5ec0c",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c5dc421a2ce1cdf989da7c282db5ec0c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45423"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a6a3e3505d46a8cdc0760ffa179fc7e4",
+        "byte_size": 1037,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a6a3e3505d46a8cdc0760ffa179fc7e4"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46075"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b06d2d248db37901b035e19e9a560fa9",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b06d2d248db37901b035e19e9a560fa9"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45245"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1b2fd317345b898fa22d1ab9e44c2dad",
+        "byte_size": 164,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1b2fd317345b898fa22d1ab9e44c2dad"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46659"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6dc91b045886ce1681b5dcf11d07e0f3",
+        "byte_size": 1045,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6dc91b045886ce1681b5dcf11d07e0f3"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46385"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c54e7e640293282594de0d16cfe2d813",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c54e7e640293282594de0d16cfe2d813"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45558"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "fa1e47cf0f9b847994d20ece5d4b8c1b",
+        "byte_size": 1045,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "fa1e47cf0f9b847994d20ece5d4b8c1b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46412"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "20f42887282f4bf87fc9d76aa1578102",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "20f42887282f4bf87fc9d76aa1578102"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46028"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4eaffe9798a630e7f7b35d94adc5681e",
+        "byte_size": 1045,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4eaffe9798a630e7f7b35d94adc5681e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45095"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "7408815811cc6083fcf63a2417e1bec2",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "7408815811cc6083fcf63a2417e1bec2"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45737"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d5a6c6f4589c8b5db4625150aec8c27e",
+        "byte_size": 179,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d5a6c6f4589c8b5db4625150aec8c27e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46594"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "0e4d96ff2b8b767e68f04bc62a704b4c",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "0e4d96ff2b8b767e68f04bc62a704b4c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46299"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "3be50c6940c311ae26c2dc7f4c7df108",
+        "byte_size": 489887,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "3be50c6940c311ae26c2dc7f4c7df108"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45104"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4f920e3548a8b17edcf2c5cd02393156",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4f920e3548a8b17edcf2c5cd02393156"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45642"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b1c827674e51653497a3a54541e36313",
+        "byte_size": 523737,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b1c827674e51653497a3a54541e36313"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45462"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "17ae93a36f0bc5af4b6d6e0634864632",
+        "byte_size": 1028,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "17ae93a36f0bc5af4b6d6e0634864632"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46531"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "db701d264ea88dffe4a47a207ab850a2",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "db701d264ea88dffe4a47a207ab850a2"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45893"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "36be4c278f402df7ee8f7a3724d9e010",
+        "byte_size": 1028,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "36be4c278f402df7ee8f7a3724d9e010"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45824"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2d4f35a104e2be5af5ce8a15519e9aac",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2d4f35a104e2be5af5ce8a15519e9aac"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45603"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "50ad11f44d3f985bfe270667b6b093b9",
+        "byte_size": 1028,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "50ad11f44d3f985bfe270667b6b093b9"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45711"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "038053e3e4ddf25cf8576219507dfaa3",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "038053e3e4ddf25cf8576219507dfaa3"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46394"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "10a7e7a80ed4aab38196fad3ff89c291",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "10a7e7a80ed4aab38196fad3ff89c291"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45398"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c53d254a96bd5c6f8b6229ae8e5a4417",
+        "byte_size": 444600,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c53d254a96bd5c6f8b6229ae8e5a4417"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46379"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "08472211cbfcf501142274f13c8eb449",
+        "byte_size": 1028,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "08472211cbfcf501142274f13c8eb449"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46199"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "fab75720328ab13511b6d397b211b948",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "fab75720328ab13511b6d397b211b948"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45949"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5179d897d306c52b209d691c35415f5c",
+        "byte_size": 1028,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5179d897d306c52b209d691c35415f5c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46440"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2c6b0d65245c1f5955ce5ccb6b5ec789",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2c6b0d65245c1f5955ce5ccb6b5ec789"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45444"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2a98a2e0a158a9af593918d54340973c",
+        "byte_size": 1028,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2a98a2e0a158a9af593918d54340973c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45158"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "51a412ffa50f35b4eddc4784d392814c",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "51a412ffa50f35b4eddc4784d392814c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45653"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6ac1a20148d2ae8984c099e033fd0c35",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6ac1a20148d2ae8984c099e033fd0c35"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45601"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "80f50906952e9c32795e83eb0cb3abaf",
+        "byte_size": 472280,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "80f50906952e9c32795e83eb0cb3abaf"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45155"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "58d8367944bf28848557da5fa9a42cbf",
+        "byte_size": 20736352,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "58d8367944bf28848557da5fa9a42cbf"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45910"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-004/",
+        "qualified_part": [
+          {
+            "relation": "sub-004/anat/",
+            "name": "anat"
+          },
+          {
+            "relation": "sub-004/func/",
+            "name": "func"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-004/anat/",
+        "qualified_part": [
+          {
+            "relation": "58d8367944bf28848557da5fa9a42cbf",
+            "name": "sub-004_T1w.nii"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "34a35e002060107f9d015e47e337ab30",
+        "byte_size": 1042,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "34a35e002060107f9d015e47e337ab30"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45136"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-004/func/",
+        "qualified_part": [
+          {
+            "relation": "34a35e002060107f9d015e47e337ab30",
+            "name": "sub-004_task-emotionProcessing_echo-1_bold.json"
+          },
+          {
+            "relation": "1966f9963c3cce7b182cd15e5fd6b247",
+            "name": "sub-004_task-emotionProcessing_echo-1_bold.nii"
+          },
+          {
+            "relation": "5a59e89c7d19e229a2813067e8e61f71",
+            "name": "sub-004_task-emotionProcessing_echo-2_bold.json"
+          },
+          {
+            "relation": "8899bd49d48c71c57e602f5048be4ac6",
+            "name": "sub-004_task-emotionProcessing_echo-2_bold.nii"
+          },
+          {
+            "relation": "4fa63ab16201e215019dda3cac213e2a",
+            "name": "sub-004_task-emotionProcessing_echo-3_bold.json"
+          },
+          {
+            "relation": "8c6d259a6aba141794311f476d629b3e",
+            "name": "sub-004_task-emotionProcessing_echo-3_bold.nii"
+          },
+          {
+            "relation": "44479a7e0853ae4448577db9d59ad4fd",
+            "name": "sub-004_task-emotionProcessing_events.tsv.gz"
+          },
+          {
+            "relation": "f36ef17a4f775994cc72f6c477617d2a",
+            "name": "sub-004_task-emotionProcessingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "43cfc6023dfa200ff0e406ba59b45c34",
+            "name": "sub-004_task-emotionProcessingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "49f053634b6e9efc7f6c75d8a27c0203",
+            "name": "sub-004_task-emotionProcessingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "74477f9caf0a44d593a03311120868de",
+            "name": "sub-004_task-emotionProcessingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "58394a3751a16d3489d7184a3c028a48",
+            "name": "sub-004_task-emotionProcessingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "1e6626678c8869bdf81d9c086f30f2dc",
+            "name": "sub-004_task-emotionProcessingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "07d6079dae864f78200f7952d9c4e4c6",
+            "name": "sub-004_task-emotionProcessingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "8305718c9f660f7a56ff7a1d20baf70d",
+            "name": "sub-004_task-emotionProcessingImagined_physio.json"
+          },
+          {
+            "relation": "c996e6b7c02de87e8aa4557c8e1f3768",
+            "name": "sub-004_task-emotionProcessingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "dab7cb3e67b101ca05a9a508215f8dd0",
+            "name": "sub-004_task-emotionProcessing_physio.json"
+          },
+          {
+            "relation": "ceea28302989820975135a9c614dd540",
+            "name": "sub-004_task-emotionProcessing_physio.tsv.gz"
+          },
+          {
+            "relation": "8a5131e167a16243ea24d0be2e50d088",
+            "name": "sub-004_task-fingerTapping_echo-1_bold.json"
+          },
+          {
+            "relation": "6f08635a0f32a98a2f79a0fa8d24535e",
+            "name": "sub-004_task-fingerTapping_echo-1_bold.nii"
+          },
+          {
+            "relation": "e2a4369dd2f8a003a7875e5ad0575be1",
+            "name": "sub-004_task-fingerTapping_echo-2_bold.json"
+          },
+          {
+            "relation": "c63ac9ab0f47be10beeecbd6994b3011",
+            "name": "sub-004_task-fingerTapping_echo-2_bold.nii"
+          },
+          {
+            "relation": "e7f2903e14bdb420ecf97e9d4c390da3",
+            "name": "sub-004_task-fingerTapping_echo-3_bold.json"
+          },
+          {
+            "relation": "40c2011540513e0feaaccf63b81b690e",
+            "name": "sub-004_task-fingerTapping_echo-3_bold.nii"
+          },
+          {
+            "relation": "cc4b52c7e9b24d4c5d83ea093200d98b",
+            "name": "sub-004_task-fingerTapping_events.tsv.gz"
+          },
+          {
+            "relation": "a5ca44b8a3d361b1fe1b3567be9adea6",
+            "name": "sub-004_task-fingerTappingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "683f476deac7c52b45a1246b2e1ffb35",
+            "name": "sub-004_task-fingerTappingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "d0af5398225d1082e6c1af5eed463db9",
+            "name": "sub-004_task-fingerTappingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "9cc07e3893057ca6cdfd206828d16194",
+            "name": "sub-004_task-fingerTappingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "4a18cf99e492cf5c14e7639fb31842e7",
+            "name": "sub-004_task-fingerTappingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "c80b6124c2c5b4fad41bb398416d86a4",
+            "name": "sub-004_task-fingerTappingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "ba23264ce250a919463ac1c88740217e",
+            "name": "sub-004_task-fingerTappingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "d2c6e3310ed7ef5d21f969b30244f520",
+            "name": "sub-004_task-fingerTappingImagined_physio.json"
+          },
+          {
+            "relation": "94966adddec90ba26e94b32be4eebc61",
+            "name": "sub-004_task-fingerTappingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "ee153b04600e381b86f0543a33f91a6f",
+            "name": "sub-004_task-fingerTapping_physio.json"
+          },
+          {
+            "relation": "82b693bd13603114e1366bcd7451a2ce",
+            "name": "sub-004_task-fingerTapping_physio.tsv.gz"
+          },
+          {
+            "relation": "ca28f098501f7d6279f2643df7a809ed",
+            "name": "sub-004_task-rest_run-1_echo-1_bold.json"
+          },
+          {
+            "relation": "b4fc16017fc34696bad6b292e90ee274",
+            "name": "sub-004_task-rest_run-1_echo-1_bold.nii"
+          },
+          {
+            "relation": "01e1290eb404eccf4520e1dab01c24bb",
+            "name": "sub-004_task-rest_run-1_echo-2_bold.json"
+          },
+          {
+            "relation": "5e911175e9c452cca2d6f25436a9bfb8",
+            "name": "sub-004_task-rest_run-1_echo-2_bold.nii"
+          },
+          {
+            "relation": "2ca75787822c8e4f03ca5b67a60531a9",
+            "name": "sub-004_task-rest_run-1_echo-3_bold.json"
+          },
+          {
+            "relation": "561457fa892cbdd65220c6e3128e1f49",
+            "name": "sub-004_task-rest_run-1_echo-3_bold.nii"
+          },
+          {
+            "relation": "285431e80fa96a66ecb6e37f4fb414cf",
+            "name": "sub-004_task-rest_run-1_physio.json"
+          },
+          {
+            "relation": "956ca5c8a5d40a90cf1504da247c6b4c",
+            "name": "sub-004_task-rest_run-1_physio.tsv.gz"
+          },
+          {
+            "relation": "5cde587fccae4ea2bbfac89fe90762e5",
+            "name": "sub-004_task-rest_run-2_echo-1_bold.json"
+          },
+          {
+            "relation": "afebe2e9412da20fabb39983ad8bf4e4",
+            "name": "sub-004_task-rest_run-2_echo-1_bold.nii"
+          },
+          {
+            "relation": "22021c29436d8dd41bdcc4d623767287",
+            "name": "sub-004_task-rest_run-2_echo-2_bold.json"
+          },
+          {
+            "relation": "c8470d6102b3ae3d8cbaa5cba22c0470",
+            "name": "sub-004_task-rest_run-2_echo-2_bold.nii"
+          },
+          {
+            "relation": "8e0eb4c3371a930c04845b7eb889d1a2",
+            "name": "sub-004_task-rest_run-2_echo-3_bold.json"
+          },
+          {
+            "relation": "e124551b127db0efc5489510daf2f037",
+            "name": "sub-004_task-rest_run-2_echo-3_bold.nii"
+          },
+          {
+            "relation": "4f5d46a7566d1a7bbfbd5be7ad026956",
+            "name": "sub-004_task-rest_run-2_physio.json"
+          },
+          {
+            "relation": "6c03087b2beb9db957ef5988fb253057",
+            "name": "sub-004_task-rest_run-2_physio.tsv.gz"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1966f9963c3cce7b182cd15e5fd6b247",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1966f9963c3cce7b182cd15e5fd6b247"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45861"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5a59e89c7d19e229a2813067e8e61f71",
+        "byte_size": 1042,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5a59e89c7d19e229a2813067e8e61f71"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45843"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8899bd49d48c71c57e602f5048be4ac6",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8899bd49d48c71c57e602f5048be4ac6"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46511"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4fa63ab16201e215019dda3cac213e2a",
+        "byte_size": 1042,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4fa63ab16201e215019dda3cac213e2a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46148"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8c6d259a6aba141794311f476d629b3e",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8c6d259a6aba141794311f476d629b3e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45304"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "44479a7e0853ae4448577db9d59ad4fd",
+        "byte_size": 1868,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "44479a7e0853ae4448577db9d59ad4fd"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46578"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f36ef17a4f775994cc72f6c477617d2a",
+        "byte_size": 1050,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f36ef17a4f775994cc72f6c477617d2a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45189"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "43cfc6023dfa200ff0e406ba59b45c34",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "43cfc6023dfa200ff0e406ba59b45c34"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46089"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "49f053634b6e9efc7f6c75d8a27c0203",
+        "byte_size": 1050,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "49f053634b6e9efc7f6c75d8a27c0203"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45971"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "74477f9caf0a44d593a03311120868de",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "74477f9caf0a44d593a03311120868de"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45846"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "58394a3751a16d3489d7184a3c028a48",
+        "byte_size": 1050,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "58394a3751a16d3489d7184a3c028a48"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45712"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1e6626678c8869bdf81d9c086f30f2dc",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1e6626678c8869bdf81d9c086f30f2dc"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46428"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "07d6079dae864f78200f7952d9c4e4c6",
+        "byte_size": 175,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "07d6079dae864f78200f7952d9c4e4c6"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46652"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8305718c9f660f7a56ff7a1d20baf70d",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8305718c9f660f7a56ff7a1d20baf70d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46063"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c996e6b7c02de87e8aa4557c8e1f3768",
+        "byte_size": 485821,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c996e6b7c02de87e8aa4557c8e1f3768"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46192"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "dab7cb3e67b101ca05a9a508215f8dd0",
+        "byte_size": 142,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "dab7cb3e67b101ca05a9a508215f8dd0"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46444"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ceea28302989820975135a9c614dd540",
+        "byte_size": 508552,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ceea28302989820975135a9c614dd540"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46376"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8a5131e167a16243ea24d0be2e50d088",
+        "byte_size": 1038,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8a5131e167a16243ea24d0be2e50d088"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46086"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6f08635a0f32a98a2f79a0fa8d24535e",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6f08635a0f32a98a2f79a0fa8d24535e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46326"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e2a4369dd2f8a003a7875e5ad0575be1",
+        "byte_size": 1038,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e2a4369dd2f8a003a7875e5ad0575be1"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46419"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c63ac9ab0f47be10beeecbd6994b3011",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c63ac9ab0f47be10beeecbd6994b3011"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45294"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e7f2903e14bdb420ecf97e9d4c390da3",
+        "byte_size": 1038,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e7f2903e14bdb420ecf97e9d4c390da3"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45926"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "40c2011540513e0feaaccf63b81b690e",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "40c2011540513e0feaaccf63b81b690e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45710"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "cc4b52c7e9b24d4c5d83ea093200d98b",
+        "byte_size": 165,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "cc4b52c7e9b24d4c5d83ea093200d98b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46629"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a5ca44b8a3d361b1fe1b3567be9adea6",
+        "byte_size": 1046,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a5ca44b8a3d361b1fe1b3567be9adea6"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46222"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "683f476deac7c52b45a1246b2e1ffb35",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "683f476deac7c52b45a1246b2e1ffb35"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45911"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d0af5398225d1082e6c1af5eed463db9",
+        "byte_size": 1046,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d0af5398225d1082e6c1af5eed463db9"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45226"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "9cc07e3893057ca6cdfd206828d16194",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "9cc07e3893057ca6cdfd206828d16194"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45393"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4a18cf99e492cf5c14e7639fb31842e7",
+        "byte_size": 1046,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4a18cf99e492cf5c14e7639fb31842e7"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46491"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c80b6124c2c5b4fad41bb398416d86a4",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c80b6124c2c5b4fad41bb398416d86a4"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45318"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ba23264ce250a919463ac1c88740217e",
+        "byte_size": 179,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ba23264ce250a919463ac1c88740217e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46615"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d2c6e3310ed7ef5d21f969b30244f520",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d2c6e3310ed7ef5d21f969b30244f520"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45402"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "94966adddec90ba26e94b32be4eebc61",
+        "byte_size": 487009,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "94966adddec90ba26e94b32be4eebc61"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46367"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ee153b04600e381b86f0543a33f91a6f",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ee153b04600e381b86f0543a33f91a6f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46014"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "82b693bd13603114e1366bcd7451a2ce",
+        "byte_size": 489124,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "82b693bd13603114e1366bcd7451a2ce"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46533"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ca28f098501f7d6279f2643df7a809ed",
+        "byte_size": 1029,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ca28f098501f7d6279f2643df7a809ed"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45765"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b4fc16017fc34696bad6b292e90ee274",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b4fc16017fc34696bad6b292e90ee274"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45257"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "01e1290eb404eccf4520e1dab01c24bb",
+        "byte_size": 1029,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "01e1290eb404eccf4520e1dab01c24bb"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46427"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5e911175e9c452cca2d6f25436a9bfb8",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5e911175e9c452cca2d6f25436a9bfb8"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45390"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2ca75787822c8e4f03ca5b67a60531a9",
+        "byte_size": 1029,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2ca75787822c8e4f03ca5b67a60531a9"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46110"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "561457fa892cbdd65220c6e3128e1f49",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "561457fa892cbdd65220c6e3128e1f49"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45326"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "285431e80fa96a66ecb6e37f4fb414cf",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "285431e80fa96a66ecb6e37f4fb414cf"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45959"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "956ca5c8a5d40a90cf1504da247c6b4c",
+        "byte_size": 452268,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "956ca5c8a5d40a90cf1504da247c6b4c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45366"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5cde587fccae4ea2bbfac89fe90762e5",
+        "byte_size": 1029,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5cde587fccae4ea2bbfac89fe90762e5"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45700"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "afebe2e9412da20fabb39983ad8bf4e4",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "afebe2e9412da20fabb39983ad8bf4e4"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45543"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "22021c29436d8dd41bdcc4d623767287",
+        "byte_size": 1029,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "22021c29436d8dd41bdcc4d623767287"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45994"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c8470d6102b3ae3d8cbaa5cba22c0470",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c8470d6102b3ae3d8cbaa5cba22c0470"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45614"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8e0eb4c3371a930c04845b7eb889d1a2",
+        "byte_size": 1029,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8e0eb4c3371a930c04845b7eb889d1a2"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46519"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e124551b127db0efc5489510daf2f037",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e124551b127db0efc5489510daf2f037"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45572"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4f5d46a7566d1a7bbfbd5be7ad026956",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4f5d46a7566d1a7bbfbd5be7ad026956"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45449"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6c03087b2beb9db957ef5988fb253057",
+        "byte_size": 466721,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6c03087b2beb9db957ef5988fb253057"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45537"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ba7215ae4a975c77d06363cc23455895",
+        "byte_size": 20736352,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ba7215ae4a975c77d06363cc23455895"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45156"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-005/",
+        "qualified_part": [
+          {
+            "relation": "sub-005/anat/",
+            "name": "anat"
+          },
+          {
+            "relation": "sub-005/func/",
+            "name": "func"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-005/anat/",
+        "qualified_part": [
+          {
+            "relation": "ba7215ae4a975c77d06363cc23455895",
+            "name": "sub-005_T1w.nii"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5620260863482ac69a3d880b3cc5d4d5",
+        "byte_size": 1036,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5620260863482ac69a3d880b3cc5d4d5"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45239"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-005/func/",
+        "qualified_part": [
+          {
+            "relation": "5620260863482ac69a3d880b3cc5d4d5",
+            "name": "sub-005_task-emotionProcessing_echo-1_bold.json"
+          },
+          {
+            "relation": "e8597ab384391f88368f92df85528228",
+            "name": "sub-005_task-emotionProcessing_echo-1_bold.nii"
+          },
+          {
+            "relation": "06a41d823bf94b4e474e61bdb7c600f7",
+            "name": "sub-005_task-emotionProcessing_echo-2_bold.json"
+          },
+          {
+            "relation": "d8886eae9e8b52724ac1b3a739f845fd",
+            "name": "sub-005_task-emotionProcessing_echo-2_bold.nii"
+          },
+          {
+            "relation": "857942be9fae2be22771e0fa3e6c0596",
+            "name": "sub-005_task-emotionProcessing_echo-3_bold.json"
+          },
+          {
+            "relation": "2463012f8847a959bcc923302e446034",
+            "name": "sub-005_task-emotionProcessing_echo-3_bold.nii"
+          },
+          {
+            "relation": "8591fb9d4b80fe2e976d8556478965eb",
+            "name": "sub-005_task-emotionProcessing_events.tsv.gz"
+          },
+          {
+            "relation": "cf85da54869c203e5227cd2e678827be",
+            "name": "sub-005_task-emotionProcessingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "1827f157a2ea364d9d0d4a91b8f4e9e8",
+            "name": "sub-005_task-emotionProcessingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "a26bcd77739bb9a39b6a097a50927e9e",
+            "name": "sub-005_task-emotionProcessingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "86d61fffd5f9bfe8985687ca25db1b3d",
+            "name": "sub-005_task-emotionProcessingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "2e6bb2a54113f9b4bfa0db68bbbd9582",
+            "name": "sub-005_task-emotionProcessingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "560c581bd2dd79e4e515a5b8fc684e16",
+            "name": "sub-005_task-emotionProcessingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "1b2cccc690fa0fb1292b34051d0fd921",
+            "name": "sub-005_task-emotionProcessingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "e34ca6bef05662b16f9dcbd5ecf59898",
+            "name": "sub-005_task-emotionProcessingImagined_physio.json"
+          },
+          {
+            "relation": "4ae203ccaed175f79ff01003f8a19bb7",
+            "name": "sub-005_task-emotionProcessingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "57d9656db263d6740b1b3c842db67bd8",
+            "name": "sub-005_task-emotionProcessing_physio.json"
+          },
+          {
+            "relation": "076bdc3f561911acb07eab3dd1f5df9a",
+            "name": "sub-005_task-emotionProcessing_physio.tsv.gz"
+          },
+          {
+            "relation": "1058863a0b9ac9305ca3eaa205c8e482",
+            "name": "sub-005_task-fingerTapping_echo-1_bold.json"
+          },
+          {
+            "relation": "c4c158f389337815f03dd442323170cd",
+            "name": "sub-005_task-fingerTapping_echo-1_bold.nii"
+          },
+          {
+            "relation": "f7b81b0343d8bcd0037c42715e479aae",
+            "name": "sub-005_task-fingerTapping_echo-2_bold.json"
+          },
+          {
+            "relation": "61d9111af78acb7fbfc9f1c953e393d1",
+            "name": "sub-005_task-fingerTapping_echo-2_bold.nii"
+          },
+          {
+            "relation": "b838da26f4982a9055838095cd42edb8",
+            "name": "sub-005_task-fingerTapping_echo-3_bold.json"
+          },
+          {
+            "relation": "559c1c151f4130bc52190576ada7a1e0",
+            "name": "sub-005_task-fingerTapping_echo-3_bold.nii"
+          },
+          {
+            "relation": "2dc9bdf268f8ee5f6660b6079d347ae6",
+            "name": "sub-005_task-fingerTapping_events.tsv.gz"
+          },
+          {
+            "relation": "0ca76203dbb3231b05d4c28cacf8deb5",
+            "name": "sub-005_task-fingerTappingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "242cef3e49f0361bcf7ee7337ad42f9e",
+            "name": "sub-005_task-fingerTappingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "acb9906cfe54b0a07753784ceebe36d1",
+            "name": "sub-005_task-fingerTappingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "cf58f27bec609869d3e1223ec0928040",
+            "name": "sub-005_task-fingerTappingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "6d3d0a49ce28df559814f25c3f56249d",
+            "name": "sub-005_task-fingerTappingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "fb5d2a49b1fa43561b3893c705f20a37",
+            "name": "sub-005_task-fingerTappingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "5511a9bdf9b4bc31847a527f09b1dc0e",
+            "name": "sub-005_task-fingerTappingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "534405ecb32f76a2885211190f10fb72",
+            "name": "sub-005_task-fingerTappingImagined_physio.json"
+          },
+          {
+            "relation": "4e38eaee3bca1fe437c028cddbc84a58",
+            "name": "sub-005_task-fingerTappingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "1b95897a4ff499880e19e33c1d9063e1",
+            "name": "sub-005_task-fingerTapping_physio.json"
+          },
+          {
+            "relation": "cb614443d3b1a376ff71023ef5762224",
+            "name": "sub-005_task-fingerTapping_physio.tsv.gz"
+          },
+          {
+            "relation": "fd7a04bc9095b203ce07810848951508",
+            "name": "sub-005_task-rest_run-1_echo-1_bold.json"
+          },
+          {
+            "relation": "f27c8fa8553a3105635841347685da9e",
+            "name": "sub-005_task-rest_run-1_echo-1_bold.nii"
+          },
+          {
+            "relation": "503939b3eacaf49259ed9f0485fbb169",
+            "name": "sub-005_task-rest_run-1_echo-2_bold.json"
+          },
+          {
+            "relation": "826254d83065c0461428cf7a1c7bcbfb",
+            "name": "sub-005_task-rest_run-1_echo-2_bold.nii"
+          },
+          {
+            "relation": "efb5d489c01003958d3b3f84ef85bf49",
+            "name": "sub-005_task-rest_run-1_echo-3_bold.json"
+          },
+          {
+            "relation": "4908d85ca4e3b0a0d5e354107329c93d",
+            "name": "sub-005_task-rest_run-1_echo-3_bold.nii"
+          },
+          {
+            "relation": "a13d5b27089b27005943abc68e90c2d5",
+            "name": "sub-005_task-rest_run-1_physio.json"
+          },
+          {
+            "relation": "800ebe464c7dc49deb06e557e0f29ea7",
+            "name": "sub-005_task-rest_run-1_physio.tsv.gz"
+          },
+          {
+            "relation": "8b7812f78a276e261df17d3b221a066a",
+            "name": "sub-005_task-rest_run-2_echo-1_bold.json"
+          },
+          {
+            "relation": "fea0858e750b27aa46e3c8a3b411f10f",
+            "name": "sub-005_task-rest_run-2_echo-1_bold.nii"
+          },
+          {
+            "relation": "e011cc059bd77e9c19a5e38584eb5628",
+            "name": "sub-005_task-rest_run-2_echo-2_bold.json"
+          },
+          {
+            "relation": "35fdfa50f2d36c0ac4d329e5012369ad",
+            "name": "sub-005_task-rest_run-2_echo-2_bold.nii"
+          },
+          {
+            "relation": "6611683433437ac176de1c263a2f4ecc",
+            "name": "sub-005_task-rest_run-2_echo-3_bold.json"
+          },
+          {
+            "relation": "b3c11c643a12d6acb7dd626b963ad193",
+            "name": "sub-005_task-rest_run-2_echo-3_bold.nii"
+          },
+          {
+            "relation": "d66328032fd3fbc635bd564170bc8671",
+            "name": "sub-005_task-rest_run-2_physio.json"
+          },
+          {
+            "relation": "b7338170f7583bc97fbc2140052f28c2",
+            "name": "sub-005_task-rest_run-2_physio.tsv.gz"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e8597ab384391f88368f92df85528228",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e8597ab384391f88368f92df85528228"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46232"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "06a41d823bf94b4e474e61bdb7c600f7",
+        "byte_size": 1036,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "06a41d823bf94b4e474e61bdb7c600f7"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46042"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d8886eae9e8b52724ac1b3a739f845fd",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d8886eae9e8b52724ac1b3a739f845fd"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46361"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "857942be9fae2be22771e0fa3e6c0596",
+        "byte_size": 1036,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "857942be9fae2be22771e0fa3e6c0596"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45904"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2463012f8847a959bcc923302e446034",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2463012f8847a959bcc923302e446034"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45237"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8591fb9d4b80fe2e976d8556478965eb",
+        "byte_size": 1906,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8591fb9d4b80fe2e976d8556478965eb"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46647"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "cf85da54869c203e5227cd2e678827be",
+        "byte_size": 1043,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "cf85da54869c203e5227cd2e678827be"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45588"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1827f157a2ea364d9d0d4a91b8f4e9e8",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1827f157a2ea364d9d0d4a91b8f4e9e8"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45292"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a26bcd77739bb9a39b6a097a50927e9e",
+        "byte_size": 1043,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a26bcd77739bb9a39b6a097a50927e9e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45629"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "86d61fffd5f9bfe8985687ca25db1b3d",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "86d61fffd5f9bfe8985687ca25db1b3d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45323"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2e6bb2a54113f9b4bfa0db68bbbd9582",
+        "byte_size": 1043,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2e6bb2a54113f9b4bfa0db68bbbd9582"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45418"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "560c581bd2dd79e4e515a5b8fc684e16",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "560c581bd2dd79e4e515a5b8fc684e16"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46049"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1b2cccc690fa0fb1292b34051d0fd921",
+        "byte_size": 174,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1b2cccc690fa0fb1292b34051d0fd921"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46593"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e34ca6bef05662b16f9dcbd5ecf59898",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e34ca6bef05662b16f9dcbd5ecf59898"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45436"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4ae203ccaed175f79ff01003f8a19bb7",
+        "byte_size": 476888,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4ae203ccaed175f79ff01003f8a19bb7"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46164"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "57d9656db263d6740b1b3c842db67bd8",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "57d9656db263d6740b1b3c842db67bd8"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45484"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "076bdc3f561911acb07eab3dd1f5df9a",
+        "byte_size": 488391,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "076bdc3f561911acb07eab3dd1f5df9a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46064"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1058863a0b9ac9305ca3eaa205c8e482",
+        "byte_size": 1031,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1058863a0b9ac9305ca3eaa205c8e482"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45465"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c4c158f389337815f03dd442323170cd",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c4c158f389337815f03dd442323170cd"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46119"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f7b81b0343d8bcd0037c42715e479aae",
+        "byte_size": 1031,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f7b81b0343d8bcd0037c42715e479aae"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45664"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "61d9111af78acb7fbfc9f1c953e393d1",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "61d9111af78acb7fbfc9f1c953e393d1"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45637"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b838da26f4982a9055838095cd42edb8",
+        "byte_size": 1031,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b838da26f4982a9055838095cd42edb8"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45590"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "559c1c151f4130bc52190576ada7a1e0",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "559c1c151f4130bc52190576ada7a1e0"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46421"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2dc9bdf268f8ee5f6660b6079d347ae6",
+        "byte_size": 164,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2dc9bdf268f8ee5f6660b6079d347ae6"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46624"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "0ca76203dbb3231b05d4c28cacf8deb5",
+        "byte_size": 1040,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "0ca76203dbb3231b05d4c28cacf8deb5"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45091"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "242cef3e49f0361bcf7ee7337ad42f9e",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "242cef3e49f0361bcf7ee7337ad42f9e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45467"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "acb9906cfe54b0a07753784ceebe36d1",
+        "byte_size": 1040,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "acb9906cfe54b0a07753784ceebe36d1"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46534"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "cf58f27bec609869d3e1223ec0928040",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "cf58f27bec609869d3e1223ec0928040"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46451"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6d3d0a49ce28df559814f25c3f56249d",
+        "byte_size": 1040,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6d3d0a49ce28df559814f25c3f56249d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45480"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "fb5d2a49b1fa43561b3893c705f20a37",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "fb5d2a49b1fa43561b3893c705f20a37"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45271"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5511a9bdf9b4bc31847a527f09b1dc0e",
+        "byte_size": 178,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5511a9bdf9b4bc31847a527f09b1dc0e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46553"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "534405ecb32f76a2885211190f10fb72",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "534405ecb32f76a2885211190f10fb72"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46509"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4e38eaee3bca1fe437c028cddbc84a58",
+        "byte_size": 477047,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4e38eaee3bca1fe437c028cddbc84a58"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45342"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1b95897a4ff499880e19e33c1d9063e1",
+        "byte_size": 142,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1b95897a4ff499880e19e33c1d9063e1"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45293"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "cb614443d3b1a376ff71023ef5762224",
+        "byte_size": 494630,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "cb614443d3b1a376ff71023ef5762224"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45865"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "fd7a04bc9095b203ce07810848951508",
+        "byte_size": 1023,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "fd7a04bc9095b203ce07810848951508"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45275"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f27c8fa8553a3105635841347685da9e",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f27c8fa8553a3105635841347685da9e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45787"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "503939b3eacaf49259ed9f0485fbb169",
+        "byte_size": 1023,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "503939b3eacaf49259ed9f0485fbb169"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46073"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "826254d83065c0461428cf7a1c7bcbfb",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "826254d83065c0461428cf7a1c7bcbfb"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45227"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "efb5d489c01003958d3b3f84ef85bf49",
+        "byte_size": 1023,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "efb5d489c01003958d3b3f84ef85bf49"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46474"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4908d85ca4e3b0a0d5e354107329c93d",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4908d85ca4e3b0a0d5e354107329c93d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45396"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a13d5b27089b27005943abc68e90c2d5",
+        "byte_size": 142,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a13d5b27089b27005943abc68e90c2d5"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46302"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "800ebe464c7dc49deb06e557e0f29ea7",
+        "byte_size": 451182,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "800ebe464c7dc49deb06e557e0f29ea7"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45778"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8b7812f78a276e261df17d3b221a066a",
+        "byte_size": 1021,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8b7812f78a276e261df17d3b221a066a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45490"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "fea0858e750b27aa46e3c8a3b411f10f",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "fea0858e750b27aa46e3c8a3b411f10f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46130"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e011cc059bd77e9c19a5e38584eb5628",
+        "byte_size": 1021,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e011cc059bd77e9c19a5e38584eb5628"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45740"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "35fdfa50f2d36c0ac4d329e5012369ad",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "35fdfa50f2d36c0ac4d329e5012369ad"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45154"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6611683433437ac176de1c263a2f4ecc",
+        "byte_size": 1021,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6611683433437ac176de1c263a2f4ecc"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46541"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b3c11c643a12d6acb7dd626b963ad193",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b3c11c643a12d6acb7dd626b963ad193"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45277"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d66328032fd3fbc635bd564170bc8671",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d66328032fd3fbc635bd564170bc8671"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45451"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b7338170f7583bc97fbc2140052f28c2",
+        "byte_size": 455634,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b7338170f7583bc97fbc2140052f28c2"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45723"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "9d3c80f922108f4f4b0a509b48f19215",
+        "byte_size": 20736352,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "9d3c80f922108f4f4b0a509b48f19215"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46481"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-006/",
+        "qualified_part": [
+          {
+            "relation": "sub-006/anat/",
+            "name": "anat"
+          },
+          {
+            "relation": "sub-006/func/",
+            "name": "func"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-006/anat/",
+        "qualified_part": [
+          {
+            "relation": "9d3c80f922108f4f4b0a509b48f19215",
+            "name": "sub-006_T1w.nii"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "19d730e7f95456220e9a207e24aeb85c",
+        "byte_size": 1040,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "19d730e7f95456220e9a207e24aeb85c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46010"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-006/func/",
+        "qualified_part": [
+          {
+            "relation": "19d730e7f95456220e9a207e24aeb85c",
+            "name": "sub-006_task-emotionProcessing_echo-1_bold.json"
+          },
+          {
+            "relation": "790c9551fe64f5bf1505f57c08a41752",
+            "name": "sub-006_task-emotionProcessing_echo-1_bold.nii"
+          },
+          {
+            "relation": "27b0d9091824e35ec179f26bae10ac3b",
+            "name": "sub-006_task-emotionProcessing_echo-2_bold.json"
+          },
+          {
+            "relation": "133c94bb368ecdaea7f44b7516487173",
+            "name": "sub-006_task-emotionProcessing_echo-2_bold.nii"
+          },
+          {
+            "relation": "753ef08256365e77b156a2253826019b",
+            "name": "sub-006_task-emotionProcessing_echo-3_bold.json"
+          },
+          {
+            "relation": "2b0c6daf7d033cbd6aa50e33643e3a55",
+            "name": "sub-006_task-emotionProcessing_echo-3_bold.nii"
+          },
+          {
+            "relation": "cc467164073fc96d80c0acffd443393e",
+            "name": "sub-006_task-emotionProcessing_events.tsv.gz"
+          },
+          {
+            "relation": "7dd90f3e0b89cecf35ee80581c470b24",
+            "name": "sub-006_task-emotionProcessingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "6ffda225a2031c373c9d20043c2bc95c",
+            "name": "sub-006_task-emotionProcessingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "8c4c9cbdf880b4835108bcb06f12fc65",
+            "name": "sub-006_task-emotionProcessingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "d951cc8d496ef3ab6de4ef5aeb781a82",
+            "name": "sub-006_task-emotionProcessingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "00fd2c769d3635aaa5316175f80c1809",
+            "name": "sub-006_task-emotionProcessingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "11b60cd08709c18a081020f900068d20",
+            "name": "sub-006_task-emotionProcessingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "9b728f7556d453898be3d4af32fb1547",
+            "name": "sub-006_task-emotionProcessingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "75bd732c9458524aace0ea22711c60c5",
+            "name": "sub-006_task-emotionProcessingImagined_physio.json"
+          },
+          {
+            "relation": "6e10a0278d083ca6429de64a22b39171",
+            "name": "sub-006_task-emotionProcessingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "475357635c0286f20fbf29453815fb81",
+            "name": "sub-006_task-emotionProcessing_physio.json"
+          },
+          {
+            "relation": "ed554922d2b3f7f717bbc8284e4ea27b",
+            "name": "sub-006_task-emotionProcessing_physio.tsv.gz"
+          },
+          {
+            "relation": "dad55e717902bc97813aae0d69004b7d",
+            "name": "sub-006_task-fingerTapping_echo-1_bold.json"
+          },
+          {
+            "relation": "46a2ac4ea03adc8f2aa8139f49151177",
+            "name": "sub-006_task-fingerTapping_echo-1_bold.nii"
+          },
+          {
+            "relation": "bd248b0b225157cb9faa47f231b7687b",
+            "name": "sub-006_task-fingerTapping_echo-2_bold.json"
+          },
+          {
+            "relation": "e6f261aced80375d6485eb6a0591c46f",
+            "name": "sub-006_task-fingerTapping_echo-2_bold.nii"
+          },
+          {
+            "relation": "ffaea300a145bb2d8f41179f24f6095c",
+            "name": "sub-006_task-fingerTapping_echo-3_bold.json"
+          },
+          {
+            "relation": "1ee36d37a637953c423827d3593a68fe",
+            "name": "sub-006_task-fingerTapping_echo-3_bold.nii"
+          },
+          {
+            "relation": "97cda8e7a0ccb7735140f207f0fac941",
+            "name": "sub-006_task-fingerTapping_events.tsv.gz"
+          },
+          {
+            "relation": "838a300357bb8c8f7b7ef7b713e77505",
+            "name": "sub-006_task-fingerTappingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "25b554d3c728a1eaee9742af3ee2f04c",
+            "name": "sub-006_task-fingerTappingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "f790dcfe4fdfbbc880afb29c4ab97e2a",
+            "name": "sub-006_task-fingerTappingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "84e86baec637e4f1056ef8b4d9c43f8c",
+            "name": "sub-006_task-fingerTappingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "874c40b78895b1a4d0ef778e2d7e2f0e",
+            "name": "sub-006_task-fingerTappingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "0d0257625e969fdf73b3435f0b62b672",
+            "name": "sub-006_task-fingerTappingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "34513c7eb841d2d29b30d3afb9a6fb8a",
+            "name": "sub-006_task-fingerTappingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "a97a5b4ee2a2ceb39548b97747c5f4ef",
+            "name": "sub-006_task-fingerTappingImagined_physio.json"
+          },
+          {
+            "relation": "489ade52cee2ab077ab53960f14e8879",
+            "name": "sub-006_task-fingerTappingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "54e018529ba4432aa63cb13717f61cde",
+            "name": "sub-006_task-fingerTapping_physio.json"
+          },
+          {
+            "relation": "189a945abfc4f3585f040ace44a19f20",
+            "name": "sub-006_task-fingerTapping_physio.tsv.gz"
+          },
+          {
+            "relation": "669a562f9541700c11b9f570cf642776",
+            "name": "sub-006_task-rest_run-1_echo-1_bold.json"
+          },
+          {
+            "relation": "e34bca7c50a48aeb3bc133a4a3ad9609",
+            "name": "sub-006_task-rest_run-1_echo-1_bold.nii"
+          },
+          {
+            "relation": "abea61313a4f682180a67d01e9f537b2",
+            "name": "sub-006_task-rest_run-1_echo-2_bold.json"
+          },
+          {
+            "relation": "abd127f75e7f44c47c560a049d9d1859",
+            "name": "sub-006_task-rest_run-1_echo-2_bold.nii"
+          },
+          {
+            "relation": "bb93a09ac4d604d2c37428e24e271f97",
+            "name": "sub-006_task-rest_run-1_echo-3_bold.json"
+          },
+          {
+            "relation": "819a2c8cc4d45feed5fc8a6d9fe19f1d",
+            "name": "sub-006_task-rest_run-1_echo-3_bold.nii"
+          },
+          {
+            "relation": "8c28268a70a2208a8596249381e2d5b0",
+            "name": "sub-006_task-rest_run-1_physio.json"
+          },
+          {
+            "relation": "6ed25207a1fd7daeb1b0d92d8b1290c2",
+            "name": "sub-006_task-rest_run-1_physio.tsv.gz"
+          },
+          {
+            "relation": "a32ed609bc7ae23d5b0ea2d64e101f42",
+            "name": "sub-006_task-rest_run-2_echo-1_bold.json"
+          },
+          {
+            "relation": "e251adeba1d8f17ceadc117659d5f50c",
+            "name": "sub-006_task-rest_run-2_echo-1_bold.nii"
+          },
+          {
+            "relation": "32c38c5ea5a8a4944fbb7e58c389b06c",
+            "name": "sub-006_task-rest_run-2_echo-2_bold.json"
+          },
+          {
+            "relation": "a49a7475acc48e3a8c541d28de3ac89d",
+            "name": "sub-006_task-rest_run-2_echo-2_bold.nii"
+          },
+          {
+            "relation": "da5c5f6183f155557598ef18cafee90d",
+            "name": "sub-006_task-rest_run-2_echo-3_bold.json"
+          },
+          {
+            "relation": "ec8d899551a623c7cd5234b66578c893",
+            "name": "sub-006_task-rest_run-2_echo-3_bold.nii"
+          },
+          {
+            "relation": "8aa7cae04a66c8841494937ec2ca77ef",
+            "name": "sub-006_task-rest_run-2_physio.json"
+          },
+          {
+            "relation": "bef7ae13fdf5c01e6b16c281ec653db7",
+            "name": "sub-006_task-rest_run-2_physio.tsv.gz"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "790c9551fe64f5bf1505f57c08a41752",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "790c9551fe64f5bf1505f57c08a41752"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46107"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "27b0d9091824e35ec179f26bae10ac3b",
+        "byte_size": 1040,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "27b0d9091824e35ec179f26bae10ac3b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45488"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "133c94bb368ecdaea7f44b7516487173",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "133c94bb368ecdaea7f44b7516487173"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45208"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "753ef08256365e77b156a2253826019b",
+        "byte_size": 1040,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "753ef08256365e77b156a2253826019b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45213"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2b0c6daf7d033cbd6aa50e33643e3a55",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2b0c6daf7d033cbd6aa50e33643e3a55"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45810"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "cc467164073fc96d80c0acffd443393e",
+        "byte_size": 1939,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "cc467164073fc96d80c0acffd443393e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46577"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "7dd90f3e0b89cecf35ee80581c470b24",
+        "byte_size": 1048,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "7dd90f3e0b89cecf35ee80581c470b24"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45299"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6ffda225a2031c373c9d20043c2bc95c",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6ffda225a2031c373c9d20043c2bc95c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46377"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8c4c9cbdf880b4835108bcb06f12fc65",
+        "byte_size": 1048,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8c4c9cbdf880b4835108bcb06f12fc65"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46295"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d951cc8d496ef3ab6de4ef5aeb781a82",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d951cc8d496ef3ab6de4ef5aeb781a82"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45631"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "00fd2c769d3635aaa5316175f80c1809",
+        "byte_size": 1048,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "00fd2c769d3635aaa5316175f80c1809"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45139"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "11b60cd08709c18a081020f900068d20",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "11b60cd08709c18a081020f900068d20"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45308"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "9b728f7556d453898be3d4af32fb1547",
+        "byte_size": 177,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "9b728f7556d453898be3d4af32fb1547"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46587"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "75bd732c9458524aace0ea22711c60c5",
+        "byte_size": 142,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "75bd732c9458524aace0ea22711c60c5"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45205"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6e10a0278d083ca6429de64a22b39171",
+        "byte_size": 477953,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6e10a0278d083ca6429de64a22b39171"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46356"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "475357635c0286f20fbf29453815fb81",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "475357635c0286f20fbf29453815fb81"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45520"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ed554922d2b3f7f717bbc8284e4ea27b",
+        "byte_size": 487297,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ed554922d2b3f7f717bbc8284e4ea27b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45538"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "dad55e717902bc97813aae0d69004b7d",
+        "byte_size": 1035,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "dad55e717902bc97813aae0d69004b7d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46436"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "46a2ac4ea03adc8f2aa8139f49151177",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "46a2ac4ea03adc8f2aa8139f49151177"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46347"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "bd248b0b225157cb9faa47f231b7687b",
+        "byte_size": 1035,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "bd248b0b225157cb9faa47f231b7687b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46178"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e6f261aced80375d6485eb6a0591c46f",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e6f261aced80375d6485eb6a0591c46f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46006"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ffaea300a145bb2d8f41179f24f6095c",
+        "byte_size": 1035,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ffaea300a145bb2d8f41179f24f6095c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46417"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1ee36d37a637953c423827d3593a68fe",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1ee36d37a637953c423827d3593a68fe"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46390"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "97cda8e7a0ccb7735140f207f0fac941",
+        "byte_size": 164,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "97cda8e7a0ccb7735140f207f0fac941"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46580"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "838a300357bb8c8f7b7ef7b713e77505",
+        "byte_size": 1043,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "838a300357bb8c8f7b7ef7b713e77505"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45738"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "25b554d3c728a1eaee9742af3ee2f04c",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "25b554d3c728a1eaee9742af3ee2f04c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45666"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f790dcfe4fdfbbc880afb29c4ab97e2a",
+        "byte_size": 1043,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f790dcfe4fdfbbc880afb29c4ab97e2a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46141"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "84e86baec637e4f1056ef8b4d9c43f8c",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "84e86baec637e4f1056ef8b4d9c43f8c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45841"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "874c40b78895b1a4d0ef778e2d7e2f0e",
+        "byte_size": 1043,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "874c40b78895b1a4d0ef778e2d7e2f0e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46095"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "0d0257625e969fdf73b3435f0b62b672",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "0d0257625e969fdf73b3435f0b62b672"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46487"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "34513c7eb841d2d29b30d3afb9a6fb8a",
+        "byte_size": 178,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "34513c7eb841d2d29b30d3afb9a6fb8a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46574"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a97a5b4ee2a2ceb39548b97747c5f4ef",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a97a5b4ee2a2ceb39548b97747c5f4ef"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45852"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "489ade52cee2ab077ab53960f14e8879",
+        "byte_size": 495320,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "489ade52cee2ab077ab53960f14e8879"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46002"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "54e018529ba4432aa63cb13717f61cde",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "54e018529ba4432aa63cb13717f61cde"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46461"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "189a945abfc4f3585f040ace44a19f20",
+        "byte_size": 481816,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "189a945abfc4f3585f040ace44a19f20"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45167"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "669a562f9541700c11b9f570cf642776",
+        "byte_size": 1027,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "669a562f9541700c11b9f570cf642776"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45354"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e34bca7c50a48aeb3bc133a4a3ad9609",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e34bca7c50a48aeb3bc133a4a3ad9609"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46453"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "abea61313a4f682180a67d01e9f537b2",
+        "byte_size": 1027,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "abea61313a4f682180a67d01e9f537b2"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45498"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "abd127f75e7f44c47c560a049d9d1859",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "abd127f75e7f44c47c560a049d9d1859"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46051"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "bb93a09ac4d604d2c37428e24e271f97",
+        "byte_size": 1027,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "bb93a09ac4d604d2c37428e24e271f97"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45138"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "819a2c8cc4d45feed5fc8a6d9fe19f1d",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "819a2c8cc4d45feed5fc8a6d9fe19f1d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46244"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8c28268a70a2208a8596249381e2d5b0",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8c28268a70a2208a8596249381e2d5b0"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45983"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6ed25207a1fd7daeb1b0d92d8b1290c2",
+        "byte_size": 470282,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6ed25207a1fd7daeb1b0d92d8b1290c2"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45594"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a32ed609bc7ae23d5b0ea2d64e101f42",
+        "byte_size": 1027,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a32ed609bc7ae23d5b0ea2d64e101f42"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45430"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e251adeba1d8f17ceadc117659d5f50c",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e251adeba1d8f17ceadc117659d5f50c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45200"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "32c38c5ea5a8a4944fbb7e58c389b06c",
+        "byte_size": 1027,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "32c38c5ea5a8a4944fbb7e58c389b06c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46516"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a49a7475acc48e3a8c541d28de3ac89d",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a49a7475acc48e3a8c541d28de3ac89d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46176"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "da5c5f6183f155557598ef18cafee90d",
+        "byte_size": 1027,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "da5c5f6183f155557598ef18cafee90d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46515"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ec8d899551a623c7cd5234b66578c893",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ec8d899551a623c7cd5234b66578c893"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46266"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8aa7cae04a66c8841494937ec2ca77ef",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8aa7cae04a66c8841494937ec2ca77ef"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46341"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "bef7ae13fdf5c01e6b16c281ec653db7",
+        "byte_size": 476201,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "bef7ae13fdf5c01e6b16c281ec653db7"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45286"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "fbc1e0cadc88e77c902c3957d3697ff8",
+        "byte_size": 20736352,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "fbc1e0cadc88e77c902c3957d3697ff8"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45827"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-007/",
+        "qualified_part": [
+          {
+            "relation": "sub-007/anat/",
+            "name": "anat"
+          },
+          {
+            "relation": "sub-007/func/",
+            "name": "func"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-007/anat/",
+        "qualified_part": [
+          {
+            "relation": "fbc1e0cadc88e77c902c3957d3697ff8",
+            "name": "sub-007_T1w.nii"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "546bfbdc9eb9e8d4fdd72f7f2a2855bc",
+        "byte_size": 1043,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "546bfbdc9eb9e8d4fdd72f7f2a2855bc"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45251"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-007/func/",
+        "qualified_part": [
+          {
+            "relation": "546bfbdc9eb9e8d4fdd72f7f2a2855bc",
+            "name": "sub-007_task-emotionProcessing_echo-1_bold.json"
+          },
+          {
+            "relation": "ff85dbedbb45279bb3f3fdd7c23012e7",
+            "name": "sub-007_task-emotionProcessing_echo-1_bold.nii"
+          },
+          {
+            "relation": "f6745fa00ca7d991f6a1028d7dc587bf",
+            "name": "sub-007_task-emotionProcessing_echo-2_bold.json"
+          },
+          {
+            "relation": "cf7167081c0ae6e886080eea50e45e5f",
+            "name": "sub-007_task-emotionProcessing_echo-2_bold.nii"
+          },
+          {
+            "relation": "01560fd90928f842b4fece30ecccef6f",
+            "name": "sub-007_task-emotionProcessing_echo-3_bold.json"
+          },
+          {
+            "relation": "8784a8244173581831f8c154b94f8077",
+            "name": "sub-007_task-emotionProcessing_echo-3_bold.nii"
+          },
+          {
+            "relation": "9f87561b465acf40c79a9c2d3a8319b6",
+            "name": "sub-007_task-emotionProcessing_events.tsv.gz"
+          },
+          {
+            "relation": "7011c67d20cfdfe41797613299b4ad0f",
+            "name": "sub-007_task-emotionProcessingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "9c1f6a85f118a8c1b511be62b57b3789",
+            "name": "sub-007_task-emotionProcessingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "181e1d723e5107c1bf52f314403ce2f7",
+            "name": "sub-007_task-emotionProcessingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "1d7028d89cdde68515286a63ebc47ae7",
+            "name": "sub-007_task-emotionProcessingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "f94a966d01fbb37b3804b43233b09228",
+            "name": "sub-007_task-emotionProcessingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "c9af8f55d26f56477b0b42d647c75538",
+            "name": "sub-007_task-emotionProcessingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "a14595a04fa570203ff5a200bf6b4f42",
+            "name": "sub-007_task-emotionProcessingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "2bd463332c59abb455e544e5b926b075",
+            "name": "sub-007_task-emotionProcessingImagined_physio.json"
+          },
+          {
+            "relation": "8d61be093569285fe4d0ccba7b8d4066",
+            "name": "sub-007_task-emotionProcessingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "ebd4c5024fc2c63829cd66705135c047",
+            "name": "sub-007_task-emotionProcessing_physio.json"
+          },
+          {
+            "relation": "b4e5d718da2c84444e15c191d680f756",
+            "name": "sub-007_task-emotionProcessing_physio.tsv.gz"
+          },
+          {
+            "relation": "b8aa0235d1518b988e3a07f658738226",
+            "name": "sub-007_task-fingerTapping_echo-1_bold.json"
+          },
+          {
+            "relation": "19292eaa783f4d0598a87cd1ca7b0563",
+            "name": "sub-007_task-fingerTapping_echo-1_bold.nii"
+          },
+          {
+            "relation": "361961f4bc30ec4eaa1bfe9a36e270dc",
+            "name": "sub-007_task-fingerTapping_echo-2_bold.json"
+          },
+          {
+            "relation": "472188cbd9b951f8ccca6f236151395b",
+            "name": "sub-007_task-fingerTapping_echo-2_bold.nii"
+          },
+          {
+            "relation": "33a478f431f41fd183c58c138c6b57a9",
+            "name": "sub-007_task-fingerTapping_echo-3_bold.json"
+          },
+          {
+            "relation": "522e173aa201ab2270c7adb597c97105",
+            "name": "sub-007_task-fingerTapping_echo-3_bold.nii"
+          },
+          {
+            "relation": "80f803f4d5795a7ac16a0fece568730d",
+            "name": "sub-007_task-fingerTapping_events.tsv.gz"
+          },
+          {
+            "relation": "1da6abda2407618e0df5c408f656f030",
+            "name": "sub-007_task-fingerTappingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "6782618324fef13f1889ab44b53774ec",
+            "name": "sub-007_task-fingerTappingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "bef00992f80fbca5c89dec95e7e29962",
+            "name": "sub-007_task-fingerTappingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "d16a3909c93e1b5fabe5fcb0d94a124b",
+            "name": "sub-007_task-fingerTappingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "8469140ce87ef9f4060a88bbed4439be",
+            "name": "sub-007_task-fingerTappingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "b08e9141daca5df31278b472b2080608",
+            "name": "sub-007_task-fingerTappingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "9046a531aa50523795d30ead98aa3efa",
+            "name": "sub-007_task-fingerTappingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "f90f2c7f8d0d8658759199e1bce75aa5",
+            "name": "sub-007_task-fingerTappingImagined_physio.json"
+          },
+          {
+            "relation": "df7af70a068b02d5093813ef3e034ef9",
+            "name": "sub-007_task-fingerTappingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "20a6d9fec97d01da69ff7b1063e151d8",
+            "name": "sub-007_task-fingerTapping_physio.json"
+          },
+          {
+            "relation": "d74a7e3e51b82463356492dded1fd888",
+            "name": "sub-007_task-fingerTapping_physio.tsv.gz"
+          },
+          {
+            "relation": "4959a08e00f5f4648e2d61f408cc0b38",
+            "name": "sub-007_task-rest_run-1_echo-1_bold.json"
+          },
+          {
+            "relation": "7e6e883dcd5dcb54cbbc00404009989a",
+            "name": "sub-007_task-rest_run-1_echo-1_bold.nii"
+          },
+          {
+            "relation": "034b7fa7cf9975f5bf5acab99af751c5",
+            "name": "sub-007_task-rest_run-1_echo-2_bold.json"
+          },
+          {
+            "relation": "1109e59c036b13ed6f9d40aa275e650f",
+            "name": "sub-007_task-rest_run-1_echo-2_bold.nii"
+          },
+          {
+            "relation": "901312b94dcad0754bfa7c01b96ace98",
+            "name": "sub-007_task-rest_run-1_echo-3_bold.json"
+          },
+          {
+            "relation": "b75defef6758d046883ac46f7fe718f6",
+            "name": "sub-007_task-rest_run-1_echo-3_bold.nii"
+          },
+          {
+            "relation": "2c05d7ffba904b20acf7f8d798e56f1a",
+            "name": "sub-007_task-rest_run-1_physio.json"
+          },
+          {
+            "relation": "26bdaee0f8531fba3f072d0de0dafdff",
+            "name": "sub-007_task-rest_run-1_physio.tsv.gz"
+          },
+          {
+            "relation": "f870b8885b5f5777c880004242ada96c",
+            "name": "sub-007_task-rest_run-2_echo-1_bold.json"
+          },
+          {
+            "relation": "135abe8207577cc86e46e70c541a095e",
+            "name": "sub-007_task-rest_run-2_echo-1_bold.nii"
+          },
+          {
+            "relation": "0cea8aabf50a08cf40064469989c7a24",
+            "name": "sub-007_task-rest_run-2_echo-2_bold.json"
+          },
+          {
+            "relation": "62b37f39c8e730772e07d76cd7f883ff",
+            "name": "sub-007_task-rest_run-2_echo-2_bold.nii"
+          },
+          {
+            "relation": "2528930ba2cb1ee93762bbf4d2b6cf88",
+            "name": "sub-007_task-rest_run-2_echo-3_bold.json"
+          },
+          {
+            "relation": "92cbee685bec54eea7b58fab9cfa87be",
+            "name": "sub-007_task-rest_run-2_echo-3_bold.nii"
+          },
+          {
+            "relation": "e2b861e80af7998037002ea748928567",
+            "name": "sub-007_task-rest_run-2_physio.json"
+          },
+          {
+            "relation": "55a951fd7252a67fad44cf4a2d4d2c36",
+            "name": "sub-007_task-rest_run-2_physio.tsv.gz"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ff85dbedbb45279bb3f3fdd7c23012e7",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ff85dbedbb45279bb3f3fdd7c23012e7"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46209"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f6745fa00ca7d991f6a1028d7dc587bf",
+        "byte_size": 1043,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f6745fa00ca7d991f6a1028d7dc587bf"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45212"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "cf7167081c0ae6e886080eea50e45e5f",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "cf7167081c0ae6e886080eea50e45e5f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45779"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "01560fd90928f842b4fece30ecccef6f",
+        "byte_size": 1043,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "01560fd90928f842b4fece30ecccef6f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45881"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8784a8244173581831f8c154b94f8077",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8784a8244173581831f8c154b94f8077"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45562"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "9f87561b465acf40c79a9c2d3a8319b6",
+        "byte_size": 1901,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "9f87561b465acf40c79a9c2d3a8319b6"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46554"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "7011c67d20cfdfe41797613299b4ad0f",
+        "byte_size": 1051,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "7011c67d20cfdfe41797613299b4ad0f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46454"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "9c1f6a85f118a8c1b511be62b57b3789",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "9c1f6a85f118a8c1b511be62b57b3789"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45274"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "181e1d723e5107c1bf52f314403ce2f7",
+        "byte_size": 1051,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "181e1d723e5107c1bf52f314403ce2f7"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45283"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1d7028d89cdde68515286a63ebc47ae7",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1d7028d89cdde68515286a63ebc47ae7"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45331"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f94a966d01fbb37b3804b43233b09228",
+        "byte_size": 1051,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f94a966d01fbb37b3804b43233b09228"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45146"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c9af8f55d26f56477b0b42d647c75538",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c9af8f55d26f56477b0b42d647c75538"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46044"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a14595a04fa570203ff5a200bf6b4f42",
+        "byte_size": 173,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a14595a04fa570203ff5a200bf6b4f42"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46645"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2bd463332c59abb455e544e5b926b075",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2bd463332c59abb455e544e5b926b075"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45873"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8d61be093569285fe4d0ccba7b8d4066",
+        "byte_size": 505783,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8d61be093569285fe4d0ccba7b8d4066"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45284"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ebd4c5024fc2c63829cd66705135c047",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ebd4c5024fc2c63829cd66705135c047"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46005"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b4e5d718da2c84444e15c191d680f756",
+        "byte_size": 465952,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b4e5d718da2c84444e15c191d680f756"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46050"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b8aa0235d1518b988e3a07f658738226",
+        "byte_size": 1039,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b8aa0235d1518b988e3a07f658738226"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46245"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "19292eaa783f4d0598a87cd1ca7b0563",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "19292eaa783f4d0598a87cd1ca7b0563"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46007"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "361961f4bc30ec4eaa1bfe9a36e270dc",
+        "byte_size": 1039,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "361961f4bc30ec4eaa1bfe9a36e270dc"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45116"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "472188cbd9b951f8ccca6f236151395b",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "472188cbd9b951f8ccca6f236151395b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45232"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "33a478f431f41fd183c58c138c6b57a9",
+        "byte_size": 1039,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "33a478f431f41fd183c58c138c6b57a9"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45585"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "522e173aa201ab2270c7adb597c97105",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "522e173aa201ab2270c7adb597c97105"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45476"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "80f803f4d5795a7ac16a0fece568730d",
+        "byte_size": 162,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "80f803f4d5795a7ac16a0fece568730d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46582"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1da6abda2407618e0df5c408f656f030",
+        "byte_size": 1047,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1da6abda2407618e0df5c408f656f030"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45524"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6782618324fef13f1889ab44b53774ec",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6782618324fef13f1889ab44b53774ec"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46297"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "bef00992f80fbca5c89dec95e7e29962",
+        "byte_size": 1047,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "bef00992f80fbca5c89dec95e7e29962"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45570"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d16a3909c93e1b5fabe5fcb0d94a124b",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d16a3909c93e1b5fabe5fcb0d94a124b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45867"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8469140ce87ef9f4060a88bbed4439be",
+        "byte_size": 1047,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8469140ce87ef9f4060a88bbed4439be"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45878"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b08e9141daca5df31278b472b2080608",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b08e9141daca5df31278b472b2080608"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46304"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "9046a531aa50523795d30ead98aa3efa",
+        "byte_size": 175,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "9046a531aa50523795d30ead98aa3efa"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46589"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f90f2c7f8d0d8658759199e1bce75aa5",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f90f2c7f8d0d8658759199e1bce75aa5"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46396"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "df7af70a068b02d5093813ef3e034ef9",
+        "byte_size": 460170,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "df7af70a068b02d5093813ef3e034ef9"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45539"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "20a6d9fec97d01da69ff7b1063e151d8",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "20a6d9fec97d01da69ff7b1063e151d8"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45627"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d74a7e3e51b82463356492dded1fd888",
+        "byte_size": 479042,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d74a7e3e51b82463356492dded1fd888"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45438"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4959a08e00f5f4648e2d61f408cc0b38",
+        "byte_size": 1030,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4959a08e00f5f4648e2d61f408cc0b38"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45887"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "7e6e883dcd5dcb54cbbc00404009989a",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "7e6e883dcd5dcb54cbbc00404009989a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46413"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "034b7fa7cf9975f5bf5acab99af751c5",
+        "byte_size": 1030,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "034b7fa7cf9975f5bf5acab99af751c5"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45389"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1109e59c036b13ed6f9d40aa275e650f",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1109e59c036b13ed6f9d40aa275e650f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45942"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "901312b94dcad0754bfa7c01b96ace98",
+        "byte_size": 1030,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "901312b94dcad0754bfa7c01b96ace98"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45800"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b75defef6758d046883ac46f7fe718f6",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b75defef6758d046883ac46f7fe718f6"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46497"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2c05d7ffba904b20acf7f8d798e56f1a",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2c05d7ffba904b20acf7f8d798e56f1a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46142"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "26bdaee0f8531fba3f072d0de0dafdff",
+        "byte_size": 453559,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "26bdaee0f8531fba3f072d0de0dafdff"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46008"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f870b8885b5f5777c880004242ada96c",
+        "byte_size": 1030,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f870b8885b5f5777c880004242ada96c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45163"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "135abe8207577cc86e46e70c541a095e",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "135abe8207577cc86e46e70c541a095e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45674"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "0cea8aabf50a08cf40064469989c7a24",
+        "byte_size": 1030,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "0cea8aabf50a08cf40064469989c7a24"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45832"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "62b37f39c8e730772e07d76cd7f883ff",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "62b37f39c8e730772e07d76cd7f883ff"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46317"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2528930ba2cb1ee93762bbf4d2b6cf88",
+        "byte_size": 1030,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2528930ba2cb1ee93762bbf4d2b6cf88"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46537"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "92cbee685bec54eea7b58fab9cfa87be",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "92cbee685bec54eea7b58fab9cfa87be"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45668"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e2b861e80af7998037002ea748928567",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e2b861e80af7998037002ea748928567"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46230"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "55a951fd7252a67fad44cf4a2d4d2c36",
+        "byte_size": 444758,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "55a951fd7252a67fad44cf4a2d4d2c36"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46184"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b3077aed8b42c7b913990adb014c3048",
+        "byte_size": 20736352,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b3077aed8b42c7b913990adb014c3048"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46471"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-010/",
+        "qualified_part": [
+          {
+            "relation": "sub-010/anat/",
+            "name": "anat"
+          },
+          {
+            "relation": "sub-010/func/",
+            "name": "func"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-010/anat/",
+        "qualified_part": [
+          {
+            "relation": "b3077aed8b42c7b913990adb014c3048",
+            "name": "sub-010_T1w.nii"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d7902ae5755e22be8fa2d6b8d0884caa",
+        "byte_size": 1042,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d7902ae5755e22be8fa2d6b8d0884caa"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45248"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-010/func/",
+        "qualified_part": [
+          {
+            "relation": "d7902ae5755e22be8fa2d6b8d0884caa",
+            "name": "sub-010_task-emotionProcessing_echo-1_bold.json"
+          },
+          {
+            "relation": "3d565ac576fdae0bccaf91a945b4e6e0",
+            "name": "sub-010_task-emotionProcessing_echo-1_bold.nii"
+          },
+          {
+            "relation": "2737d5e2127911240a0668c1ee439f71",
+            "name": "sub-010_task-emotionProcessing_echo-2_bold.json"
+          },
+          {
+            "relation": "35c37986da86c0212ff6293e50bba0dc",
+            "name": "sub-010_task-emotionProcessing_echo-2_bold.nii"
+          },
+          {
+            "relation": "32066bc8ff38a2d996177efeeacece1a",
+            "name": "sub-010_task-emotionProcessing_echo-3_bold.json"
+          },
+          {
+            "relation": "304fc0316cd8bdc94d86c0cdf0fffc6d",
+            "name": "sub-010_task-emotionProcessing_echo-3_bold.nii"
+          },
+          {
+            "relation": "b9b914b29a4a98a38f3687d506ff1382",
+            "name": "sub-010_task-emotionProcessing_events.tsv.gz"
+          },
+          {
+            "relation": "7e2ebc1a862896ec2c579d602c90ecf4",
+            "name": "sub-010_task-emotionProcessingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "92fc1ca8f032ad7ad4cf6a38d5bd83b6",
+            "name": "sub-010_task-emotionProcessingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "ed835fe6ac5c46db6a78becb00b9a6b3",
+            "name": "sub-010_task-emotionProcessingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "6a1cb1c4be9e0bc6372c50abf0e475ff",
+            "name": "sub-010_task-emotionProcessingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "f25f858d4fb92f3782ed330a8246988a",
+            "name": "sub-010_task-emotionProcessingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "834e21e666bf2b6fd0a9d91da6496033",
+            "name": "sub-010_task-emotionProcessingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "90fe04ee120c67a7736e7d57e494b3a7",
+            "name": "sub-010_task-emotionProcessingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "4c0258f56ab2d5b9c849a907fbe99370",
+            "name": "sub-010_task-emotionProcessingImagined_physio.json"
+          },
+          {
+            "relation": "d8a6822cee54e4f25fa51962ac919f16",
+            "name": "sub-010_task-emotionProcessingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "1b303daf14c578e9af688ffe870d007e",
+            "name": "sub-010_task-emotionProcessing_physio.json"
+          },
+          {
+            "relation": "719ea8f9d5b8da93a26e672b28903983",
+            "name": "sub-010_task-emotionProcessing_physio.tsv.gz"
+          },
+          {
+            "relation": "41f79f2307ebac763f7a4130024a1ad5",
+            "name": "sub-010_task-fingerTapping_echo-1_bold.json"
+          },
+          {
+            "relation": "85bfb3b996a3e363341e71a3cd9fae42",
+            "name": "sub-010_task-fingerTapping_echo-1_bold.nii"
+          },
+          {
+            "relation": "3b54a011c9dc6999fa71ed00da1c7b02",
+            "name": "sub-010_task-fingerTapping_echo-2_bold.json"
+          },
+          {
+            "relation": "b48377a889536602e998ee678696daec",
+            "name": "sub-010_task-fingerTapping_echo-2_bold.nii"
+          },
+          {
+            "relation": "925a84e91f2ba11ea6d7e1bfa6ea32aa",
+            "name": "sub-010_task-fingerTapping_echo-3_bold.json"
+          },
+          {
+            "relation": "7b6a9bbaf03466614419c88ead447c63",
+            "name": "sub-010_task-fingerTapping_echo-3_bold.nii"
+          },
+          {
+            "relation": "13eecaf8e5d96e416ecc8d9f9d741dbb",
+            "name": "sub-010_task-fingerTapping_events.tsv.gz"
+          },
+          {
+            "relation": "0c664901323404e22f267dcb240647d8",
+            "name": "sub-010_task-fingerTappingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "ce3af5c2a3f18df9ee255e0752dee7d0",
+            "name": "sub-010_task-fingerTappingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "74af5cbb23fe19b5e0b77b6c1cf400b8",
+            "name": "sub-010_task-fingerTappingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "3c40888bc656e6497dcb1bcdd0576f44",
+            "name": "sub-010_task-fingerTappingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "dc2b090512113f82d5606d3adc06f616",
+            "name": "sub-010_task-fingerTappingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "af351919e3f9eb6b8ae1b6648f4ed9c4",
+            "name": "sub-010_task-fingerTappingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "d32cce9233e1ec88d65e121fe1d46bf5",
+            "name": "sub-010_task-fingerTappingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "40496512d9d271d8d4777a5ba8a45020",
+            "name": "sub-010_task-fingerTappingImagined_physio.json"
+          },
+          {
+            "relation": "b7ddc4eab27aea3d811b52302b447c3d",
+            "name": "sub-010_task-fingerTappingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "01f363feb27b24b1d987ceebff33c223",
+            "name": "sub-010_task-fingerTapping_physio.json"
+          },
+          {
+            "relation": "d93c77119a2e47f583488fe26339e20a",
+            "name": "sub-010_task-fingerTapping_physio.tsv.gz"
+          },
+          {
+            "relation": "8b40a3a3357d881c508208473509c5f3",
+            "name": "sub-010_task-rest_run-1_echo-1_bold.json"
+          },
+          {
+            "relation": "782e1f1a21fa2241d559e7c3283ffa39",
+            "name": "sub-010_task-rest_run-1_echo-1_bold.nii"
+          },
+          {
+            "relation": "10fa6a7d96f3792f52e375350918ee86",
+            "name": "sub-010_task-rest_run-1_echo-2_bold.json"
+          },
+          {
+            "relation": "fa62a534801a97ae30eb84c3394e7dcd",
+            "name": "sub-010_task-rest_run-1_echo-2_bold.nii"
+          },
+          {
+            "relation": "763295aba2ac0ba5bf10fea22c41f404",
+            "name": "sub-010_task-rest_run-1_echo-3_bold.json"
+          },
+          {
+            "relation": "663fb57530eef754952991dec16af2b3",
+            "name": "sub-010_task-rest_run-1_echo-3_bold.nii"
+          },
+          {
+            "relation": "b3c24aa9b3f9b5e8addebc27680ca61c",
+            "name": "sub-010_task-rest_run-1_physio.json"
+          },
+          {
+            "relation": "517b4d76691685dd772eeaf35023c8a5",
+            "name": "sub-010_task-rest_run-1_physio.tsv.gz"
+          },
+          {
+            "relation": "849ddca842961f33bd2a508b4b66243e",
+            "name": "sub-010_task-rest_run-2_echo-1_bold.json"
+          },
+          {
+            "relation": "b772fa7627a2c78cbf6bbc7aa8e15fc5",
+            "name": "sub-010_task-rest_run-2_echo-1_bold.nii"
+          },
+          {
+            "relation": "e181c7d8e19289a06d9d934cbec46373",
+            "name": "sub-010_task-rest_run-2_echo-2_bold.json"
+          },
+          {
+            "relation": "061f466079bc706ddb09c4dc7f1f7ec8",
+            "name": "sub-010_task-rest_run-2_echo-2_bold.nii"
+          },
+          {
+            "relation": "da466649c5100e5c28b525ef4bbed378",
+            "name": "sub-010_task-rest_run-2_echo-3_bold.json"
+          },
+          {
+            "relation": "2ad6ec828be8d507d6a9f96050cb024d",
+            "name": "sub-010_task-rest_run-2_echo-3_bold.nii"
+          },
+          {
+            "relation": "cd63bc3de6119017f97434fcefd06cd6",
+            "name": "sub-010_task-rest_run-2_physio.json"
+          },
+          {
+            "relation": "1763774e3b11a68c20653f60dbbfc9ea",
+            "name": "sub-010_task-rest_run-2_physio.tsv.gz"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "3d565ac576fdae0bccaf91a945b4e6e0",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "3d565ac576fdae0bccaf91a945b4e6e0"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46438"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2737d5e2127911240a0668c1ee439f71",
+        "byte_size": 1042,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2737d5e2127911240a0668c1ee439f71"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45984"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "35c37986da86c0212ff6293e50bba0dc",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "35c37986da86c0212ff6293e50bba0dc"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46338"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "32066bc8ff38a2d996177efeeacece1a",
+        "byte_size": 1042,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "32066bc8ff38a2d996177efeeacece1a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46136"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "304fc0316cd8bdc94d86c0cdf0fffc6d",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "304fc0316cd8bdc94d86c0cdf0fffc6d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45448"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b9b914b29a4a98a38f3687d506ff1382",
+        "byte_size": 1918,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b9b914b29a4a98a38f3687d506ff1382"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46656"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "7e2ebc1a862896ec2c579d602c90ecf4",
+        "byte_size": 1050,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "7e2ebc1a862896ec2c579d602c90ecf4"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46539"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "92fc1ca8f032ad7ad4cf6a38d5bd83b6",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "92fc1ca8f032ad7ad4cf6a38d5bd83b6"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45431"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ed835fe6ac5c46db6a78becb00b9a6b3",
+        "byte_size": 1050,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ed835fe6ac5c46db6a78becb00b9a6b3"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46088"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6a1cb1c4be9e0bc6372c50abf0e475ff",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6a1cb1c4be9e0bc6372c50abf0e475ff"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45216"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f25f858d4fb92f3782ed330a8246988a",
+        "byte_size": 1050,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f25f858d4fb92f3782ed330a8246988a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46156"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "834e21e666bf2b6fd0a9d91da6496033",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "834e21e666bf2b6fd0a9d91da6496033"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46397"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "90fe04ee120c67a7736e7d57e494b3a7",
+        "byte_size": 178,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "90fe04ee120c67a7736e7d57e494b3a7"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46631"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4c0258f56ab2d5b9c849a907fbe99370",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4c0258f56ab2d5b9c849a907fbe99370"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46301"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d8a6822cee54e4f25fa51962ac919f16",
+        "byte_size": 608637,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d8a6822cee54e4f25fa51962ac919f16"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45161"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1b303daf14c578e9af688ffe870d007e",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1b303daf14c578e9af688ffe870d007e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46087"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "719ea8f9d5b8da93a26e672b28903983",
+        "byte_size": 474961,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "719ea8f9d5b8da93a26e672b28903983"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46415"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "41f79f2307ebac763f7a4130024a1ad5",
+        "byte_size": 1038,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "41f79f2307ebac763f7a4130024a1ad5"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46267"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "85bfb3b996a3e363341e71a3cd9fae42",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "85bfb3b996a3e363341e71a3cd9fae42"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45855"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "3b54a011c9dc6999fa71ed00da1c7b02",
+        "byte_size": 1038,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "3b54a011c9dc6999fa71ed00da1c7b02"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46181"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b48377a889536602e998ee678696daec",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b48377a889536602e998ee678696daec"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45719"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "925a84e91f2ba11ea6d7e1bfa6ea32aa",
+        "byte_size": 1038,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "925a84e91f2ba11ea6d7e1bfa6ea32aa"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45862"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "7b6a9bbaf03466614419c88ead447c63",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "7b6a9bbaf03466614419c88ead447c63"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45928"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "13eecaf8e5d96e416ecc8d9f9d741dbb",
+        "byte_size": 162,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "13eecaf8e5d96e416ecc8d9f9d741dbb"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46623"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "0c664901323404e22f267dcb240647d8",
+        "byte_size": 1045,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "0c664901323404e22f267dcb240647d8"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46081"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ce3af5c2a3f18df9ee255e0752dee7d0",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ce3af5c2a3f18df9ee255e0752dee7d0"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46476"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "74af5cbb23fe19b5e0b77b6c1cf400b8",
+        "byte_size": 1045,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "74af5cbb23fe19b5e0b77b6c1cf400b8"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45825"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "3c40888bc656e6497dcb1bcdd0576f44",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "3c40888bc656e6497dcb1bcdd0576f44"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45869"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "dc2b090512113f82d5606d3adc06f616",
+        "byte_size": 1045,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "dc2b090512113f82d5606d3adc06f616"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46494"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "af351919e3f9eb6b8ae1b6648f4ed9c4",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "af351919e3f9eb6b8ae1b6648f4ed9c4"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45986"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d32cce9233e1ec88d65e121fe1d46bf5",
+        "byte_size": 178,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d32cce9233e1ec88d65e121fe1d46bf5"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46640"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "40496512d9d271d8d4777a5ba8a45020",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "40496512d9d271d8d4777a5ba8a45020"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45305"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b7ddc4eab27aea3d811b52302b447c3d",
+        "byte_size": 502922,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b7ddc4eab27aea3d811b52302b447c3d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45956"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "01f363feb27b24b1d987ceebff33c223",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "01f363feb27b24b1d987ceebff33c223"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46215"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d93c77119a2e47f583488fe26339e20a",
+        "byte_size": 524308,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d93c77119a2e47f583488fe26339e20a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45185"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8b40a3a3357d881c508208473509c5f3",
+        "byte_size": 1027,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8b40a3a3357d881c508208473509c5f3"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45098"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "782e1f1a21fa2241d559e7c3283ffa39",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "782e1f1a21fa2241d559e7c3283ffa39"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45598"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "10fa6a7d96f3792f52e375350918ee86",
+        "byte_size": 1027,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "10fa6a7d96f3792f52e375350918ee86"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45530"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "fa62a534801a97ae30eb84c3394e7dcd",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "fa62a534801a97ae30eb84c3394e7dcd"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45995"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "763295aba2ac0ba5bf10fea22c41f404",
+        "byte_size": 1027,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "763295aba2ac0ba5bf10fea22c41f404"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46056"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "663fb57530eef754952991dec16af2b3",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "663fb57530eef754952991dec16af2b3"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46284"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b3c24aa9b3f9b5e8addebc27680ca61c",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b3c24aa9b3f9b5e8addebc27680ca61c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46158"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "517b4d76691685dd772eeaf35023c8a5",
+        "byte_size": 461533,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "517b4d76691685dd772eeaf35023c8a5"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45177"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "849ddca842961f33bd2a508b4b66243e",
+        "byte_size": 1027,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "849ddca842961f33bd2a508b4b66243e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45118"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b772fa7627a2c78cbf6bbc7aa8e15fc5",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b772fa7627a2c78cbf6bbc7aa8e15fc5"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45387"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e181c7d8e19289a06d9d934cbec46373",
+        "byte_size": 1027,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e181c7d8e19289a06d9d934cbec46373"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46001"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "061f466079bc706ddb09c4dc7f1f7ec8",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "061f466079bc706ddb09c4dc7f1f7ec8"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46398"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "da466649c5100e5c28b525ef4bbed378",
+        "byte_size": 1027,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "da466649c5100e5c28b525ef4bbed378"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45689"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2ad6ec828be8d507d6a9f96050cb024d",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2ad6ec828be8d507d6a9f96050cb024d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45404"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "cd63bc3de6119017f97434fcefd06cd6",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "cd63bc3de6119017f97434fcefd06cd6"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45527"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1763774e3b11a68c20653f60dbbfc9ea",
+        "byte_size": 469789,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1763774e3b11a68c20653f60dbbfc9ea"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45509"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d79a9ccb0fb162198b466b5fdd3eb48a",
+        "byte_size": 20736352,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d79a9ccb0fb162198b466b5fdd3eb48a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45153"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-011/",
+        "qualified_part": [
+          {
+            "relation": "sub-011/anat/",
+            "name": "anat"
+          },
+          {
+            "relation": "sub-011/func/",
+            "name": "func"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-011/anat/",
+        "qualified_part": [
+          {
+            "relation": "d79a9ccb0fb162198b466b5fdd3eb48a",
+            "name": "sub-011_T1w.nii"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b1ee64a3d382b49939d138dd4f44449a",
+        "byte_size": 1039,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b1ee64a3d382b49939d138dd4f44449a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46084"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-011/func/",
+        "qualified_part": [
+          {
+            "relation": "b1ee64a3d382b49939d138dd4f44449a",
+            "name": "sub-011_task-emotionProcessing_echo-1_bold.json"
+          },
+          {
+            "relation": "9721f67b8fef76ba6a0330c0556cf4d7",
+            "name": "sub-011_task-emotionProcessing_echo-1_bold.nii"
+          },
+          {
+            "relation": "92ae7f4d53aaa1dfcb6b1aa4831e2b01",
+            "name": "sub-011_task-emotionProcessing_echo-2_bold.json"
+          },
+          {
+            "relation": "cd28ad527b17d01fdb165a8187f9edd0",
+            "name": "sub-011_task-emotionProcessing_echo-2_bold.nii"
+          },
+          {
+            "relation": "1a6854b2757b610ba1cd38e38052807a",
+            "name": "sub-011_task-emotionProcessing_echo-3_bold.json"
+          },
+          {
+            "relation": "6b54bde4edbc9783b4fec3f4ff5dbf99",
+            "name": "sub-011_task-emotionProcessing_echo-3_bold.nii"
+          },
+          {
+            "relation": "44a21e171d72d65a62e26533d1c13c35",
+            "name": "sub-011_task-emotionProcessing_events.tsv.gz"
+          },
+          {
+            "relation": "d5c1c4ed0bcb9763c953698de001df64",
+            "name": "sub-011_task-emotionProcessingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "251cda48fe3fc0ff19a7bb7aaf832a27",
+            "name": "sub-011_task-emotionProcessingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "bfe715ec7a82f1ee4af69387207bed99",
+            "name": "sub-011_task-emotionProcessingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "75fe1c10b3ea1ff1215e64d3e08b441e",
+            "name": "sub-011_task-emotionProcessingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "da20dd65ebd552dff0227a15340490db",
+            "name": "sub-011_task-emotionProcessingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "41ce6c032b35b7ad8416302af406668f",
+            "name": "sub-011_task-emotionProcessingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "bcb0401f7c891a209243d32ef16f439a",
+            "name": "sub-011_task-emotionProcessingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "4dc4089ecb97f39170ea2d120a5c93e5",
+            "name": "sub-011_task-emotionProcessingImagined_physio.json"
+          },
+          {
+            "relation": "46b5fb70b031ce15fb5e7b60188cece3",
+            "name": "sub-011_task-emotionProcessingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "67f253b34a9bae8537f3bcdbafe722de",
+            "name": "sub-011_task-emotionProcessing_physio.json"
+          },
+          {
+            "relation": "f78c15f33b5a48a9dd7dc7646ce379f6",
+            "name": "sub-011_task-emotionProcessing_physio.tsv.gz"
+          },
+          {
+            "relation": "f68613335edd1800b81176499103cf90",
+            "name": "sub-011_task-fingerTapping_echo-1_bold.json"
+          },
+          {
+            "relation": "5a16b498dcaccd3dcc624918af24a44c",
+            "name": "sub-011_task-fingerTapping_echo-1_bold.nii"
+          },
+          {
+            "relation": "67493d53087a90ed9a788b156c7156f7",
+            "name": "sub-011_task-fingerTapping_echo-2_bold.json"
+          },
+          {
+            "relation": "2c2acd45644590194b1cf8e73ad92783",
+            "name": "sub-011_task-fingerTapping_echo-2_bold.nii"
+          },
+          {
+            "relation": "55555dc1b04e4999a286e7533504c00c",
+            "name": "sub-011_task-fingerTapping_echo-3_bold.json"
+          },
+          {
+            "relation": "879269a51ef784261e097fca08e77c91",
+            "name": "sub-011_task-fingerTapping_echo-3_bold.nii"
+          },
+          {
+            "relation": "67e6b607675a3b5675a20c0593b0ba2e",
+            "name": "sub-011_task-fingerTapping_events.tsv.gz"
+          },
+          {
+            "relation": "62152681cf9c628c2e244f6a4c54806a",
+            "name": "sub-011_task-fingerTappingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "7df91aa22b60c6e5fd5db9f55108b860",
+            "name": "sub-011_task-fingerTappingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "8db4cdcd06a3a3d5414e024ab6150ea0",
+            "name": "sub-011_task-fingerTappingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "c8a4081202b2d5d174b3d294d1ba5612",
+            "name": "sub-011_task-fingerTappingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "d9cf03c8282508c2bf3eec29b63bd178",
+            "name": "sub-011_task-fingerTappingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "c9f183132721513e629b5e1b52f348a9",
+            "name": "sub-011_task-fingerTappingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "b99b1551578390d5d9370833fe4dfd57",
+            "name": "sub-011_task-fingerTappingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "3869cd5c408fe7d4931ddef3af2c9034",
+            "name": "sub-011_task-fingerTappingImagined_physio.json"
+          },
+          {
+            "relation": "6b89f5151428bdcebabdf1213eaf0d0a",
+            "name": "sub-011_task-fingerTappingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "345716ebcc9747689b51775cba0a324f",
+            "name": "sub-011_task-fingerTapping_physio.json"
+          },
+          {
+            "relation": "01c001d27101079d5192a3cd9a73030f",
+            "name": "sub-011_task-fingerTapping_physio.tsv.gz"
+          },
+          {
+            "relation": "b10520e2662633d333bd9241847ef6cc",
+            "name": "sub-011_task-rest_run-1_echo-1_bold.json"
+          },
+          {
+            "relation": "ce39533f0e6735ce343fcc97213b078e",
+            "name": "sub-011_task-rest_run-1_echo-1_bold.nii"
+          },
+          {
+            "relation": "9d15b7e87a5b0b54898f81593d98bc56",
+            "name": "sub-011_task-rest_run-1_echo-2_bold.json"
+          },
+          {
+            "relation": "9853e26d852f88d0fb0671632098ebc5",
+            "name": "sub-011_task-rest_run-1_echo-2_bold.nii"
+          },
+          {
+            "relation": "87f69b8909f5f31e28a899052c77c232",
+            "name": "sub-011_task-rest_run-1_echo-3_bold.json"
+          },
+          {
+            "relation": "cf5370cc14cbeb0e6eeb053c2f2be559",
+            "name": "sub-011_task-rest_run-1_echo-3_bold.nii"
+          },
+          {
+            "relation": "06ccf364a78119afd801ef5870a3b5ce",
+            "name": "sub-011_task-rest_run-1_physio.json"
+          },
+          {
+            "relation": "9036b3c81432071b57427b4731cbe612",
+            "name": "sub-011_task-rest_run-1_physio.tsv.gz"
+          },
+          {
+            "relation": "734ec463c1346a0649d5aabbd3e66492",
+            "name": "sub-011_task-rest_run-2_echo-1_bold.json"
+          },
+          {
+            "relation": "8a2a4ccec405b9f83b593449a467b6b0",
+            "name": "sub-011_task-rest_run-2_echo-1_bold.nii"
+          },
+          {
+            "relation": "8856f20a4bb61095e41153ebfb24856a",
+            "name": "sub-011_task-rest_run-2_echo-2_bold.json"
+          },
+          {
+            "relation": "36bae91c122a3ce04df9bcee2a583d15",
+            "name": "sub-011_task-rest_run-2_echo-2_bold.nii"
+          },
+          {
+            "relation": "cb9cf3f1a210b9e2a3ba359fea0c2779",
+            "name": "sub-011_task-rest_run-2_echo-3_bold.json"
+          },
+          {
+            "relation": "577b270c64d285540992f988d5aa4e8d",
+            "name": "sub-011_task-rest_run-2_echo-3_bold.nii"
+          },
+          {
+            "relation": "ec4eedadf6dcf0c1941077b992168140",
+            "name": "sub-011_task-rest_run-2_physio.json"
+          },
+          {
+            "relation": "31c1315cca51318e840f45596998a980",
+            "name": "sub-011_task-rest_run-2_physio.tsv.gz"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "9721f67b8fef76ba6a0330c0556cf4d7",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "9721f67b8fef76ba6a0330c0556cf4d7"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46043"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "92ae7f4d53aaa1dfcb6b1aa4831e2b01",
+        "byte_size": 1039,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "92ae7f4d53aaa1dfcb6b1aa4831e2b01"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45758"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "cd28ad527b17d01fdb165a8187f9edd0",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "cd28ad527b17d01fdb165a8187f9edd0"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45818"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1a6854b2757b610ba1cd38e38052807a",
+        "byte_size": 1039,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1a6854b2757b610ba1cd38e38052807a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46455"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6b54bde4edbc9783b4fec3f4ff5dbf99",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6b54bde4edbc9783b4fec3f4ff5dbf99"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45816"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "44a21e171d72d65a62e26533d1c13c35",
+        "byte_size": 1915,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "44a21e171d72d65a62e26533d1c13c35"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46644"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d5c1c4ed0bcb9763c953698de001df64",
+        "byte_size": 1047,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d5c1c4ed0bcb9763c953698de001df64"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45837"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "251cda48fe3fc0ff19a7bb7aaf832a27",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "251cda48fe3fc0ff19a7bb7aaf832a27"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45433"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "bfe715ec7a82f1ee4af69387207bed99",
+        "byte_size": 1047,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "bfe715ec7a82f1ee4af69387207bed99"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46409"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "75fe1c10b3ea1ff1215e64d3e08b441e",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "75fe1c10b3ea1ff1215e64d3e08b441e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46425"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "da20dd65ebd552dff0227a15340490db",
+        "byte_size": 1047,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "da20dd65ebd552dff0227a15340490db"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45713"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "41ce6c032b35b7ad8416302af406668f",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "41ce6c032b35b7ad8416302af406668f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45969"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "bcb0401f7c891a209243d32ef16f439a",
+        "byte_size": 178,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "bcb0401f7c891a209243d32ef16f439a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46608"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4dc4089ecb97f39170ea2d120a5c93e5",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4dc4089ecb97f39170ea2d120a5c93e5"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46432"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "46b5fb70b031ce15fb5e7b60188cece3",
+        "byte_size": 598103,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "46b5fb70b031ce15fb5e7b60188cece3"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45231"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "67f253b34a9bae8537f3bcdbafe722de",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "67f253b34a9bae8537f3bcdbafe722de"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46372"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f78c15f33b5a48a9dd7dc7646ce379f6",
+        "byte_size": 512048,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f78c15f33b5a48a9dd7dc7646ce379f6"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45297"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f68613335edd1800b81176499103cf90",
+        "byte_size": 1035,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f68613335edd1800b81176499103cf90"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45241"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5a16b498dcaccd3dcc624918af24a44c",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5a16b498dcaccd3dcc624918af24a44c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46011"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "67493d53087a90ed9a788b156c7156f7",
+        "byte_size": 1035,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "67493d53087a90ed9a788b156c7156f7"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46464"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2c2acd45644590194b1cf8e73ad92783",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2c2acd45644590194b1cf8e73ad92783"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45235"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "55555dc1b04e4999a286e7533504c00c",
+        "byte_size": 1035,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "55555dc1b04e4999a286e7533504c00c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45578"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "879269a51ef784261e097fca08e77c91",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "879269a51ef784261e097fca08e77c91"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45698"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "67e6b607675a3b5675a20c0593b0ba2e",
+        "byte_size": 164,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "67e6b607675a3b5675a20c0593b0ba2e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46596"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "62152681cf9c628c2e244f6a4c54806a",
+        "byte_size": 1043,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "62152681cf9c628c2e244f6a4c54806a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46155"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "7df91aa22b60c6e5fd5db9f55108b860",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "7df91aa22b60c6e5fd5db9f55108b860"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46139"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8db4cdcd06a3a3d5414e024ab6150ea0",
+        "byte_size": 1043,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8db4cdcd06a3a3d5414e024ab6150ea0"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45811"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c8a4081202b2d5d174b3d294d1ba5612",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c8a4081202b2d5d174b3d294d1ba5612"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45382"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d9cf03c8282508c2bf3eec29b63bd178",
+        "byte_size": 1043,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d9cf03c8282508c2bf3eec29b63bd178"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46017"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c9f183132721513e629b5e1b52f348a9",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c9f183132721513e629b5e1b52f348a9"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45914"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b99b1551578390d5d9370833fe4dfd57",
+        "byte_size": 179,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b99b1551578390d5d9370833fe4dfd57"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46570"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "3869cd5c408fe7d4931ddef3af2c9034",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "3869cd5c408fe7d4931ddef3af2c9034"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46331"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6b89f5151428bdcebabdf1213eaf0d0a",
+        "byte_size": 582479,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6b89f5151428bdcebabdf1213eaf0d0a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45574"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "345716ebcc9747689b51775cba0a324f",
+        "byte_size": 142,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "345716ebcc9747689b51775cba0a324f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45920"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "01c001d27101079d5192a3cd9a73030f",
+        "byte_size": 525437,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "01c001d27101079d5192a3cd9a73030f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45628"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b10520e2662633d333bd9241847ef6cc",
+        "byte_size": 1026,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b10520e2662633d333bd9241847ef6cc"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45561"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ce39533f0e6735ce343fcc97213b078e",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ce39533f0e6735ce343fcc97213b078e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45890"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "9d15b7e87a5b0b54898f81593d98bc56",
+        "byte_size": 1026,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "9d15b7e87a5b0b54898f81593d98bc56"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45714"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "9853e26d852f88d0fb0671632098ebc5",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "9853e26d852f88d0fb0671632098ebc5"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45392"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "87f69b8909f5f31e28a899052c77c232",
+        "byte_size": 1026,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "87f69b8909f5f31e28a899052c77c232"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45287"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "cf5370cc14cbeb0e6eeb053c2f2be559",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "cf5370cc14cbeb0e6eeb053c2f2be559"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46150"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "06ccf364a78119afd801ef5870a3b5ce",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "06ccf364a78119afd801ef5870a3b5ce"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45365"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "9036b3c81432071b57427b4731cbe612",
+        "byte_size": 469520,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "9036b3c81432071b57427b4731cbe612"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46032"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "734ec463c1346a0649d5aabbd3e66492",
+        "byte_size": 1026,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "734ec463c1346a0649d5aabbd3e66492"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46384"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8a2a4ccec405b9f83b593449a467b6b0",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8a2a4ccec405b9f83b593449a467b6b0"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45608"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8856f20a4bb61095e41153ebfb24856a",
+        "byte_size": 1026,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8856f20a4bb61095e41153ebfb24856a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46229"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "36bae91c122a3ce04df9bcee2a583d15",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "36bae91c122a3ce04df9bcee2a583d15"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46359"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "cb9cf3f1a210b9e2a3ba359fea0c2779",
+        "byte_size": 1026,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "cb9cf3f1a210b9e2a3ba359fea0c2779"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46066"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "577b270c64d285540992f988d5aa4e8d",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "577b270c64d285540992f988d5aa4e8d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46543"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ec4eedadf6dcf0c1941077b992168140",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ec4eedadf6dcf0c1941077b992168140"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46329"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "31c1315cca51318e840f45596998a980",
+        "byte_size": 487630,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "31c1315cca51318e840f45596998a980"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45977"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "795af637ef08412092a8026dc0ee140d",
+        "byte_size": 20736352,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "795af637ef08412092a8026dc0ee140d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46047"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-012/",
+        "qualified_part": [
+          {
+            "relation": "sub-012/anat/",
+            "name": "anat"
+          },
+          {
+            "relation": "sub-012/func/",
+            "name": "func"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-012/anat/",
+        "qualified_part": [
+          {
+            "relation": "795af637ef08412092a8026dc0ee140d",
+            "name": "sub-012_T1w.nii"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "382a4823b9b110d0c58322e9c40570e1",
+        "byte_size": 1041,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "382a4823b9b110d0c58322e9c40570e1"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46354"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-012/func/",
+        "qualified_part": [
+          {
+            "relation": "382a4823b9b110d0c58322e9c40570e1",
+            "name": "sub-012_task-emotionProcessing_echo-1_bold.json"
+          },
+          {
+            "relation": "b6a195317631932eab859ad0c3d6ea33",
+            "name": "sub-012_task-emotionProcessing_echo-1_bold.nii"
+          },
+          {
+            "relation": "799090ea10892c2dd15b914a46564194",
+            "name": "sub-012_task-emotionProcessing_echo-2_bold.json"
+          },
+          {
+            "relation": "ece612ba0853e7be290ec84604dfbd93",
+            "name": "sub-012_task-emotionProcessing_echo-2_bold.nii"
+          },
+          {
+            "relation": "7ef80e89f474467f5b3e969293f3467f",
+            "name": "sub-012_task-emotionProcessing_echo-3_bold.json"
+          },
+          {
+            "relation": "9ee8fff9e7c3ec8e70644854c7495c4c",
+            "name": "sub-012_task-emotionProcessing_echo-3_bold.nii"
+          },
+          {
+            "relation": "097058ecbe042066f14ed6220b0dfbd9",
+            "name": "sub-012_task-emotionProcessing_events.tsv.gz"
+          },
+          {
+            "relation": "050fb9dbf93e7c09df79e9efbb02fcb9",
+            "name": "sub-012_task-emotionProcessingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "8ae116e6ecd732f7600e04763fa2a705",
+            "name": "sub-012_task-emotionProcessingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "196a26faa275c16e97365e3a8d92ff7d",
+            "name": "sub-012_task-emotionProcessingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "c7bb51c9716c1e122ec8c2c4ae213c35",
+            "name": "sub-012_task-emotionProcessingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "b4442c318da703f7f578646358ad1d81",
+            "name": "sub-012_task-emotionProcessingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "7916e42076207b5848d0e1966997d8c2",
+            "name": "sub-012_task-emotionProcessingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "3f246551ab4cffc672ab28c6c00df119",
+            "name": "sub-012_task-emotionProcessingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "f0530603563aa5bff37d429077bf63b1",
+            "name": "sub-012_task-emotionProcessingImagined_physio.json"
+          },
+          {
+            "relation": "d3163cee8283f7d3a4e3eea656126800",
+            "name": "sub-012_task-emotionProcessingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "dd61d969dba5f822d1341db9b2ea4131",
+            "name": "sub-012_task-emotionProcessing_physio.json"
+          },
+          {
+            "relation": "51bf4260d4068cd629c8fb1700b22fec",
+            "name": "sub-012_task-emotionProcessing_physio.tsv.gz"
+          },
+          {
+            "relation": "de294fa441235170f805902ad31457e1",
+            "name": "sub-012_task-fingerTapping_echo-1_bold.json"
+          },
+          {
+            "relation": "cd2c4d3cf939bf00b695ee6ecff33064",
+            "name": "sub-012_task-fingerTapping_echo-1_bold.nii"
+          },
+          {
+            "relation": "ea835407d646a4bc33685ebc5c5b027d",
+            "name": "sub-012_task-fingerTapping_echo-2_bold.json"
+          },
+          {
+            "relation": "3c8f0fae13660639d328ecd1ec29c0a2",
+            "name": "sub-012_task-fingerTapping_echo-2_bold.nii"
+          },
+          {
+            "relation": "9a6686d65339d9d41577a6cdd9ffe09a",
+            "name": "sub-012_task-fingerTapping_echo-3_bold.json"
+          },
+          {
+            "relation": "8ed55bd04f00b343fbaa411c09f1cdea",
+            "name": "sub-012_task-fingerTapping_echo-3_bold.nii"
+          },
+          {
+            "relation": "d1d06fd9f3ec1c7df5d2838923cb98bd",
+            "name": "sub-012_task-fingerTapping_events.tsv.gz"
+          },
+          {
+            "relation": "10a34c63d3a97b2adc98d1386df793d8",
+            "name": "sub-012_task-fingerTappingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "6f95650a96ab74622d4fa8f16d0c820f",
+            "name": "sub-012_task-fingerTappingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "8ac3c9410fa371e8d49a02d68bb704ff",
+            "name": "sub-012_task-fingerTappingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "d10693fd693c1db4f1ebaca74e52cbbd",
+            "name": "sub-012_task-fingerTappingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "7a03104a2d2b3e4ccde0d1236fc995dc",
+            "name": "sub-012_task-fingerTappingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "0e1a64cd98ff26b34c4d14d0487e0636",
+            "name": "sub-012_task-fingerTappingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "0ff7dc89c68f67fbc39672b7d3cc7023",
+            "name": "sub-012_task-fingerTappingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "c57f34d5f230fe2c01f06b4865f0325f",
+            "name": "sub-012_task-fingerTappingImagined_physio.json"
+          },
+          {
+            "relation": "b26fc2f54c1b240cd8981fcb0224b4b1",
+            "name": "sub-012_task-fingerTappingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "1e300396dc5b59771f40ca8bc8b57e19",
+            "name": "sub-012_task-fingerTapping_physio.json"
+          },
+          {
+            "relation": "45f2c03f0fe510b4a3185ae6cbf496d8",
+            "name": "sub-012_task-fingerTapping_physio.tsv.gz"
+          },
+          {
+            "relation": "e3a883756d27e5b8e09e93412825c7fe",
+            "name": "sub-012_task-rest_run-1_echo-1_bold.json"
+          },
+          {
+            "relation": "7b0ef606ddc57bac0c4a06c60f51a8f3",
+            "name": "sub-012_task-rest_run-1_echo-1_bold.nii"
+          },
+          {
+            "relation": "f4ada1d0e02800ceb65f083847f950ba",
+            "name": "sub-012_task-rest_run-1_echo-2_bold.json"
+          },
+          {
+            "relation": "c2ae5a5e4ea51ac54ae4d2cc4ef30f11",
+            "name": "sub-012_task-rest_run-1_echo-2_bold.nii"
+          },
+          {
+            "relation": "dda69229fb84f9b9623f8f35de79b5e2",
+            "name": "sub-012_task-rest_run-1_echo-3_bold.json"
+          },
+          {
+            "relation": "d12af16342d85ce006b676b14a8a79e2",
+            "name": "sub-012_task-rest_run-1_echo-3_bold.nii"
+          },
+          {
+            "relation": "fadc5fbec6ea5f8adb2f31c8a837379f",
+            "name": "sub-012_task-rest_run-1_physio.json"
+          },
+          {
+            "relation": "4892d49ae507ce3fe61976ebb021cfec",
+            "name": "sub-012_task-rest_run-1_physio.tsv.gz"
+          },
+          {
+            "relation": "2c1dc9ae410b111eee9fcbd67674dd41",
+            "name": "sub-012_task-rest_run-2_echo-1_bold.json"
+          },
+          {
+            "relation": "d2404c5a5d23dbf81d32995d653125ec",
+            "name": "sub-012_task-rest_run-2_echo-1_bold.nii"
+          },
+          {
+            "relation": "6dacd51f3fdb60a29f137fb5dcadc8d9",
+            "name": "sub-012_task-rest_run-2_echo-2_bold.json"
+          },
+          {
+            "relation": "a4072099ef5cf2ec54ada3e56e44fe6d",
+            "name": "sub-012_task-rest_run-2_echo-2_bold.nii"
+          },
+          {
+            "relation": "1582d2d1a3c9da3568043e61046efc03",
+            "name": "sub-012_task-rest_run-2_echo-3_bold.json"
+          },
+          {
+            "relation": "991e8938d59ff3e37a2e5b2983b0805e",
+            "name": "sub-012_task-rest_run-2_echo-3_bold.nii"
+          },
+          {
+            "relation": "a71c4b97ebdfa87fd1314ee245a018d6",
+            "name": "sub-012_task-rest_run-2_physio.json"
+          },
+          {
+            "relation": "702951e89ef28eecc2fb0431a7138703",
+            "name": "sub-012_task-rest_run-2_physio.tsv.gz"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b6a195317631932eab859ad0c3d6ea33",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b6a195317631932eab859ad0c3d6ea33"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46535"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "799090ea10892c2dd15b914a46564194",
+        "byte_size": 1041,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "799090ea10892c2dd15b914a46564194"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45343"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ece612ba0853e7be290ec84604dfbd93",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ece612ba0853e7be290ec84604dfbd93"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45658"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "7ef80e89f474467f5b3e969293f3467f",
+        "byte_size": 1041,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "7ef80e89f474467f5b3e969293f3467f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46061"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "9ee8fff9e7c3ec8e70644854c7495c4c",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "9ee8fff9e7c3ec8e70644854c7495c4c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45109"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "097058ecbe042066f14ed6220b0dfbd9",
+        "byte_size": 1895,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "097058ecbe042066f14ed6220b0dfbd9"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46562"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "050fb9dbf93e7c09df79e9efbb02fcb9",
+        "byte_size": 1048,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "050fb9dbf93e7c09df79e9efbb02fcb9"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46483"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8ae116e6ecd732f7600e04763fa2a705",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8ae116e6ecd732f7600e04763fa2a705"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46296"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "196a26faa275c16e97365e3a8d92ff7d",
+        "byte_size": 1048,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "196a26faa275c16e97365e3a8d92ff7d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46294"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c7bb51c9716c1e122ec8c2c4ae213c35",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c7bb51c9716c1e122ec8c2c4ae213c35"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45192"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b4442c318da703f7f578646358ad1d81",
+        "byte_size": 1048,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b4442c318da703f7f578646358ad1d81"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46325"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "7916e42076207b5848d0e1966997d8c2",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "7916e42076207b5848d0e1966997d8c2"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46120"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "3f246551ab4cffc672ab28c6c00df119",
+        "byte_size": 174,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "3f246551ab4cffc672ab28c6c00df119"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46599"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f0530603563aa5bff37d429077bf63b1",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f0530603563aa5bff37d429077bf63b1"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45190"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d3163cee8283f7d3a4e3eea656126800",
+        "byte_size": 463512,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d3163cee8283f7d3a4e3eea656126800"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45255"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "dd61d969dba5f822d1341db9b2ea4131",
+        "byte_size": 141,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "dd61d969dba5f822d1341db9b2ea4131"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46530"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "51bf4260d4068cd629c8fb1700b22fec",
+        "byte_size": 525307,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "51bf4260d4068cd629c8fb1700b22fec"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45278"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "de294fa441235170f805902ad31457e1",
+        "byte_size": 1037,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "de294fa441235170f805902ad31457e1"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45808"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "cd2c4d3cf939bf00b695ee6ecff33064",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "cd2c4d3cf939bf00b695ee6ecff33064"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45618"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ea835407d646a4bc33685ebc5c5b027d",
+        "byte_size": 1037,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ea835407d646a4bc33685ebc5c5b027d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46127"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "3c8f0fae13660639d328ecd1ec29c0a2",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "3c8f0fae13660639d328ecd1ec29c0a2"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45517"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "9a6686d65339d9d41577a6cdd9ffe09a",
+        "byte_size": 1037,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "9a6686d65339d9d41577a6cdd9ffe09a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45607"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8ed55bd04f00b343fbaa411c09f1cdea",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8ed55bd04f00b343fbaa411c09f1cdea"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45575"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d1d06fd9f3ec1c7df5d2838923cb98bd",
+        "byte_size": 164,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d1d06fd9f3ec1c7df5d2838923cb98bd"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46601"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "10a34c63d3a97b2adc98d1386df793d8",
+        "byte_size": 1045,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "10a34c63d3a97b2adc98d1386df793d8"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46524"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6f95650a96ab74622d4fa8f16d0c820f",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6f95650a96ab74622d4fa8f16d0c820f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45099"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8ac3c9410fa371e8d49a02d68bb704ff",
+        "byte_size": 1045,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8ac3c9410fa371e8d49a02d68bb704ff"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46225"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d10693fd693c1db4f1ebaca74e52cbbd",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d10693fd693c1db4f1ebaca74e52cbbd"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46151"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "7a03104a2d2b3e4ccde0d1236fc995dc",
+        "byte_size": 1045,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "7a03104a2d2b3e4ccde0d1236fc995dc"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46517"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "0e1a64cd98ff26b34c4d14d0487e0636",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "0e1a64cd98ff26b34c4d14d0487e0636"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45763"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "0ff7dc89c68f67fbc39672b7d3cc7023",
+        "byte_size": 177,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "0ff7dc89c68f67fbc39672b7d3cc7023"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46569"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c57f34d5f230fe2c01f06b4865f0325f",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c57f34d5f230fe2c01f06b4865f0325f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45374"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b26fc2f54c1b240cd8981fcb0224b4b1",
+        "byte_size": 490085,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b26fc2f54c1b240cd8981fcb0224b4b1"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46532"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1e300396dc5b59771f40ca8bc8b57e19",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1e300396dc5b59771f40ca8bc8b57e19"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45142"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "45f2c03f0fe510b4a3185ae6cbf496d8",
+        "byte_size": 515014,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "45f2c03f0fe510b4a3185ae6cbf496d8"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45111"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e3a883756d27e5b8e09e93412825c7fe",
+        "byte_size": 1028,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e3a883756d27e5b8e09e93412825c7fe"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46540"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "7b0ef606ddc57bac0c4a06c60f51a8f3",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "7b0ef606ddc57bac0c4a06c60f51a8f3"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45501"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f4ada1d0e02800ceb65f083847f950ba",
+        "byte_size": 1028,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f4ada1d0e02800ceb65f083847f950ba"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46034"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c2ae5a5e4ea51ac54ae4d2cc4ef30f11",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c2ae5a5e4ea51ac54ae4d2cc4ef30f11"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45636"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "dda69229fb84f9b9623f8f35de79b5e2",
+        "byte_size": 1028,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "dda69229fb84f9b9623f8f35de79b5e2"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46443"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d12af16342d85ce006b676b14a8a79e2",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d12af16342d85ce006b676b14a8a79e2"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45709"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "fadc5fbec6ea5f8adb2f31c8a837379f",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "fadc5fbec6ea5f8adb2f31c8a837379f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45940"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4892d49ae507ce3fe61976ebb021cfec",
+        "byte_size": 463276,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4892d49ae507ce3fe61976ebb021cfec"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46402"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2c1dc9ae410b111eee9fcbd67674dd41",
+        "byte_size": 1028,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2c1dc9ae410b111eee9fcbd67674dd41"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46351"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d2404c5a5d23dbf81d32995d653125ec",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d2404c5a5d23dbf81d32995d653125ec"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46036"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6dacd51f3fdb60a29f137fb5dcadc8d9",
+        "byte_size": 1028,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6dacd51f3fdb60a29f137fb5dcadc8d9"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45492"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a4072099ef5cf2ec54ada3e56e44fe6d",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a4072099ef5cf2ec54ada3e56e44fe6d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46105"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1582d2d1a3c9da3568043e61046efc03",
+        "byte_size": 1028,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1582d2d1a3c9da3568043e61046efc03"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46235"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "991e8938d59ff3e37a2e5b2983b0805e",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "991e8938d59ff3e37a2e5b2983b0805e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45625"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a71c4b97ebdfa87fd1314ee245a018d6",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a71c4b97ebdfa87fd1314ee245a018d6"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45460"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "702951e89ef28eecc2fb0431a7138703",
+        "byte_size": 451048,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "702951e89ef28eecc2fb0431a7138703"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45281"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "35f0db586ee930c7cca38874da209ee8",
+        "byte_size": 20736352,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "35f0db586ee930c7cca38874da209ee8"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45230"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-013/",
+        "qualified_part": [
+          {
+            "relation": "sub-013/anat/",
+            "name": "anat"
+          },
+          {
+            "relation": "sub-013/func/",
+            "name": "func"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-013/anat/",
+        "qualified_part": [
+          {
+            "relation": "35f0db586ee930c7cca38874da209ee8",
+            "name": "sub-013_T1w.nii"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4c3cf2184e333516449b2fd9ab99e6f8",
+        "byte_size": 1039,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4c3cf2184e333516449b2fd9ab99e6f8"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46300"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-013/func/",
+        "qualified_part": [
+          {
+            "relation": "4c3cf2184e333516449b2fd9ab99e6f8",
+            "name": "sub-013_task-emotionProcessing_echo-1_bold.json"
+          },
+          {
+            "relation": "42da9e5f60b8474657f709ff80423b42",
+            "name": "sub-013_task-emotionProcessing_echo-1_bold.nii"
+          },
+          {
+            "relation": "428d8b271dfb0ae1adf5c4e550bd371d",
+            "name": "sub-013_task-emotionProcessing_echo-2_bold.json"
+          },
+          {
+            "relation": "b29b1ffd8a68f4cde389e2150cb16e13",
+            "name": "sub-013_task-emotionProcessing_echo-2_bold.nii"
+          },
+          {
+            "relation": "e9b416ede6a2a916a3a835654aed276c",
+            "name": "sub-013_task-emotionProcessing_echo-3_bold.json"
+          },
+          {
+            "relation": "154468e9d87e1b3daba28c51528aa2eb",
+            "name": "sub-013_task-emotionProcessing_echo-3_bold.nii"
+          },
+          {
+            "relation": "5b6fb06c3743fae4095da2eea36a5464",
+            "name": "sub-013_task-emotionProcessing_events.tsv.gz"
+          },
+          {
+            "relation": "39a8655efa4164001f70630f578860b5",
+            "name": "sub-013_task-emotionProcessingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "a5eb50a3b6d8bd2d9b9afa4af09a1672",
+            "name": "sub-013_task-emotionProcessingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "2d58a070af22c624dc461557f839120a",
+            "name": "sub-013_task-emotionProcessingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "db16713e31fcb088bf8c209cf2ccadd8",
+            "name": "sub-013_task-emotionProcessingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "d71aa1888f2c0b09ac19b1ba85089fb3",
+            "name": "sub-013_task-emotionProcessingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "612187d0f7bc9a6ca680efe80b47802d",
+            "name": "sub-013_task-emotionProcessingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "adb70a52e07794ff600c3039e4773864",
+            "name": "sub-013_task-emotionProcessingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "b0f5c8f13d597a094a1aeb3c162588dd",
+            "name": "sub-013_task-emotionProcessingImagined_physio.json"
+          },
+          {
+            "relation": "cbda14078ebecf0cb7dbce7c2f491725",
+            "name": "sub-013_task-emotionProcessingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "d0f1d46c90bc3ff7fddcfec9826bbc14",
+            "name": "sub-013_task-emotionProcessing_physio.json"
+          },
+          {
+            "relation": "6035e0d678f0067761fcca4c5b7c0bea",
+            "name": "sub-013_task-emotionProcessing_physio.tsv.gz"
+          },
+          {
+            "relation": "ab12231bb38f998b0c74148deecc6053",
+            "name": "sub-013_task-fingerTapping_echo-1_bold.json"
+          },
+          {
+            "relation": "2c0e630b0a1184a651e7c22bb47dfdf0",
+            "name": "sub-013_task-fingerTapping_echo-1_bold.nii"
+          },
+          {
+            "relation": "9ca509e0c01261e7c3ed94338394f0ca",
+            "name": "sub-013_task-fingerTapping_echo-2_bold.json"
+          },
+          {
+            "relation": "3ad4a140f2c76f0f5617eca438b2a82e",
+            "name": "sub-013_task-fingerTapping_echo-2_bold.nii"
+          },
+          {
+            "relation": "4a16fccd84cf4de9f19e99c54e681ddd",
+            "name": "sub-013_task-fingerTapping_echo-3_bold.json"
+          },
+          {
+            "relation": "8fadb476f9c9a61003e24e404e7c9237",
+            "name": "sub-013_task-fingerTapping_echo-3_bold.nii"
+          },
+          {
+            "relation": "f2f1ec4918c4fed24c7cab1b3cd4a67f",
+            "name": "sub-013_task-fingerTapping_events.tsv.gz"
+          },
+          {
+            "relation": "a02e3e3953d7f52cab57250d2114050e",
+            "name": "sub-013_task-fingerTappingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "256e93aa12107151a7656df8208f8f82",
+            "name": "sub-013_task-fingerTappingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "488c3478ab3a82b0040606e7792083dc",
+            "name": "sub-013_task-fingerTappingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "057370dbee8f6dd21a7b8c5a51782ec4",
+            "name": "sub-013_task-fingerTappingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "6b02ab76f155bb7170609f6ff2449f2e",
+            "name": "sub-013_task-fingerTappingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "147b61f47296003c21ab27a66ef64aad",
+            "name": "sub-013_task-fingerTappingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "284434bd2be53609b41ff2d7bcaf33b2",
+            "name": "sub-013_task-fingerTappingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "0e63bbb9fdc6ec15fb2ed4287485919b",
+            "name": "sub-013_task-fingerTappingImagined_physio.json"
+          },
+          {
+            "relation": "5eabf83c020779e7cf2d45e8a89cc7fa",
+            "name": "sub-013_task-fingerTappingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "735f2308bddbdd5c49117730a5de9d94",
+            "name": "sub-013_task-fingerTapping_physio.json"
+          },
+          {
+            "relation": "56f78b4bf78e6f5bbea9f758b867bb75",
+            "name": "sub-013_task-fingerTapping_physio.tsv.gz"
+          },
+          {
+            "relation": "d04baff7ec38efc1cf1c7dd5f3d88863",
+            "name": "sub-013_task-rest_run-1_echo-1_bold.json"
+          },
+          {
+            "relation": "5351444b82f30e3188c4afce97b5636a",
+            "name": "sub-013_task-rest_run-1_echo-1_bold.nii"
+          },
+          {
+            "relation": "c76360cc45e8f6240d909fdce03aab99",
+            "name": "sub-013_task-rest_run-1_echo-2_bold.json"
+          },
+          {
+            "relation": "dd0e2c99669e92efeecb0ef43e0f94b3",
+            "name": "sub-013_task-rest_run-1_echo-2_bold.nii"
+          },
+          {
+            "relation": "64c1f677782135ea0fa494767c387168",
+            "name": "sub-013_task-rest_run-1_echo-3_bold.json"
+          },
+          {
+            "relation": "afbcd0293b5deec30840611b2cc6cf31",
+            "name": "sub-013_task-rest_run-1_echo-3_bold.nii"
+          },
+          {
+            "relation": "979fda86b6c63e7652a8985cae52adf9",
+            "name": "sub-013_task-rest_run-1_physio.json"
+          },
+          {
+            "relation": "def5bd7e52762f2163b0d5ec6217b362",
+            "name": "sub-013_task-rest_run-1_physio.tsv.gz"
+          },
+          {
+            "relation": "42c0cb9985346cd68316fcbe48a8f368",
+            "name": "sub-013_task-rest_run-2_echo-1_bold.json"
+          },
+          {
+            "relation": "43cfafd2ae5359fb8e447fa19f19c36c",
+            "name": "sub-013_task-rest_run-2_echo-1_bold.nii"
+          },
+          {
+            "relation": "d8d7338d9fe7676ffc6afef85edb81c9",
+            "name": "sub-013_task-rest_run-2_echo-2_bold.json"
+          },
+          {
+            "relation": "af2f57986f7d007905fcbe99a28f7674",
+            "name": "sub-013_task-rest_run-2_echo-2_bold.nii"
+          },
+          {
+            "relation": "43a8d6de09dbc08e15946c5a02ff7da0",
+            "name": "sub-013_task-rest_run-2_echo-3_bold.json"
+          },
+          {
+            "relation": "d10ad38ae6a94e6bd64e73aaa648a10e",
+            "name": "sub-013_task-rest_run-2_echo-3_bold.nii"
+          },
+          {
+            "relation": "325a060b570ee400010c4eccbb4a1359",
+            "name": "sub-013_task-rest_run-2_physio.json"
+          },
+          {
+            "relation": "a64f2d494aaf61668dce532ba4a248a6",
+            "name": "sub-013_task-rest_run-2_physio.tsv.gz"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "42da9e5f60b8474657f709ff80423b42",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "42da9e5f60b8474657f709ff80423b42"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46508"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "428d8b271dfb0ae1adf5c4e550bd371d",
+        "byte_size": 1039,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "428d8b271dfb0ae1adf5c4e550bd371d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45647"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b29b1ffd8a68f4cde389e2150cb16e13",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b29b1ffd8a68f4cde389e2150cb16e13"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45416"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e9b416ede6a2a916a3a835654aed276c",
+        "byte_size": 1039,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e9b416ede6a2a916a3a835654aed276c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45669"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "154468e9d87e1b3daba28c51528aa2eb",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "154468e9d87e1b3daba28c51528aa2eb"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45722"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5b6fb06c3743fae4095da2eea36a5464",
+        "byte_size": 1889,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5b6fb06c3743fae4095da2eea36a5464"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46604"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "39a8655efa4164001f70630f578860b5",
+        "byte_size": 1046,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "39a8655efa4164001f70630f578860b5"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45673"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a5eb50a3b6d8bd2d9b9afa4af09a1672",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a5eb50a3b6d8bd2d9b9afa4af09a1672"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45132"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2d58a070af22c624dc461557f839120a",
+        "byte_size": 1046,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2d58a070af22c624dc461557f839120a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46169"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "db16713e31fcb088bf8c209cf2ccadd8",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "db16713e31fcb088bf8c209cf2ccadd8"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45234"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d71aa1888f2c0b09ac19b1ba85089fb3",
+        "byte_size": 1046,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d71aa1888f2c0b09ac19b1ba85089fb3"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45830"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "612187d0f7bc9a6ca680efe80b47802d",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "612187d0f7bc9a6ca680efe80b47802d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45369"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "adb70a52e07794ff600c3039e4773864",
+        "byte_size": 178,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "adb70a52e07794ff600c3039e4773864"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46591"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b0f5c8f13d597a094a1aeb3c162588dd",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b0f5c8f13d597a094a1aeb3c162588dd"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46227"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "cbda14078ebecf0cb7dbce7c2f491725",
+        "byte_size": 453405,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "cbda14078ebecf0cb7dbce7c2f491725"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46231"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d0f1d46c90bc3ff7fddcfec9826bbc14",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d0f1d46c90bc3ff7fddcfec9826bbc14"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46264"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6035e0d678f0067761fcca4c5b7c0bea",
+        "byte_size": 484357,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6035e0d678f0067761fcca4c5b7c0bea"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46134"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ab12231bb38f998b0c74148deecc6053",
+        "byte_size": 1035,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ab12231bb38f998b0c74148deecc6053"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45955"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2c0e630b0a1184a651e7c22bb47dfdf0",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2c0e630b0a1184a651e7c22bb47dfdf0"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45946"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "9ca509e0c01261e7c3ed94338394f0ca",
+        "byte_size": 1035,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "9ca509e0c01261e7c3ed94338394f0ca"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45535"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "3ad4a140f2c76f0f5617eca438b2a82e",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "3ad4a140f2c76f0f5617eca438b2a82e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45493"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4a16fccd84cf4de9f19e99c54e681ddd",
+        "byte_size": 1035,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4a16fccd84cf4de9f19e99c54e681ddd"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46214"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8fadb476f9c9a61003e24e404e7c9237",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8fadb476f9c9a61003e24e404e7c9237"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45521"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f2f1ec4918c4fed24c7cab1b3cd4a67f",
+        "byte_size": 164,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f2f1ec4918c4fed24c7cab1b3cd4a67f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46579"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a02e3e3953d7f52cab57250d2114050e",
+        "byte_size": 1043,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a02e3e3953d7f52cab57250d2114050e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45106"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "256e93aa12107151a7656df8208f8f82",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "256e93aa12107151a7656df8208f8f82"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45347"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "488c3478ab3a82b0040606e7792083dc",
+        "byte_size": 1043,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "488c3478ab3a82b0040606e7792083dc"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46094"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "057370dbee8f6dd21a7b8c5a51782ec4",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "057370dbee8f6dd21a7b8c5a51782ec4"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46292"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6b02ab76f155bb7170609f6ff2449f2e",
+        "byte_size": 1043,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6b02ab76f155bb7170609f6ff2449f2e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45731"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "147b61f47296003c21ab27a66ef64aad",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "147b61f47296003c21ab27a66ef64aad"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45954"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "284434bd2be53609b41ff2d7bcaf33b2",
+        "byte_size": 179,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "284434bd2be53609b41ff2d7bcaf33b2"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46568"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "0e63bbb9fdc6ec15fb2ed4287485919b",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "0e63bbb9fdc6ec15fb2ed4287485919b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45422"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5eabf83c020779e7cf2d45e8a89cc7fa",
+        "byte_size": 454645,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5eabf83c020779e7cf2d45e8a89cc7fa"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45571"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "735f2308bddbdd5c49117730a5de9d94",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "735f2308bddbdd5c49117730a5de9d94"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45280"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "56f78b4bf78e6f5bbea9f758b867bb75",
+        "byte_size": 522038,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "56f78b4bf78e6f5bbea9f758b867bb75"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45644"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d04baff7ec38efc1cf1c7dd5f3d88863",
+        "byte_size": 1026,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d04baff7ec38efc1cf1c7dd5f3d88863"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46374"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5351444b82f30e3188c4afce97b5636a",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5351444b82f30e3188c4afce97b5636a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46172"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c76360cc45e8f6240d909fdce03aab99",
+        "byte_size": 1026,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c76360cc45e8f6240d909fdce03aab99"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46435"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "dd0e2c99669e92efeecb0ef43e0f94b3",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "dd0e2c99669e92efeecb0ef43e0f94b3"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46108"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "64c1f677782135ea0fa494767c387168",
+        "byte_size": 1026,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "64c1f677782135ea0fa494767c387168"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46437"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "afbcd0293b5deec30840611b2cc6cf31",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "afbcd0293b5deec30840611b2cc6cf31"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46321"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "979fda86b6c63e7652a8985cae52adf9",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "979fda86b6c63e7652a8985cae52adf9"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45645"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "def5bd7e52762f2163b0d5ec6217b362",
+        "byte_size": 453506,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "def5bd7e52762f2163b0d5ec6217b362"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45151"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "42c0cb9985346cd68316fcbe48a8f368",
+        "byte_size": 1025,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "42c0cb9985346cd68316fcbe48a8f368"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46023"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "43cfafd2ae5359fb8e447fa19f19c36c",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "43cfafd2ae5359fb8e447fa19f19c36c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45624"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d8d7338d9fe7676ffc6afef85edb81c9",
+        "byte_size": 1025,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d8d7338d9fe7676ffc6afef85edb81c9"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45885"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "af2f57986f7d007905fcbe99a28f7674",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "af2f57986f7d007905fcbe99a28f7674"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45262"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "43a8d6de09dbc08e15946c5a02ff7da0",
+        "byte_size": 1025,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "43a8d6de09dbc08e15946c5a02ff7da0"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45884"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d10ad38ae6a94e6bd64e73aaa648a10e",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d10ad38ae6a94e6bd64e73aaa648a10e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46048"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "325a060b570ee400010c4eccbb4a1359",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "325a060b570ee400010c4eccbb4a1359"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45948"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a64f2d494aaf61668dce532ba4a248a6",
+        "byte_size": 451134,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a64f2d494aaf61668dce532ba4a248a6"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45809"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "88afdfebbc04230478e37729e2b3f721",
+        "byte_size": 20736352,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "88afdfebbc04230478e37729e2b3f721"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46499"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-015/",
+        "qualified_part": [
+          {
+            "relation": "sub-015/anat/",
+            "name": "anat"
+          },
+          {
+            "relation": "sub-015/func/",
+            "name": "func"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-015/anat/",
+        "qualified_part": [
+          {
+            "relation": "88afdfebbc04230478e37729e2b3f721",
+            "name": "sub-015_T1w.nii"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e34120816cd5c0bdbcd0ad658edbba83",
+        "byte_size": 1042,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e34120816cd5c0bdbcd0ad658edbba83"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45114"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-015/func/",
+        "qualified_part": [
+          {
+            "relation": "e34120816cd5c0bdbcd0ad658edbba83",
+            "name": "sub-015_task-emotionProcessing_echo-1_bold.json"
+          },
+          {
+            "relation": "c4f4862cfe0ec835801044fdef643eb8",
+            "name": "sub-015_task-emotionProcessing_echo-1_bold.nii"
+          },
+          {
+            "relation": "da28d9f7598921b29c7c8b1cfde51760",
+            "name": "sub-015_task-emotionProcessing_echo-2_bold.json"
+          },
+          {
+            "relation": "6350675b0a5449fc341702a1e797a496",
+            "name": "sub-015_task-emotionProcessing_echo-2_bold.nii"
+          },
+          {
+            "relation": "85be727178c6906ab4191aa061d7e062",
+            "name": "sub-015_task-emotionProcessing_echo-3_bold.json"
+          },
+          {
+            "relation": "ea75db2b708aa51f91cfe0385e2e40d7",
+            "name": "sub-015_task-emotionProcessing_echo-3_bold.nii"
+          },
+          {
+            "relation": "326ca4adf81e609245fe034068456435",
+            "name": "sub-015_task-emotionProcessing_events.tsv.gz"
+          },
+          {
+            "relation": "872a7f47690c97733de490f79c640f98",
+            "name": "sub-015_task-emotionProcessingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "1955df590f59261e51b1223ac656275c",
+            "name": "sub-015_task-emotionProcessingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "a224651fde289975bbb82313bd6c150f",
+            "name": "sub-015_task-emotionProcessingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "ffcc052a264c93f46d1d92789ab31ae8",
+            "name": "sub-015_task-emotionProcessingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "cfc596e4689c6c034a6f856db2cb5b97",
+            "name": "sub-015_task-emotionProcessingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "96a0121b2b151d673be11a230c686734",
+            "name": "sub-015_task-emotionProcessingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "1c79205bc8559203086dc94a4b0bb65e",
+            "name": "sub-015_task-emotionProcessingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "3d4d62a9a2163fb86392bbf84b5f859d",
+            "name": "sub-015_task-emotionProcessingImagined_physio.json"
+          },
+          {
+            "relation": "6133d70b03c4f51c70e396973ea82385",
+            "name": "sub-015_task-emotionProcessingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "8feb93770421265f6f1661f8c6ec04ff",
+            "name": "sub-015_task-emotionProcessing_physio.json"
+          },
+          {
+            "relation": "137568dffa4ffbc20f1f6fa6f39cfe55",
+            "name": "sub-015_task-emotionProcessing_physio.tsv.gz"
+          },
+          {
+            "relation": "b89ec3da1b58f481388a5f3fcc8f4829",
+            "name": "sub-015_task-fingerTapping_echo-1_bold.json"
+          },
+          {
+            "relation": "8762710b3a1640653f95ac0be249be19",
+            "name": "sub-015_task-fingerTapping_echo-1_bold.nii"
+          },
+          {
+            "relation": "5fb29bdd93aef561498e3589cb02f3cf",
+            "name": "sub-015_task-fingerTapping_echo-2_bold.json"
+          },
+          {
+            "relation": "74c02f0a65f121ab49d411d45328e0b1",
+            "name": "sub-015_task-fingerTapping_echo-2_bold.nii"
+          },
+          {
+            "relation": "3f4552ae365c2cb7475c6c86cbf6c38e",
+            "name": "sub-015_task-fingerTapping_echo-3_bold.json"
+          },
+          {
+            "relation": "5207fe7a02f624ba589113d071dfeca6",
+            "name": "sub-015_task-fingerTapping_echo-3_bold.nii"
+          },
+          {
+            "relation": "5e35a4bc332d46f5a7a5a9c43e484528",
+            "name": "sub-015_task-fingerTapping_events.tsv.gz"
+          },
+          {
+            "relation": "1d1f6527f07c9a5e0d31945da0845d7d",
+            "name": "sub-015_task-fingerTappingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "5f68b6fb473779bdbff68a8bad9fa6b7",
+            "name": "sub-015_task-fingerTappingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "bd90e2394796a552e249cd243d132138",
+            "name": "sub-015_task-fingerTappingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "fe551edd889621ed399f7326c4226966",
+            "name": "sub-015_task-fingerTappingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "18d87d036fbfdeda251d459b3b06edfa",
+            "name": "sub-015_task-fingerTappingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "989e2e3ef6fa5bc0c0a66a160ba865b3",
+            "name": "sub-015_task-fingerTappingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "c443bfaaf23700ea97fe30cec70c288d",
+            "name": "sub-015_task-fingerTappingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "c2ddbb68d9d67c56140f6bb9010eedfc",
+            "name": "sub-015_task-fingerTappingImagined_physio.json"
+          },
+          {
+            "relation": "da35b5b1491a0f48718389a2705f281a",
+            "name": "sub-015_task-fingerTappingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "ddbfe6f792ffd8a9f2188637ea838e76",
+            "name": "sub-015_task-fingerTapping_physio.json"
+          },
+          {
+            "relation": "8193c1d45a3b81190ed3f359256b9dae",
+            "name": "sub-015_task-fingerTapping_physio.tsv.gz"
+          },
+          {
+            "relation": "b2008f846b94285f46b7ff0aa4b8116b",
+            "name": "sub-015_task-rest_run-1_echo-1_bold.json"
+          },
+          {
+            "relation": "a5264529e7bc3b589a9fd9564a809639",
+            "name": "sub-015_task-rest_run-1_echo-1_bold.nii"
+          },
+          {
+            "relation": "0fab7eb93c9cb4e9412fdf078ced4d5f",
+            "name": "sub-015_task-rest_run-1_echo-2_bold.json"
+          },
+          {
+            "relation": "f8fd22cfecbc61a942031c81077dafc3",
+            "name": "sub-015_task-rest_run-1_echo-2_bold.nii"
+          },
+          {
+            "relation": "771d2ee1db43888675efa14349f68ca0",
+            "name": "sub-015_task-rest_run-1_echo-3_bold.json"
+          },
+          {
+            "relation": "cef947dcd2cbf4567fb5189670544df5",
+            "name": "sub-015_task-rest_run-1_echo-3_bold.nii"
+          },
+          {
+            "relation": "d44f0f7ec71d61a858c1daaee5cfb10c",
+            "name": "sub-015_task-rest_run-1_physio.json"
+          },
+          {
+            "relation": "62335324d50f4057f2958b816a39ac22",
+            "name": "sub-015_task-rest_run-1_physio.tsv.gz"
+          },
+          {
+            "relation": "57e0d4362eca162d5911e2d54923d9c3",
+            "name": "sub-015_task-rest_run-2_echo-1_bold.json"
+          },
+          {
+            "relation": "d57f18c07866ce290bd12113c8eea00a",
+            "name": "sub-015_task-rest_run-2_echo-1_bold.nii"
+          },
+          {
+            "relation": "e3bacec427ab14cf578613c06c37d0e6",
+            "name": "sub-015_task-rest_run-2_echo-2_bold.json"
+          },
+          {
+            "relation": "5d3d93fc7d0c2ea6252499f8960b1723",
+            "name": "sub-015_task-rest_run-2_echo-2_bold.nii"
+          },
+          {
+            "relation": "bebbfe796e2da76a7f6690b6ab54f03a",
+            "name": "sub-015_task-rest_run-2_echo-3_bold.json"
+          },
+          {
+            "relation": "9c0d403a28c6bd3600ca21f8dc4095dc",
+            "name": "sub-015_task-rest_run-2_echo-3_bold.nii"
+          },
+          {
+            "relation": "986bbaac9424c364df4be2bda84111c2",
+            "name": "sub-015_task-rest_run-2_physio.json"
+          },
+          {
+            "relation": "ba40101046df40b0be95469ba89170f6",
+            "name": "sub-015_task-rest_run-2_physio.tsv.gz"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c4f4862cfe0ec835801044fdef643eb8",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c4f4862cfe0ec835801044fdef643eb8"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46163"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "da28d9f7598921b29c7c8b1cfde51760",
+        "byte_size": 1042,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "da28d9f7598921b29c7c8b1cfde51760"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45686"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6350675b0a5449fc341702a1e797a496",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6350675b0a5449fc341702a1e797a496"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46185"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "85be727178c6906ab4191aa061d7e062",
+        "byte_size": 1042,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "85be727178c6906ab4191aa061d7e062"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46041"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ea75db2b708aa51f91cfe0385e2e40d7",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ea75db2b708aa51f91cfe0385e2e40d7"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46251"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "326ca4adf81e609245fe034068456435",
+        "byte_size": 1880,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "326ca4adf81e609245fe034068456435"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46586"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "872a7f47690c97733de490f79c640f98",
+        "byte_size": 1050,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "872a7f47690c97733de490f79c640f98"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46146"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1955df590f59261e51b1223ac656275c",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1955df590f59261e51b1223ac656275c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46447"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a224651fde289975bbb82313bd6c150f",
+        "byte_size": 1050,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a224651fde289975bbb82313bd6c150f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45288"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ffcc052a264c93f46d1d92789ab31ae8",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ffcc052a264c93f46d1d92789ab31ae8"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46357"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "cfc596e4689c6c034a6f856db2cb5b97",
+        "byte_size": 1050,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "cfc596e4689c6c034a6f856db2cb5b97"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45853"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "96a0121b2b151d673be11a230c686734",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "96a0121b2b151d673be11a230c686734"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45478"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1c79205bc8559203086dc94a4b0bb65e",
+        "byte_size": 177,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1c79205bc8559203086dc94a4b0bb65e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46653"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "3d4d62a9a2163fb86392bbf84b5f859d",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "3d4d62a9a2163fb86392bbf84b5f859d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46362"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6133d70b03c4f51c70e396973ea82385",
+        "byte_size": 472958,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6133d70b03c4f51c70e396973ea82385"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46067"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8feb93770421265f6f1661f8c6ec04ff",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8feb93770421265f6f1661f8c6ec04ff"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45258"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "137568dffa4ffbc20f1f6fa6f39cfe55",
+        "byte_size": 539456,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "137568dffa4ffbc20f1f6fa6f39cfe55"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45573"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b89ec3da1b58f481388a5f3fcc8f4829",
+        "byte_size": 1038,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b89ec3da1b58f481388a5f3fcc8f4829"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45970"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8762710b3a1640653f95ac0be249be19",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8762710b3a1640653f95ac0be249be19"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45184"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5fb29bdd93aef561498e3589cb02f3cf",
+        "byte_size": 1038,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5fb29bdd93aef561498e3589cb02f3cf"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46429"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "74c02f0a65f121ab49d411d45328e0b1",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "74c02f0a65f121ab49d411d45328e0b1"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45815"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "3f4552ae365c2cb7475c6c86cbf6c38e",
+        "byte_size": 1038,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "3f4552ae365c2cb7475c6c86cbf6c38e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45580"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5207fe7a02f624ba589113d071dfeca6",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5207fe7a02f624ba589113d071dfeca6"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45582"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5e35a4bc332d46f5a7a5a9c43e484528",
+        "byte_size": 164,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5e35a4bc332d46f5a7a5a9c43e484528"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46603"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1d1f6527f07c9a5e0d31945da0845d7d",
+        "byte_size": 1046,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1d1f6527f07c9a5e0d31945da0845d7d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45900"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5f68b6fb473779bdbff68a8bad9fa6b7",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5f68b6fb473779bdbff68a8bad9fa6b7"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45391"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "bd90e2394796a552e249cd243d132138",
+        "byte_size": 1046,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "bd90e2394796a552e249cd243d132138"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45819"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "fe551edd889621ed399f7326c4226966",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "fe551edd889621ed399f7326c4226966"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45473"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "18d87d036fbfdeda251d459b3b06edfa",
+        "byte_size": 1046,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "18d87d036fbfdeda251d459b3b06edfa"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46118"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "989e2e3ef6fa5bc0c0a66a160ba865b3",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "989e2e3ef6fa5bc0c0a66a160ba865b3"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46388"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c443bfaaf23700ea97fe30cec70c288d",
+        "byte_size": 177,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c443bfaaf23700ea97fe30cec70c288d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46556"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c2ddbb68d9d67c56140f6bb9010eedfc",
+        "byte_size": 142,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c2ddbb68d9d67c56140f6bb9010eedfc"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45147"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "da35b5b1491a0f48718389a2705f281a",
+        "byte_size": 463339,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "da35b5b1491a0f48718389a2705f281a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45589"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ddbfe6f792ffd8a9f2188637ea838e76",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ddbfe6f792ffd8a9f2188637ea838e76"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45332"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8193c1d45a3b81190ed3f359256b9dae",
+        "byte_size": 525902,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8193c1d45a3b81190ed3f359256b9dae"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45903"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b2008f846b94285f46b7ff0aa4b8116b",
+        "byte_size": 1029,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b2008f846b94285f46b7ff0aa4b8116b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45963"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a5264529e7bc3b589a9fd9564a809639",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a5264529e7bc3b589a9fd9564a809639"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45993"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "0fab7eb93c9cb4e9412fdf078ced4d5f",
+        "byte_size": 1029,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "0fab7eb93c9cb4e9412fdf078ced4d5f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46074"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f8fd22cfecbc61a942031c81077dafc3",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f8fd22cfecbc61a942031c81077dafc3"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45583"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "771d2ee1db43888675efa14349f68ca0",
+        "byte_size": 1029,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "771d2ee1db43888675efa14349f68ca0"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45320"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "cef947dcd2cbf4567fb5189670544df5",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "cef947dcd2cbf4567fb5189670544df5"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45790"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d44f0f7ec71d61a858c1daaee5cfb10c",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d44f0f7ec71d61a858c1daaee5cfb10c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45519"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "62335324d50f4057f2958b816a39ac22",
+        "byte_size": 446679,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "62335324d50f4057f2958b816a39ac22"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45791"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "57e0d4362eca162d5911e2d54923d9c3",
+        "byte_size": 1029,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "57e0d4362eca162d5911e2d54923d9c3"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45657"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d57f18c07866ce290bd12113c8eea00a",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d57f18c07866ce290bd12113c8eea00a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45782"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e3bacec427ab14cf578613c06c37d0e6",
+        "byte_size": 1029,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e3bacec427ab14cf578613c06c37d0e6"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46145"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5d3d93fc7d0c2ea6252499f8960b1723",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5d3d93fc7d0c2ea6252499f8960b1723"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45157"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "bebbfe796e2da76a7f6690b6ab54f03a",
+        "byte_size": 1029,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "bebbfe796e2da76a7f6690b6ab54f03a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46052"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "9c0d403a28c6bd3600ca21f8dc4095dc",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "9c0d403a28c6bd3600ca21f8dc4095dc"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46343"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "986bbaac9424c364df4be2bda84111c2",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "986bbaac9424c364df4be2bda84111c2"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45439"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ba40101046df40b0be95469ba89170f6",
+        "byte_size": 459996,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ba40101046df40b0be95469ba89170f6"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45368"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "31d8026e20e90e8eb58f5c8369da33b9",
+        "byte_size": 20736352,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "31d8026e20e90e8eb58f5c8369da33b9"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45246"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-016/",
+        "qualified_part": [
+          {
+            "relation": "sub-016/anat/",
+            "name": "anat"
+          },
+          {
+            "relation": "sub-016/func/",
+            "name": "func"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-016/anat/",
+        "qualified_part": [
+          {
+            "relation": "31d8026e20e90e8eb58f5c8369da33b9",
+            "name": "sub-016_T1w.nii"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "08e8474c185376d0779ff3d59b2bff3c",
+        "byte_size": 1042,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "08e8474c185376d0779ff3d59b2bff3c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45461"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-016/func/",
+        "qualified_part": [
+          {
+            "relation": "08e8474c185376d0779ff3d59b2bff3c",
+            "name": "sub-016_task-emotionProcessing_echo-1_bold.json"
+          },
+          {
+            "relation": "b0ae1b4660b02ce44f6fe8fb2e376a8b",
+            "name": "sub-016_task-emotionProcessing_echo-1_bold.nii"
+          },
+          {
+            "relation": "ed1dee63197dd55d6e072e2f6f5405b2",
+            "name": "sub-016_task-emotionProcessing_echo-2_bold.json"
+          },
+          {
+            "relation": "80aa8e8b5b109e4a0ffff5a34a2fd34e",
+            "name": "sub-016_task-emotionProcessing_echo-2_bold.nii"
+          },
+          {
+            "relation": "38f5eaea9660539ecdd735ca35ab616e",
+            "name": "sub-016_task-emotionProcessing_echo-3_bold.json"
+          },
+          {
+            "relation": "40cb433e5c6fb302f54f6fb0e6facf33",
+            "name": "sub-016_task-emotionProcessing_echo-3_bold.nii"
+          },
+          {
+            "relation": "dac29a68dc5c3f4f2ca10ec46f11c7eb",
+            "name": "sub-016_task-emotionProcessing_events.tsv.gz"
+          },
+          {
+            "relation": "3bb868574acd187ae6e7bbef7107f316",
+            "name": "sub-016_task-emotionProcessingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "d245b1944f7c9b7a30330096fa9ea2a6",
+            "name": "sub-016_task-emotionProcessingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "5f83ec535cdd690e0e325334e30f40fc",
+            "name": "sub-016_task-emotionProcessingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "8b448020772aa64321a9523fe0afe0a8",
+            "name": "sub-016_task-emotionProcessingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "6751befbdf215f731ce2023a98546f1a",
+            "name": "sub-016_task-emotionProcessingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "f2aa0fad61d8596559792ed080af9155",
+            "name": "sub-016_task-emotionProcessingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "c759824e08e5265a576a3ed30c41c9a8",
+            "name": "sub-016_task-emotionProcessingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "7ffdf8881f8ca0fb33e3e295a0dfcbed",
+            "name": "sub-016_task-emotionProcessingImagined_physio.json"
+          },
+          {
+            "relation": "23ad5834ff7d3176559ce62569dbfdb1",
+            "name": "sub-016_task-emotionProcessingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "845c1ac8b70929f102b23512388aaae0",
+            "name": "sub-016_task-emotionProcessing_physio.json"
+          },
+          {
+            "relation": "af36d726b8fc5b7ba253e32869ca16bc",
+            "name": "sub-016_task-emotionProcessing_physio.tsv.gz"
+          },
+          {
+            "relation": "9b8c71edb5f51fd9c5fa7f4be9b6972d",
+            "name": "sub-016_task-fingerTapping_echo-1_bold.json"
+          },
+          {
+            "relation": "444724a76166a7d01752c3139a54efce",
+            "name": "sub-016_task-fingerTapping_echo-1_bold.nii"
+          },
+          {
+            "relation": "46afa05e3f9bcc5a620f9a5e877c4002",
+            "name": "sub-016_task-fingerTapping_echo-2_bold.json"
+          },
+          {
+            "relation": "424531972f2df2146e7b9f180efadd95",
+            "name": "sub-016_task-fingerTapping_echo-2_bold.nii"
+          },
+          {
+            "relation": "fac4ea384b9a185e10043873f781f607",
+            "name": "sub-016_task-fingerTapping_echo-3_bold.json"
+          },
+          {
+            "relation": "abe4380cbfbb8d05eb71d189bbc7e370",
+            "name": "sub-016_task-fingerTapping_echo-3_bold.nii"
+          },
+          {
+            "relation": "d314343e2900e7ba82ff56fdfa53e54d",
+            "name": "sub-016_task-fingerTapping_events.tsv.gz"
+          },
+          {
+            "relation": "4445e300960c70aeac5820f704add828",
+            "name": "sub-016_task-fingerTappingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "712ffd316600020031eeb25ce0ad1048",
+            "name": "sub-016_task-fingerTappingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "fa36384d47253e6f49fd1c3a84ce8ae1",
+            "name": "sub-016_task-fingerTappingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "c3d90e1a44f369ee830fbc925846242a",
+            "name": "sub-016_task-fingerTappingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "9445320d6da082a454ed1766fa19d3f5",
+            "name": "sub-016_task-fingerTappingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "c586fd28791472c2ebdc9c657ffad17b",
+            "name": "sub-016_task-fingerTappingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "cfbd687636039bc92fa556dad233fc4f",
+            "name": "sub-016_task-fingerTappingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "034768366c7e99c5ae5c7bd5d8062feb",
+            "name": "sub-016_task-fingerTappingImagined_physio.json"
+          },
+          {
+            "relation": "6438acf1576ca083bf8d44530648aa9a",
+            "name": "sub-016_task-fingerTappingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "41386e28ee5edf34ed2e10d5cf61bf41",
+            "name": "sub-016_task-fingerTapping_physio.json"
+          },
+          {
+            "relation": "6e0d586e839d86a2badb6b80926b641f",
+            "name": "sub-016_task-fingerTapping_physio.tsv.gz"
+          },
+          {
+            "relation": "48a0f7170aa013d14aeb303e3f856824",
+            "name": "sub-016_task-rest_run-1_echo-1_bold.json"
+          },
+          {
+            "relation": "f532551700f959a6b9a9b78298d8ed33",
+            "name": "sub-016_task-rest_run-1_echo-1_bold.nii"
+          },
+          {
+            "relation": "4ae0b674baa370cd8825e53f413bab2e",
+            "name": "sub-016_task-rest_run-1_echo-2_bold.json"
+          },
+          {
+            "relation": "0241c09d9cba424e36bed06f41863ccd",
+            "name": "sub-016_task-rest_run-1_echo-2_bold.nii"
+          },
+          {
+            "relation": "963cce7febb74776ab3ec1c60588a5e2",
+            "name": "sub-016_task-rest_run-1_echo-3_bold.json"
+          },
+          {
+            "relation": "655370b635f41840115b4c560492d47e",
+            "name": "sub-016_task-rest_run-1_echo-3_bold.nii"
+          },
+          {
+            "relation": "6f93d507dfb2f0e8d5f1c701e4905883",
+            "name": "sub-016_task-rest_run-1_physio.json"
+          },
+          {
+            "relation": "fcee2d47ec8682d2b225e8ab3fb9f04a",
+            "name": "sub-016_task-rest_run-1_physio.tsv.gz"
+          },
+          {
+            "relation": "84cc70775c04a49d194655df552503cc",
+            "name": "sub-016_task-rest_run-2_echo-1_bold.json"
+          },
+          {
+            "relation": "402f8627e49e317bfbe1a2cc698325e5",
+            "name": "sub-016_task-rest_run-2_echo-1_bold.nii"
+          },
+          {
+            "relation": "57434db2ad04582f7f96d8f037069076",
+            "name": "sub-016_task-rest_run-2_echo-2_bold.json"
+          },
+          {
+            "relation": "74ec0685e27a57412cb74d00d60813da",
+            "name": "sub-016_task-rest_run-2_echo-2_bold.nii"
+          },
+          {
+            "relation": "94f7316ef91ade5b966f52c68f6343a5",
+            "name": "sub-016_task-rest_run-2_echo-3_bold.json"
+          },
+          {
+            "relation": "1ac94022b69e64c4ff225f728ec49bc3",
+            "name": "sub-016_task-rest_run-2_echo-3_bold.nii"
+          },
+          {
+            "relation": "6ff54c42753602c542673831aae3e39c",
+            "name": "sub-016_task-rest_run-2_physio.json"
+          },
+          {
+            "relation": "1d6be496d3bb38563acfb4de457cca63",
+            "name": "sub-016_task-rest_run-2_physio.tsv.gz"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b0ae1b4660b02ce44f6fe8fb2e376a8b",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b0ae1b4660b02ce44f6fe8fb2e376a8b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45447"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ed1dee63197dd55d6e072e2f6f5405b2",
+        "byte_size": 1042,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ed1dee63197dd55d6e072e2f6f5405b2"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45953"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "80aa8e8b5b109e4a0ffff5a34a2fd34e",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "80aa8e8b5b109e4a0ffff5a34a2fd34e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45371"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "38f5eaea9660539ecdd735ca35ab616e",
+        "byte_size": 1042,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "38f5eaea9660539ecdd735ca35ab616e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46161"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "40cb433e5c6fb302f54f6fb0e6facf33",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "40cb433e5c6fb302f54f6fb0e6facf33"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45701"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "dac29a68dc5c3f4f2ca10ec46f11c7eb",
+        "byte_size": 1898,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "dac29a68dc5c3f4f2ca10ec46f11c7eb"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46651"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "3bb868574acd187ae6e7bbef7107f316",
+        "byte_size": 1050,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "3bb868574acd187ae6e7bbef7107f316"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45814"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d245b1944f7c9b7a30330096fa9ea2a6",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d245b1944f7c9b7a30330096fa9ea2a6"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46162"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5f83ec535cdd690e0e325334e30f40fc",
+        "byte_size": 1050,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5f83ec535cdd690e0e325334e30f40fc"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46542"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8b448020772aa64321a9523fe0afe0a8",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8b448020772aa64321a9523fe0afe0a8"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45494"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6751befbdf215f731ce2023a98546f1a",
+        "byte_size": 1050,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6751befbdf215f731ce2023a98546f1a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45325"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f2aa0fad61d8596559792ed080af9155",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f2aa0fad61d8596559792ed080af9155"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46187"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c759824e08e5265a576a3ed30c41c9a8",
+        "byte_size": 174,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c759824e08e5265a576a3ed30c41c9a8"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46585"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "7ffdf8881f8ca0fb33e3e295a0dfcbed",
+        "byte_size": 141,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "7ffdf8881f8ca0fb33e3e295a0dfcbed"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45285"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "23ad5834ff7d3176559ce62569dbfdb1",
+        "byte_size": 459585,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "23ad5834ff7d3176559ce62569dbfdb1"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46307"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "845c1ac8b70929f102b23512388aaae0",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "845c1ac8b70929f102b23512388aaae0"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46018"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "af36d726b8fc5b7ba253e32869ca16bc",
+        "byte_size": 446734,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "af36d726b8fc5b7ba253e32869ca16bc"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45169"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "9b8c71edb5f51fd9c5fa7f4be9b6972d",
+        "byte_size": 1038,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "9b8c71edb5f51fd9c5fa7f4be9b6972d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46247"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "444724a76166a7d01752c3139a54efce",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "444724a76166a7d01752c3139a54efce"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45507"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "46afa05e3f9bcc5a620f9a5e877c4002",
+        "byte_size": 1038,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "46afa05e3f9bcc5a620f9a5e877c4002"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45792"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "424531972f2df2146e7b9f180efadd95",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "424531972f2df2146e7b9f180efadd95"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46378"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "fac4ea384b9a185e10043873f781f607",
+        "byte_size": 1038,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "fac4ea384b9a185e10043873f781f607"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45844"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "abe4380cbfbb8d05eb71d189bbc7e370",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "abe4380cbfbb8d05eb71d189bbc7e370"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45744"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d314343e2900e7ba82ff56fdfa53e54d",
+        "byte_size": 165,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d314343e2900e7ba82ff56fdfa53e54d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46549"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4445e300960c70aeac5820f704add828",
+        "byte_size": 1046,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4445e300960c70aeac5820f704add828"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45581"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "712ffd316600020031eeb25ce0ad1048",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "712ffd316600020031eeb25ce0ad1048"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45586"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "fa36384d47253e6f49fd1c3a84ce8ae1",
+        "byte_size": 1046,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "fa36384d47253e6f49fd1c3a84ce8ae1"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46058"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c3d90e1a44f369ee830fbc925846242a",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c3d90e1a44f369ee830fbc925846242a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45379"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "9445320d6da082a454ed1766fa19d3f5",
+        "byte_size": 1046,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "9445320d6da082a454ed1766fa19d3f5"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45424"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c586fd28791472c2ebdc9c657ffad17b",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c586fd28791472c2ebdc9c657ffad17b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45595"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "cfbd687636039bc92fa556dad233fc4f",
+        "byte_size": 178,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "cfbd687636039bc92fa556dad233fc4f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46564"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "034768366c7e99c5ae5c7bd5d8062feb",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "034768366c7e99c5ae5c7bd5d8062feb"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45309"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6438acf1576ca083bf8d44530648aa9a",
+        "byte_size": 458214,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6438acf1576ca083bf8d44530648aa9a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46129"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "41386e28ee5edf34ed2e10d5cf61bf41",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "41386e28ee5edf34ed2e10d5cf61bf41"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45924"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6e0d586e839d86a2badb6b80926b641f",
+        "byte_size": 372090,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6e0d586e839d86a2badb6b80926b641f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45695"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "48a0f7170aa013d14aeb303e3f856824",
+        "byte_size": 1029,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "48a0f7170aa013d14aeb303e3f856824"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45793"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f532551700f959a6b9a9b78298d8ed33",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f532551700f959a6b9a9b78298d8ed33"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46004"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4ae0b674baa370cd8825e53f413bab2e",
+        "byte_size": 1029,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4ae0b674baa370cd8825e53f413bab2e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46355"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "0241c09d9cba424e36bed06f41863ccd",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "0241c09d9cba424e36bed06f41863ccd"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45901"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "963cce7febb74776ab3ec1c60588a5e2",
+        "byte_size": 1029,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "963cce7febb74776ab3ec1c60588a5e2"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46522"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "655370b635f41840115b4c560492d47e",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "655370b635f41840115b4c560492d47e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46224"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6f93d507dfb2f0e8d5f1c701e4905883",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6f93d507dfb2f0e8d5f1c701e4905883"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46241"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "fcee2d47ec8682d2b225e8ab3fb9f04a",
+        "byte_size": 430389,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "fcee2d47ec8682d2b225e8ab3fb9f04a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46289"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "84cc70775c04a49d194655df552503cc",
+        "byte_size": 1029,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "84cc70775c04a49d194655df552503cc"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45370"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "402f8627e49e317bfbe1a2cc698325e5",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "402f8627e49e317bfbe1a2cc698325e5"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45523"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "57434db2ad04582f7f96d8f037069076",
+        "byte_size": 1029,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "57434db2ad04582f7f96d8f037069076"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45172"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "74ec0685e27a57412cb74d00d60813da",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "74ec0685e27a57412cb74d00d60813da"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45560"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "94f7316ef91ade5b966f52c68f6343a5",
+        "byte_size": 1029,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "94f7316ef91ade5b966f52c68f6343a5"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45895"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1ac94022b69e64c4ff225f728ec49bc3",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1ac94022b69e64c4ff225f728ec49bc3"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45162"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6ff54c42753602c542673831aae3e39c",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6ff54c42753602c542673831aae3e39c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46368"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1d6be496d3bb38563acfb4de457cca63",
+        "byte_size": 462641,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1d6be496d3bb38563acfb4de457cca63"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46320"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8a31ce74ffb3bb8218e54828ce1bb7bc",
+        "byte_size": 20736352,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8a31ce74ffb3bb8218e54828ce1bb7bc"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46093"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-017/",
+        "qualified_part": [
+          {
+            "relation": "sub-017/anat/",
+            "name": "anat"
+          },
+          {
+            "relation": "sub-017/func/",
+            "name": "func"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-017/anat/",
+        "qualified_part": [
+          {
+            "relation": "8a31ce74ffb3bb8218e54828ce1bb7bc",
+            "name": "sub-017_T1w.nii"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f0eff72e0e7149911dac1674911c0a53",
+        "byte_size": 1039,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f0eff72e0e7149911dac1674911c0a53"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46090"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-017/func/",
+        "qualified_part": [
+          {
+            "relation": "f0eff72e0e7149911dac1674911c0a53",
+            "name": "sub-017_task-emotionProcessing_echo-1_bold.json"
+          },
+          {
+            "relation": "49bd6392aabdd13fb1f061d584fdfc5d",
+            "name": "sub-017_task-emotionProcessing_echo-1_bold.nii"
+          },
+          {
+            "relation": "c6792ff5c1c23b3515f3f1f9302baf75",
+            "name": "sub-017_task-emotionProcessing_echo-2_bold.json"
+          },
+          {
+            "relation": "cfb6e06f72ecb8eabf9cd409edaeaf93",
+            "name": "sub-017_task-emotionProcessing_echo-2_bold.nii"
+          },
+          {
+            "relation": "a528b89b95b3f3128e8e98a9237edc64",
+            "name": "sub-017_task-emotionProcessing_echo-3_bold.json"
+          },
+          {
+            "relation": "6f919d3a07df2b44ee4ebf59a04eefad",
+            "name": "sub-017_task-emotionProcessing_echo-3_bold.nii"
+          },
+          {
+            "relation": "512913b1b38ca0f4202f6ca3c3605ab7",
+            "name": "sub-017_task-emotionProcessing_events.tsv.gz"
+          },
+          {
+            "relation": "35681199bfc3e571aae5477ce1191bf3",
+            "name": "sub-017_task-emotionProcessingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "246521bd5001db167861cf5da9c9468e",
+            "name": "sub-017_task-emotionProcessingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "cd5b275b00155c6655e6163dc9563bac",
+            "name": "sub-017_task-emotionProcessingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "193cb8ecc6cd158d8ecd4764aeba0b02",
+            "name": "sub-017_task-emotionProcessingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "f4c03ab759da66ffb6774913e4bf6c70",
+            "name": "sub-017_task-emotionProcessingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "e1f5d15b62dde1cde99e429788d7be0e",
+            "name": "sub-017_task-emotionProcessingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "782ccc689087c2d7ebbac8acd4770997",
+            "name": "sub-017_task-emotionProcessingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "d09ab3c66bdfca4f24ca0495469c9b78",
+            "name": "sub-017_task-emotionProcessingImagined_physio.json"
+          },
+          {
+            "relation": "6a2527bd9a7c8b613cef15d92020f475",
+            "name": "sub-017_task-emotionProcessingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "5ab56953069930dde62e936cca3bb403",
+            "name": "sub-017_task-emotionProcessing_physio.json"
+          },
+          {
+            "relation": "d2d2f6899051f0b2703084793376566a",
+            "name": "sub-017_task-emotionProcessing_physio.tsv.gz"
+          },
+          {
+            "relation": "a81c54ce06347f213b53121dae0893cb",
+            "name": "sub-017_task-fingerTapping_echo-1_bold.json"
+          },
+          {
+            "relation": "a3ae572c8c08c4f4439aedc929b2f764",
+            "name": "sub-017_task-fingerTapping_echo-1_bold.nii"
+          },
+          {
+            "relation": "1fae2f3de9799c2f5453c2fd7f1eb6b7",
+            "name": "sub-017_task-fingerTapping_echo-2_bold.json"
+          },
+          {
+            "relation": "91a3a7af3f8746d109626c0abe9047ac",
+            "name": "sub-017_task-fingerTapping_echo-2_bold.nii"
+          },
+          {
+            "relation": "21a1213eceb3fa03b239b84a2ee553b9",
+            "name": "sub-017_task-fingerTapping_echo-3_bold.json"
+          },
+          {
+            "relation": "05142b0bacff1ab7da64ebfcb73bae03",
+            "name": "sub-017_task-fingerTapping_echo-3_bold.nii"
+          },
+          {
+            "relation": "f0f48d05413226bdc642faef1aa666ff",
+            "name": "sub-017_task-fingerTapping_events.tsv.gz"
+          },
+          {
+            "relation": "476d04c8a39a356361311baa48b3d47f",
+            "name": "sub-017_task-fingerTappingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "39110bab63dc3d41f3d09c1b5a5e6dd8",
+            "name": "sub-017_task-fingerTappingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "27e9d3e5020feb7b3c45f290447b72da",
+            "name": "sub-017_task-fingerTappingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "f0b062a4383267f9392126b8ded03250",
+            "name": "sub-017_task-fingerTappingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "640d68482d7ca776db7d8ffd20c710f5",
+            "name": "sub-017_task-fingerTappingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "66f1619b1ba2e9eda4749c3aef4b552b",
+            "name": "sub-017_task-fingerTappingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "a98da27e0755ccefd4d98a77debc5e5f",
+            "name": "sub-017_task-fingerTappingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "294a3c8ca8bfd7441b17a63378592daa",
+            "name": "sub-017_task-fingerTappingImagined_physio.json"
+          },
+          {
+            "relation": "46290d9393671049db251e3435e4aeef",
+            "name": "sub-017_task-fingerTappingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "a3342ebda0beb4502ce9c9dd5ab527d6",
+            "name": "sub-017_task-fingerTapping_physio.json"
+          },
+          {
+            "relation": "6d23e1674aa125506ca24aa173282614",
+            "name": "sub-017_task-fingerTapping_physio.tsv.gz"
+          },
+          {
+            "relation": "ea2c4f2379ca18e87ea3f6d52b0568e9",
+            "name": "sub-017_task-rest_run-1_echo-1_bold.json"
+          },
+          {
+            "relation": "dd1fd2df29e32a6ea212fe640e375a39",
+            "name": "sub-017_task-rest_run-1_echo-1_bold.nii"
+          },
+          {
+            "relation": "c1da6b603a1c3d11ff9cff5e78690a6e",
+            "name": "sub-017_task-rest_run-1_echo-2_bold.json"
+          },
+          {
+            "relation": "baf772ab2471f417131cb7e9dda728f8",
+            "name": "sub-017_task-rest_run-1_echo-2_bold.nii"
+          },
+          {
+            "relation": "3a7f850a5b7f3465ae0c623be38910ec",
+            "name": "sub-017_task-rest_run-1_echo-3_bold.json"
+          },
+          {
+            "relation": "a2a7e7eb3bcdf8a867ce1b99b653c4b9",
+            "name": "sub-017_task-rest_run-1_echo-3_bold.nii"
+          },
+          {
+            "relation": "e8f482f7e7732c656de46ba094f00b71",
+            "name": "sub-017_task-rest_run-1_physio.json"
+          },
+          {
+            "relation": "78267cb7d6e83c76d9c0f993e3925f14",
+            "name": "sub-017_task-rest_run-1_physio.tsv.gz"
+          },
+          {
+            "relation": "20f75958d0053920cb12a8e5d594fc8c",
+            "name": "sub-017_task-rest_run-2_echo-1_bold.json"
+          },
+          {
+            "relation": "448b7a0ec38d72fce9923dfa86c90c74",
+            "name": "sub-017_task-rest_run-2_echo-1_bold.nii"
+          },
+          {
+            "relation": "ac5b05347c7c89c81616416a4d599159",
+            "name": "sub-017_task-rest_run-2_echo-2_bold.json"
+          },
+          {
+            "relation": "1a9aebad3a6c4790cbd335d657be9fb8",
+            "name": "sub-017_task-rest_run-2_echo-2_bold.nii"
+          },
+          {
+            "relation": "ab14d28bb0b0111dcbd82e34a685f0c9",
+            "name": "sub-017_task-rest_run-2_echo-3_bold.json"
+          },
+          {
+            "relation": "4699b14b4d1fc69be7e5753b10b4eb8a",
+            "name": "sub-017_task-rest_run-2_echo-3_bold.nii"
+          },
+          {
+            "relation": "36c47f48e263ca8084edd851e612d302",
+            "name": "sub-017_task-rest_run-2_physio.json"
+          },
+          {
+            "relation": "b5790975f1314dc05b060076a288be5d",
+            "name": "sub-017_task-rest_run-2_physio.tsv.gz"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "49bd6392aabdd13fb1f061d584fdfc5d",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "49bd6392aabdd13fb1f061d584fdfc5d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46395"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c6792ff5c1c23b3515f3f1f9302baf75",
+        "byte_size": 1039,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c6792ff5c1c23b3515f3f1f9302baf75"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46324"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "cfb6e06f72ecb8eabf9cd409edaeaf93",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "cfb6e06f72ecb8eabf9cd409edaeaf93"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45754"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a528b89b95b3f3128e8e98a9237edc64",
+        "byte_size": 1039,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a528b89b95b3f3128e8e98a9237edc64"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45454"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6f919d3a07df2b44ee4ebf59a04eefad",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6f919d3a07df2b44ee4ebf59a04eefad"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45336"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "512913b1b38ca0f4202f6ca3c3605ab7",
+        "byte_size": 1896,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "512913b1b38ca0f4202f6ca3c3605ab7"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46557"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "35681199bfc3e571aae5477ce1191bf3",
+        "byte_size": 1047,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "35681199bfc3e571aae5477ce1191bf3"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46269"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "246521bd5001db167861cf5da9c9468e",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "246521bd5001db167861cf5da9c9468e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45687"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "cd5b275b00155c6655e6163dc9563bac",
+        "byte_size": 1047,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "cd5b275b00155c6655e6163dc9563bac"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45243"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "193cb8ecc6cd158d8ecd4764aeba0b02",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "193cb8ecc6cd158d8ecd4764aeba0b02"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46113"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f4c03ab759da66ffb6774913e4bf6c70",
+        "byte_size": 1047,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f4c03ab759da66ffb6774913e4bf6c70"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45935"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e1f5d15b62dde1cde99e429788d7be0e",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e1f5d15b62dde1cde99e429788d7be0e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45362"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "782ccc689087c2d7ebbac8acd4770997",
+        "byte_size": 175,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "782ccc689087c2d7ebbac8acd4770997"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46561"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d09ab3c66bdfca4f24ca0495469c9b78",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d09ab3c66bdfca4f24ca0495469c9b78"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46165"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6a2527bd9a7c8b613cef15d92020f475",
+        "byte_size": 473929,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6a2527bd9a7c8b613cef15d92020f475"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46168"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5ab56953069930dde62e936cca3bb403",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5ab56953069930dde62e936cca3bb403"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45735"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d2d2f6899051f0b2703084793376566a",
+        "byte_size": 499951,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d2d2f6899051f0b2703084793376566a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45445"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a81c54ce06347f213b53121dae0893cb",
+        "byte_size": 1035,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a81c54ce06347f213b53121dae0893cb"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45678"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a3ae572c8c08c4f4439aedc929b2f764",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a3ae572c8c08c4f4439aedc929b2f764"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45804"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1fae2f3de9799c2f5453c2fd7f1eb6b7",
+        "byte_size": 1035,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1fae2f3de9799c2f5453c2fd7f1eb6b7"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45440"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "91a3a7af3f8746d109626c0abe9047ac",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "91a3a7af3f8746d109626c0abe9047ac"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45350"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "21a1213eceb3fa03b239b84a2ee553b9",
+        "byte_size": 1035,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "21a1213eceb3fa03b239b84a2ee553b9"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45344"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "05142b0bacff1ab7da64ebfcb73bae03",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "05142b0bacff1ab7da64ebfcb73bae03"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46186"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f0f48d05413226bdc642faef1aa666ff",
+        "byte_size": 161,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f0f48d05413226bdc642faef1aa666ff"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46571"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "476d04c8a39a356361311baa48b3d47f",
+        "byte_size": 1043,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "476d04c8a39a356361311baa48b3d47f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46078"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "39110bab63dc3d41f3d09c1b5a5e6dd8",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "39110bab63dc3d41f3d09c1b5a5e6dd8"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45591"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "27e9d3e5020feb7b3c45f290447b72da",
+        "byte_size": 1043,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "27e9d3e5020feb7b3c45f290447b72da"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46274"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f0b062a4383267f9392126b8ded03250",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f0b062a4383267f9392126b8ded03250"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46407"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "640d68482d7ca776db7d8ffd20c710f5",
+        "byte_size": 1043,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "640d68482d7ca776db7d8ffd20c710f5"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45626"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "66f1619b1ba2e9eda4749c3aef4b552b",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "66f1619b1ba2e9eda4749c3aef4b552b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45550"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a98da27e0755ccefd4d98a77debc5e5f",
+        "byte_size": 176,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a98da27e0755ccefd4d98a77debc5e5f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46621"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "294a3c8ca8bfd7441b17a63378592daa",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "294a3c8ca8bfd7441b17a63378592daa"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45799"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "46290d9393671049db251e3435e4aeef",
+        "byte_size": 460894,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "46290d9393671049db251e3435e4aeef"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46012"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a3342ebda0beb4502ce9c9dd5ab527d6",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a3342ebda0beb4502ce9c9dd5ab527d6"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46160"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6d23e1674aa125506ca24aa173282614",
+        "byte_size": 495881,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6d23e1674aa125506ca24aa173282614"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46344"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ea2c4f2379ca18e87ea3f6d52b0568e9",
+        "byte_size": 1024,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ea2c4f2379ca18e87ea3f6d52b0568e9"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45137"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "dd1fd2df29e32a6ea212fe640e375a39",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "dd1fd2df29e32a6ea212fe640e375a39"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45140"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c1da6b603a1c3d11ff9cff5e78690a6e",
+        "byte_size": 1024,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c1da6b603a1c3d11ff9cff5e78690a6e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45611"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "baf772ab2471f417131cb7e9dda728f8",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "baf772ab2471f417131cb7e9dda728f8"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46306"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "3a7f850a5b7f3465ae0c623be38910ec",
+        "byte_size": 1024,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "3a7f850a5b7f3465ae0c623be38910ec"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45097"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a2a7e7eb3bcdf8a867ce1b99b653c4b9",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a2a7e7eb3bcdf8a867ce1b99b653c4b9"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46466"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e8f482f7e7732c656de46ba094f00b71",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e8f482f7e7732c656de46ba094f00b71"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46250"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "78267cb7d6e83c76d9c0f993e3925f14",
+        "byte_size": 456750,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "78267cb7d6e83c76d9c0f993e3925f14"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45691"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "20f75958d0053920cb12a8e5d594fc8c",
+        "byte_size": 1026,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "20f75958d0053920cb12a8e5d594fc8c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46253"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "448b7a0ec38d72fce9923dfa86c90c74",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "448b7a0ec38d72fce9923dfa86c90c74"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46485"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ac5b05347c7c89c81616416a4d599159",
+        "byte_size": 1026,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ac5b05347c7c89c81616416a4d599159"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46315"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1a9aebad3a6c4790cbd335d657be9fb8",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1a9aebad3a6c4790cbd335d657be9fb8"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45905"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ab14d28bb0b0111dcbd82e34a685f0c9",
+        "byte_size": 1026,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ab14d28bb0b0111dcbd82e34a685f0c9"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45665"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4699b14b4d1fc69be7e5753b10b4eb8a",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4699b14b4d1fc69be7e5753b10b4eb8a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45364"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "36c47f48e263ca8084edd851e612d302",
+        "byte_size": 142,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "36c47f48e263ca8084edd851e612d302"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46523"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b5790975f1314dc05b060076a288be5d",
+        "byte_size": 464147,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b5790975f1314dc05b060076a288be5d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45820"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "0562eacf5cf688fece5bb99d1bf11d7a",
+        "byte_size": 20736352,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "0562eacf5cf688fece5bb99d1bf11d7a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46477"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-018/",
+        "qualified_part": [
+          {
+            "relation": "sub-018/anat/",
+            "name": "anat"
+          },
+          {
+            "relation": "sub-018/func/",
+            "name": "func"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-018/anat/",
+        "qualified_part": [
+          {
+            "relation": "0562eacf5cf688fece5bb99d1bf11d7a",
+            "name": "sub-018_T1w.nii"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c3469a90251c21df2cd808f4ab158b5e",
+        "byte_size": 1042,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c3469a90251c21df2cd808f4ab158b5e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46027"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-018/func/",
+        "qualified_part": [
+          {
+            "relation": "c3469a90251c21df2cd808f4ab158b5e",
+            "name": "sub-018_task-emotionProcessing_echo-1_bold.json"
+          },
+          {
+            "relation": "10c530a30235ce16ca1f242f1741bf84",
+            "name": "sub-018_task-emotionProcessing_echo-1_bold.nii"
+          },
+          {
+            "relation": "9083871e42e383818f0153139602bcbe",
+            "name": "sub-018_task-emotionProcessing_echo-2_bold.json"
+          },
+          {
+            "relation": "e9fceab854c3d0cdbfc49f0ca87636a0",
+            "name": "sub-018_task-emotionProcessing_echo-2_bold.nii"
+          },
+          {
+            "relation": "81812dbee74b11f9eb9ec34ed2267291",
+            "name": "sub-018_task-emotionProcessing_echo-3_bold.json"
+          },
+          {
+            "relation": "b1182ef00fe01573f3673946877fbdd4",
+            "name": "sub-018_task-emotionProcessing_echo-3_bold.nii"
+          },
+          {
+            "relation": "94ab76b693f38ad49ee5371a27ab6276",
+            "name": "sub-018_task-emotionProcessing_events.tsv.gz"
+          },
+          {
+            "relation": "2160787763f6b9fbc2ae28d843f31279",
+            "name": "sub-018_task-emotionProcessingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "4df238d58b3bb698ce1be59503355897",
+            "name": "sub-018_task-emotionProcessingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "62d008dae0c8adfbe27eb46a087c4b8c",
+            "name": "sub-018_task-emotionProcessingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "5a9413d4da22e50224287e8e96d41810",
+            "name": "sub-018_task-emotionProcessingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "c409998196cb9a5131a63402444232ac",
+            "name": "sub-018_task-emotionProcessingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "6a73e734759a10f82ff828482fe2d084",
+            "name": "sub-018_task-emotionProcessingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "743a87b2467a7337dfb6390668a1eee7",
+            "name": "sub-018_task-emotionProcessingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "ec52dc6c7e742e9080a469c814e936e3",
+            "name": "sub-018_task-emotionProcessingImagined_physio.json"
+          },
+          {
+            "relation": "9f32c8d0c82ebe7a4c7c2f3ed1964bb3",
+            "name": "sub-018_task-emotionProcessingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "2aafbcf919a4ecd3813d471678b194e8",
+            "name": "sub-018_task-emotionProcessing_physio.json"
+          },
+          {
+            "relation": "4a6ecece2df4de53f22b90facf70accf",
+            "name": "sub-018_task-emotionProcessing_physio.tsv.gz"
+          },
+          {
+            "relation": "e423c29e0444e827b1811bd8fd595528",
+            "name": "sub-018_task-fingerTapping_echo-1_bold.json"
+          },
+          {
+            "relation": "f929fad9fa89daa7375f57c988e29302",
+            "name": "sub-018_task-fingerTapping_echo-1_bold.nii"
+          },
+          {
+            "relation": "861a3cd2e3a4fa2c191e262cabbbdef6",
+            "name": "sub-018_task-fingerTapping_echo-2_bold.json"
+          },
+          {
+            "relation": "27c2135927b49179019bcf61804f45bf",
+            "name": "sub-018_task-fingerTapping_echo-2_bold.nii"
+          },
+          {
+            "relation": "d1e95a770e7b00f4cf23bfeed927ae4f",
+            "name": "sub-018_task-fingerTapping_echo-3_bold.json"
+          },
+          {
+            "relation": "b94d5b9fb36479ec1f67582d78d07229",
+            "name": "sub-018_task-fingerTapping_echo-3_bold.nii"
+          },
+          {
+            "relation": "e0f507974252817e79c9fbe4879847f0",
+            "name": "sub-018_task-fingerTapping_events.tsv.gz"
+          },
+          {
+            "relation": "ced4090a09793017f415eebed9b3bc01",
+            "name": "sub-018_task-fingerTappingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "abf2229dc1c0186c3c24b9f198142407",
+            "name": "sub-018_task-fingerTappingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "09962b2c547b21ae031f3e440bd2f60c",
+            "name": "sub-018_task-fingerTappingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "4f3444ad5223f1996fbd107349c95486",
+            "name": "sub-018_task-fingerTappingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "7bac8f37bec0dc4e0aab226b5edbf4c6",
+            "name": "sub-018_task-fingerTappingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "071183c6163bdbf82510bcee1592c3ff",
+            "name": "sub-018_task-fingerTappingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "a92cd802a259c806053f2408c3a9ced7",
+            "name": "sub-018_task-fingerTappingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "f8fba2227070030bfad34288122cfe9d",
+            "name": "sub-018_task-fingerTappingImagined_physio.json"
+          },
+          {
+            "relation": "743e580636625b4cd29911bdb803dda6",
+            "name": "sub-018_task-fingerTappingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "aec3e1ac31432db849b7b97677b140e4",
+            "name": "sub-018_task-fingerTapping_physio.json"
+          },
+          {
+            "relation": "bf9f8ed0e10c83d504f6b6ec5e565021",
+            "name": "sub-018_task-fingerTapping_physio.tsv.gz"
+          },
+          {
+            "relation": "582d335a6f1ff0292b253b6b7f7ac70f",
+            "name": "sub-018_task-rest_run-1_echo-1_bold.json"
+          },
+          {
+            "relation": "65f53aa192dcf0cfdb39272e50b4cd41",
+            "name": "sub-018_task-rest_run-1_echo-1_bold.nii"
+          },
+          {
+            "relation": "639e135352fd3dc65180f8741ddca7a5",
+            "name": "sub-018_task-rest_run-1_echo-2_bold.json"
+          },
+          {
+            "relation": "34704cd69f8ffe219490b9b8ac489bee",
+            "name": "sub-018_task-rest_run-1_echo-2_bold.nii"
+          },
+          {
+            "relation": "fd5f69e655165421934afcb46d6d9ab7",
+            "name": "sub-018_task-rest_run-1_echo-3_bold.json"
+          },
+          {
+            "relation": "205ddb41c3fb0f6a75248fde2596ef9f",
+            "name": "sub-018_task-rest_run-1_echo-3_bold.nii"
+          },
+          {
+            "relation": "fa48a2a92f511b5b2bf86f89eff447ea",
+            "name": "sub-018_task-rest_run-1_physio.json"
+          },
+          {
+            "relation": "e6cd780a202753329df22e92906086ea",
+            "name": "sub-018_task-rest_run-1_physio.tsv.gz"
+          },
+          {
+            "relation": "9dd4558b268c0f1e51654984a9817602",
+            "name": "sub-018_task-rest_run-2_echo-1_bold.json"
+          },
+          {
+            "relation": "dbda73c0db2c05ab9afc6d3bd7145618",
+            "name": "sub-018_task-rest_run-2_echo-1_bold.nii"
+          },
+          {
+            "relation": "f1dca01b8dd106ea30e379432867b265",
+            "name": "sub-018_task-rest_run-2_echo-2_bold.json"
+          },
+          {
+            "relation": "8dcf40fa74d8d71fb5d04eddae09f246",
+            "name": "sub-018_task-rest_run-2_echo-2_bold.nii"
+          },
+          {
+            "relation": "7f32563d7e6d8f41efba1a2f2ffe2484",
+            "name": "sub-018_task-rest_run-2_echo-3_bold.json"
+          },
+          {
+            "relation": "28467ebfdcf77caaa83d407fe31c7464",
+            "name": "sub-018_task-rest_run-2_echo-3_bold.nii"
+          },
+          {
+            "relation": "fd2778d2800a21e39b4561327eecb5ce",
+            "name": "sub-018_task-rest_run-2_physio.json"
+          },
+          {
+            "relation": "2b4b5e1520eea448d3df546544a719e7",
+            "name": "sub-018_task-rest_run-2_physio.tsv.gz"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "10c530a30235ce16ca1f242f1741bf84",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "10c530a30235ce16ca1f242f1741bf84"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46143"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "9083871e42e383818f0153139602bcbe",
+        "byte_size": 1042,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "9083871e42e383818f0153139602bcbe"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46243"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e9fceab854c3d0cdbfc49f0ca87636a0",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e9fceab854c3d0cdbfc49f0ca87636a0"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46498"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "81812dbee74b11f9eb9ec34ed2267291",
+        "byte_size": 1042,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "81812dbee74b11f9eb9ec34ed2267291"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45295"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b1182ef00fe01573f3673946877fbdd4",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b1182ef00fe01573f3673946877fbdd4"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45547"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "94ab76b693f38ad49ee5371a27ab6276",
+        "byte_size": 1936,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "94ab76b693f38ad49ee5371a27ab6276"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46558"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2160787763f6b9fbc2ae28d843f31279",
+        "byte_size": 1051,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2160787763f6b9fbc2ae28d843f31279"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46416"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4df238d58b3bb698ce1be59503355897",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4df238d58b3bb698ce1be59503355897"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45962"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "62d008dae0c8adfbe27eb46a087c4b8c",
+        "byte_size": 1051,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "62d008dae0c8adfbe27eb46a087c4b8c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45122"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5a9413d4da22e50224287e8e96d41810",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5a9413d4da22e50224287e8e96d41810"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46527"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c409998196cb9a5131a63402444232ac",
+        "byte_size": 1051,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c409998196cb9a5131a63402444232ac"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45774"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6a73e734759a10f82ff828482fe2d084",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6a73e734759a10f82ff828482fe2d084"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45101"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "743a87b2467a7337dfb6390668a1eee7",
+        "byte_size": 178,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "743a87b2467a7337dfb6390668a1eee7"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46550"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ec52dc6c7e742e9080a469c814e936e3",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ec52dc6c7e742e9080a469c814e936e3"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45479"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "9f32c8d0c82ebe7a4c7c2f3ed1964bb3",
+        "byte_size": 477438,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "9f32c8d0c82ebe7a4c7c2f3ed1964bb3"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45552"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2aafbcf919a4ecd3813d471678b194e8",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2aafbcf919a4ecd3813d471678b194e8"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45173"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4a6ecece2df4de53f22b90facf70accf",
+        "byte_size": 643344,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4a6ecece2df4de53f22b90facf70accf"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45703"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e423c29e0444e827b1811bd8fd595528",
+        "byte_size": 1039,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e423c29e0444e827b1811bd8fd595528"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46195"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f929fad9fa89daa7375f57c988e29302",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f929fad9fa89daa7375f57c988e29302"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45261"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "861a3cd2e3a4fa2c191e262cabbbdef6",
+        "byte_size": 1039,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "861a3cd2e3a4fa2c191e262cabbbdef6"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45233"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "27c2135927b49179019bcf61804f45bf",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "27c2135927b49179019bcf61804f45bf"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45747"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d1e95a770e7b00f4cf23bfeed927ae4f",
+        "byte_size": 1039,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d1e95a770e7b00f4cf23bfeed927ae4f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45409"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b94d5b9fb36479ec1f67582d78d07229",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b94d5b9fb36479ec1f67582d78d07229"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45302"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e0f507974252817e79c9fbe4879847f0",
+        "byte_size": 167,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e0f507974252817e79c9fbe4879847f0"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46655"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ced4090a09793017f415eebed9b3bc01",
+        "byte_size": 1047,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ced4090a09793017f415eebed9b3bc01"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45428"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "abf2229dc1c0186c3c24b9f198142407",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "abf2229dc1c0186c3c24b9f198142407"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45188"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "09962b2c547b21ae031f3e440bd2f60c",
+        "byte_size": 1047,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "09962b2c547b21ae031f3e440bd2f60c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45745"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4f3444ad5223f1996fbd107349c95486",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4f3444ad5223f1996fbd107349c95486"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46038"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "7bac8f37bec0dc4e0aab226b5edbf4c6",
+        "byte_size": 1047,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "7bac8f37bec0dc4e0aab226b5edbf4c6"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45426"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "071183c6163bdbf82510bcee1592c3ff",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "071183c6163bdbf82510bcee1592c3ff"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46069"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a92cd802a259c806053f2408c3a9ced7",
+        "byte_size": 179,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a92cd802a259c806053f2408c3a9ced7"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46602"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f8fba2227070030bfad34288122cfe9d",
+        "byte_size": 142,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f8fba2227070030bfad34288122cfe9d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46138"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "743e580636625b4cd29911bdb803dda6",
+        "byte_size": 474630,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "743e580636625b4cd29911bdb803dda6"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46442"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "aec3e1ac31432db849b7b97677b140e4",
+        "byte_size": 142,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "aec3e1ac31432db849b7b97677b140e4"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46322"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "bf9f8ed0e10c83d504f6b6ec5e565021",
+        "byte_size": 513523,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "bf9f8ed0e10c83d504f6b6ec5e565021"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45579"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "582d335a6f1ff0292b253b6b7f7ac70f",
+        "byte_size": 1030,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "582d335a6f1ff0292b253b6b7f7ac70f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46263"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "65f53aa192dcf0cfdb39272e50b4cd41",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "65f53aa192dcf0cfdb39272e50b4cd41"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45916"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "639e135352fd3dc65180f8741ddca7a5",
+        "byte_size": 1030,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "639e135352fd3dc65180f8741ddca7a5"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45923"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "34704cd69f8ffe219490b9b8ac489bee",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "34704cd69f8ffe219490b9b8ac489bee"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45123"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "fd5f69e655165421934afcb46d6d9ab7",
+        "byte_size": 1030,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "fd5f69e655165421934afcb46d6d9ab7"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46188"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "205ddb41c3fb0f6a75248fde2596ef9f",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "205ddb41c3fb0f6a75248fde2596ef9f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46228"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "fa48a2a92f511b5b2bf86f89eff447ea",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "fa48a2a92f511b5b2bf86f89eff447ea"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46339"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e6cd780a202753329df22e92906086ea",
+        "byte_size": 456499,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e6cd780a202753329df22e92906086ea"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45175"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "9dd4558b268c0f1e51654984a9817602",
+        "byte_size": 1030,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "9dd4558b268c0f1e51654984a9817602"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45961"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "dbda73c0db2c05ab9afc6d3bd7145618",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "dbda73c0db2c05ab9afc6d3bd7145618"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46513"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f1dca01b8dd106ea30e379432867b265",
+        "byte_size": 1030,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f1dca01b8dd106ea30e379432867b265"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45557"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8dcf40fa74d8d71fb5d04eddae09f246",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8dcf40fa74d8d71fb5d04eddae09f246"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45376"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "7f32563d7e6d8f41efba1a2f2ffe2484",
+        "byte_size": 1030,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "7f32563d7e6d8f41efba1a2f2ffe2484"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46365"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "28467ebfdcf77caaa83d407fe31c7464",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "28467ebfdcf77caaa83d407fe31c7464"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46249"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "fd2778d2800a21e39b4561327eecb5ce",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "fd2778d2800a21e39b4561327eecb5ce"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45676"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2b4b5e1520eea448d3df546544a719e7",
+        "byte_size": 462069,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2b4b5e1520eea448d3df546544a719e7"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45199"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2f4fa393be40ddc00c27a138b5f7fd48",
+        "byte_size": 20736352,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2f4fa393be40ddc00c27a138b5f7fd48"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46125"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-019/",
+        "qualified_part": [
+          {
+            "relation": "sub-019/anat/",
+            "name": "anat"
+          },
+          {
+            "relation": "sub-019/func/",
+            "name": "func"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-019/anat/",
+        "qualified_part": [
+          {
+            "relation": "2f4fa393be40ddc00c27a138b5f7fd48",
+            "name": "sub-019_T1w.nii"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "26489abd8ee555b1de70af69095875e5",
+        "byte_size": 1038,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "26489abd8ee555b1de70af69095875e5"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45859"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-019/func/",
+        "qualified_part": [
+          {
+            "relation": "26489abd8ee555b1de70af69095875e5",
+            "name": "sub-019_task-emotionProcessing_echo-1_bold.json"
+          },
+          {
+            "relation": "6aa733780d6bf9addd4ea3d05ed51924",
+            "name": "sub-019_task-emotionProcessing_echo-1_bold.nii"
+          },
+          {
+            "relation": "11c9a5133067418baba05651e4e6d53b",
+            "name": "sub-019_task-emotionProcessing_echo-2_bold.json"
+          },
+          {
+            "relation": "1855f130ac422e998e659ac0386e8ede",
+            "name": "sub-019_task-emotionProcessing_echo-2_bold.nii"
+          },
+          {
+            "relation": "d19eb8cedec51262e5eb75d2785fca6a",
+            "name": "sub-019_task-emotionProcessing_echo-3_bold.json"
+          },
+          {
+            "relation": "08ca55e4d2fd91fc5b15a22b732938a3",
+            "name": "sub-019_task-emotionProcessing_echo-3_bold.nii"
+          },
+          {
+            "relation": "bb5add688ff56a82bbca17a6eb55e7ca",
+            "name": "sub-019_task-emotionProcessing_events.tsv.gz"
+          },
+          {
+            "relation": "b1a3e5cb27a2636734ba18ce531d9248",
+            "name": "sub-019_task-emotionProcessingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "ee1d6e2cb43a658f018f3cee66691205",
+            "name": "sub-019_task-emotionProcessingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "cc8b80c64786026ecdb401d835b6c2ea",
+            "name": "sub-019_task-emotionProcessingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "07e6633e94e0e6e104ed0b768a685d97",
+            "name": "sub-019_task-emotionProcessingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "da2025294b29d05a04a3ce88334bb78e",
+            "name": "sub-019_task-emotionProcessingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "593b93faf187ed1529d0d67c70a52064",
+            "name": "sub-019_task-emotionProcessingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "189b63cfd0ed5265678518483743162c",
+            "name": "sub-019_task-emotionProcessingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "af8c49a408751e4d2e1c7550ac3196ce",
+            "name": "sub-019_task-emotionProcessingImagined_physio.json"
+          },
+          {
+            "relation": "247a7ecbb38fef53debe799b72e7064e",
+            "name": "sub-019_task-emotionProcessingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "0b5cb7229e2fcbae77ef3ad2b2db8040",
+            "name": "sub-019_task-emotionProcessing_physio.json"
+          },
+          {
+            "relation": "3aa4c7b9e8339ac90a0e764c89ea6647",
+            "name": "sub-019_task-emotionProcessing_physio.tsv.gz"
+          },
+          {
+            "relation": "3d01dda30aaba71344aaaa17e47b8e11",
+            "name": "sub-019_task-fingerTapping_echo-1_bold.json"
+          },
+          {
+            "relation": "a770d3f9ca52e238a5c322eda9a483c3",
+            "name": "sub-019_task-fingerTapping_echo-1_bold.nii"
+          },
+          {
+            "relation": "9270a115239c71322b2136225d1de014",
+            "name": "sub-019_task-fingerTapping_echo-2_bold.json"
+          },
+          {
+            "relation": "ec9c3f2cded0b6462edf4727b4179bed",
+            "name": "sub-019_task-fingerTapping_echo-2_bold.nii"
+          },
+          {
+            "relation": "04d5039942c6ecb2b4cd0b84f256b2a7",
+            "name": "sub-019_task-fingerTapping_echo-3_bold.json"
+          },
+          {
+            "relation": "22d7379427b1021462add9190e53ebfc",
+            "name": "sub-019_task-fingerTapping_echo-3_bold.nii"
+          },
+          {
+            "relation": "f1c6da5fca90a4d4da36d5cf97c31e2b",
+            "name": "sub-019_task-fingerTapping_events.tsv.gz"
+          },
+          {
+            "relation": "2d252ae6f47238c8407e63b425e1a323",
+            "name": "sub-019_task-fingerTappingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "ffffccac3809ac8d3f344a8cdc59a967",
+            "name": "sub-019_task-fingerTappingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "72a4cd3573a708d5ececf2b51097c5a8",
+            "name": "sub-019_task-fingerTappingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "f77f9150229dd232cc026c61a8f936b9",
+            "name": "sub-019_task-fingerTappingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "989b6c9e32ee328c74763545e14aa7ac",
+            "name": "sub-019_task-fingerTappingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "f4d329cb4f46502b98ca797d6efb821a",
+            "name": "sub-019_task-fingerTappingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "e22a6384385779bfd07902623d084563",
+            "name": "sub-019_task-fingerTappingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "e5c279f326ee9a8d48e4fe532807129b",
+            "name": "sub-019_task-fingerTappingImagined_physio.json"
+          },
+          {
+            "relation": "63e7ec079d0b86765b16405bca76eaa7",
+            "name": "sub-019_task-fingerTappingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "3eee13807fa200e7c94d7241dd26cd7a",
+            "name": "sub-019_task-fingerTapping_physio.json"
+          },
+          {
+            "relation": "ca4c0bbbb035517432413a9cbb5187cd",
+            "name": "sub-019_task-fingerTapping_physio.tsv.gz"
+          },
+          {
+            "relation": "a0365d0d70eef29defbe1518c75efaf8",
+            "name": "sub-019_task-rest_run-1_echo-1_bold.json"
+          },
+          {
+            "relation": "b3db2bf6ef1925eb2d0602e3318f5a3a",
+            "name": "sub-019_task-rest_run-1_echo-1_bold.nii"
+          },
+          {
+            "relation": "ea41f1b42f6ccca0ba65174f3b2e3b6b",
+            "name": "sub-019_task-rest_run-1_echo-2_bold.json"
+          },
+          {
+            "relation": "ed3231b108f5e7ad6749f2c8eef91cea",
+            "name": "sub-019_task-rest_run-1_echo-2_bold.nii"
+          },
+          {
+            "relation": "70a500bab6e0571167acf5378e335e0a",
+            "name": "sub-019_task-rest_run-1_echo-3_bold.json"
+          },
+          {
+            "relation": "754b73d4ff587d8bcd246fbb26e1fe83",
+            "name": "sub-019_task-rest_run-1_echo-3_bold.nii"
+          },
+          {
+            "relation": "276ce10bff283ab4d57782e8992d4593",
+            "name": "sub-019_task-rest_run-1_physio.json"
+          },
+          {
+            "relation": "515d8d65fbe994cfb276173666c5d084",
+            "name": "sub-019_task-rest_run-1_physio.tsv.gz"
+          },
+          {
+            "relation": "ccea34f1f7872ae7188e375f7909c8d0",
+            "name": "sub-019_task-rest_run-2_echo-1_bold.json"
+          },
+          {
+            "relation": "89d7c2abf06fc026ad7dd36eb852748b",
+            "name": "sub-019_task-rest_run-2_echo-1_bold.nii"
+          },
+          {
+            "relation": "cbfd7780f899b213b810417dab5bfed5",
+            "name": "sub-019_task-rest_run-2_echo-2_bold.json"
+          },
+          {
+            "relation": "4c5cee193ed25e8927d349759c4390bd",
+            "name": "sub-019_task-rest_run-2_echo-2_bold.nii"
+          },
+          {
+            "relation": "fbc01f613cb706a07b5bd20a965962c5",
+            "name": "sub-019_task-rest_run-2_echo-3_bold.json"
+          },
+          {
+            "relation": "311ff32bb975770b4f8f5c822c4330cc",
+            "name": "sub-019_task-rest_run-2_echo-3_bold.nii"
+          },
+          {
+            "relation": "37c77f3c79b7551b8e19f42a7db9ea8d",
+            "name": "sub-019_task-rest_run-2_physio.json"
+          },
+          {
+            "relation": "5633574342d8f03a72e934625fa9201c",
+            "name": "sub-019_task-rest_run-2_physio.tsv.gz"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6aa733780d6bf9addd4ea3d05ed51924",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6aa733780d6bf9addd4ea3d05ed51924"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45112"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "11c9a5133067418baba05651e4e6d53b",
+        "byte_size": 1038,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "11c9a5133067418baba05651e4e6d53b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46261"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1855f130ac422e998e659ac0386e8ede",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1855f130ac422e998e659ac0386e8ede"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45769"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d19eb8cedec51262e5eb75d2785fca6a",
+        "byte_size": 1038,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d19eb8cedec51262e5eb75d2785fca6a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45249"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "08ca55e4d2fd91fc5b15a22b732938a3",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "08ca55e4d2fd91fc5b15a22b732938a3"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45554"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "bb5add688ff56a82bbca17a6eb55e7ca",
+        "byte_size": 1857,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "bb5add688ff56a82bbca17a6eb55e7ca"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46612"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b1a3e5cb27a2636734ba18ce531d9248",
+        "byte_size": 1045,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b1a3e5cb27a2636734ba18ce531d9248"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45359"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ee1d6e2cb43a658f018f3cee66691205",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ee1d6e2cb43a658f018f3cee66691205"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45508"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "cc8b80c64786026ecdb401d835b6c2ea",
+        "byte_size": 1045,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "cc8b80c64786026ecdb401d835b6c2ea"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46279"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "07e6633e94e0e6e104ed0b768a685d97",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "07e6633e94e0e6e104ed0b768a685d97"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46117"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "da2025294b29d05a04a3ce88334bb78e",
+        "byte_size": 1045,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "da2025294b29d05a04a3ce88334bb78e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45807"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "593b93faf187ed1529d0d67c70a52064",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "593b93faf187ed1529d0d67c70a52064"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46076"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "189b63cfd0ed5265678518483743162c",
+        "byte_size": 176,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "189b63cfd0ed5265678518483743162c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46583"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "af8c49a408751e4d2e1c7550ac3196ce",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "af8c49a408751e4d2e1c7550ac3196ce"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45805"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "247a7ecbb38fef53debe799b72e7064e",
+        "byte_size": 474948,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "247a7ecbb38fef53debe799b72e7064e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45276"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "0b5cb7229e2fcbae77ef3ad2b2db8040",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "0b5cb7229e2fcbae77ef3ad2b2db8040"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45225"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "3aa4c7b9e8339ac90a0e764c89ea6647",
+        "byte_size": 494275,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "3aa4c7b9e8339ac90a0e764c89ea6647"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45105"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "3d01dda30aaba71344aaaa17e47b8e11",
+        "byte_size": 1034,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "3d01dda30aaba71344aaaa17e47b8e11"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45937"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a770d3f9ca52e238a5c322eda9a483c3",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a770d3f9ca52e238a5c322eda9a483c3"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46149"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "9270a115239c71322b2136225d1de014",
+        "byte_size": 1034,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "9270a115239c71322b2136225d1de014"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46475"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ec9c3f2cded0b6462edf4727b4179bed",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ec9c3f2cded0b6462edf4727b4179bed"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46411"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "04d5039942c6ecb2b4cd0b84f256b2a7",
+        "byte_size": 1034,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "04d5039942c6ecb2b4cd0b84f256b2a7"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45683"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "22d7379427b1021462add9190e53ebfc",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "22d7379427b1021462add9190e53ebfc"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46358"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f1c6da5fca90a4d4da36d5cf97c31e2b",
+        "byte_size": 167,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f1c6da5fca90a4d4da36d5cf97c31e2b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46560"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2d252ae6f47238c8407e63b425e1a323",
+        "byte_size": 1042,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2d252ae6f47238c8407e63b425e1a323"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45742"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ffffccac3809ac8d3f344a8cdc59a967",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ffffccac3809ac8d3f344a8cdc59a967"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45982"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "72a4cd3573a708d5ececf2b51097c5a8",
+        "byte_size": 1042,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "72a4cd3573a708d5ececf2b51097c5a8"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46217"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f77f9150229dd232cc026c61a8f936b9",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f77f9150229dd232cc026c61a8f936b9"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46457"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "989b6c9e32ee328c74763545e14aa7ac",
+        "byte_size": 1042,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "989b6c9e32ee328c74763545e14aa7ac"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46472"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f4d329cb4f46502b98ca797d6efb821a",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f4d329cb4f46502b98ca797d6efb821a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46383"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e22a6384385779bfd07902623d084563",
+        "byte_size": 179,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e22a6384385779bfd07902623d084563"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46609"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e5c279f326ee9a8d48e4fe532807129b",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e5c279f326ee9a8d48e4fe532807129b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45197"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "63e7ec079d0b86765b16405bca76eaa7",
+        "byte_size": 470533,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "63e7ec079d0b86765b16405bca76eaa7"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45525"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "3eee13807fa200e7c94d7241dd26cd7a",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "3eee13807fa200e7c94d7241dd26cd7a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45960"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ca4c0bbbb035517432413a9cbb5187cd",
+        "byte_size": 519192,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ca4c0bbbb035517432413a9cbb5187cd"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45252"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a0365d0d70eef29defbe1518c75efaf8",
+        "byte_size": 1023,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a0365d0d70eef29defbe1518c75efaf8"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46510"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b3db2bf6ef1925eb2d0602e3318f5a3a",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b3db2bf6ef1925eb2d0602e3318f5a3a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45764"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ea41f1b42f6ccca0ba65174f3b2e3b6b",
+        "byte_size": 1023,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ea41f1b42f6ccca0ba65174f3b2e3b6b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45777"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ed3231b108f5e7ad6749f2c8eef91cea",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ed3231b108f5e7ad6749f2c8eef91cea"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45346"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "70a500bab6e0571167acf5378e335e0a",
+        "byte_size": 1023,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "70a500bab6e0571167acf5378e335e0a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45907"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "754b73d4ff587d8bcd246fbb26e1fe83",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "754b73d4ff587d8bcd246fbb26e1fe83"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45616"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "276ce10bff283ab4d57782e8992d4593",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "276ce10bff283ab4d57782e8992d4593"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46400"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "515d8d65fbe994cfb276173666c5d084",
+        "byte_size": 468658,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "515d8d65fbe994cfb276173666c5d084"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46079"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ccea34f1f7872ae7188e375f7909c8d0",
+        "byte_size": 1025,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ccea34f1f7872ae7188e375f7909c8d0"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46386"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "89d7c2abf06fc026ad7dd36eb852748b",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "89d7c2abf06fc026ad7dd36eb852748b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45866"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "cbfd7780f899b213b810417dab5bfed5",
+        "byte_size": 1025,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "cbfd7780f899b213b810417dab5bfed5"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45680"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4c5cee193ed25e8927d349759c4390bd",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4c5cee193ed25e8927d349759c4390bd"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45378"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "fbc01f613cb706a07b5bd20a965962c5",
+        "byte_size": 1025,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "fbc01f613cb706a07b5bd20a965962c5"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45828"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "311ff32bb975770b4f8f5c822c4330cc",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "311ff32bb975770b4f8f5c822c4330cc"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46153"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "37c77f3c79b7551b8e19f42a7db9ea8d",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "37c77f3c79b7551b8e19f42a7db9ea8d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45966"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5633574342d8f03a72e934625fa9201c",
+        "byte_size": 467073,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5633574342d8f03a72e934625fa9201c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45497"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2031bfb21864f6e06400b510b8203044",
+        "byte_size": 20736352,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2031bfb21864f6e06400b510b8203044"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45619"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-020/",
+        "qualified_part": [
+          {
+            "relation": "sub-020/anat/",
+            "name": "anat"
+          },
+          {
+            "relation": "sub-020/func/",
+            "name": "func"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-020/anat/",
+        "qualified_part": [
+          {
+            "relation": "2031bfb21864f6e06400b510b8203044",
+            "name": "sub-020_T1w.nii"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "af9d9451739f64a0f22ff1b30a3fa978",
+        "byte_size": 1041,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "af9d9451739f64a0f22ff1b30a3fa978"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45324"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-020/func/",
+        "qualified_part": [
+          {
+            "relation": "af9d9451739f64a0f22ff1b30a3fa978",
+            "name": "sub-020_task-emotionProcessing_echo-1_bold.json"
+          },
+          {
+            "relation": "a9236393e1e47f0b93eec303465128cb",
+            "name": "sub-020_task-emotionProcessing_echo-1_bold.nii"
+          },
+          {
+            "relation": "68a0cc41e95d67371eaaea84c0dbc4a6",
+            "name": "sub-020_task-emotionProcessing_echo-2_bold.json"
+          },
+          {
+            "relation": "a773cd7727a540c59e6f360646037c27",
+            "name": "sub-020_task-emotionProcessing_echo-2_bold.nii"
+          },
+          {
+            "relation": "6bc691ba3a1cdd343b8f316e59f79f0f",
+            "name": "sub-020_task-emotionProcessing_echo-3_bold.json"
+          },
+          {
+            "relation": "4f896fe9c393d710e40dcea762abfb29",
+            "name": "sub-020_task-emotionProcessing_echo-3_bold.nii"
+          },
+          {
+            "relation": "18d24a490dfd820a1fb7b01308a7ac6f",
+            "name": "sub-020_task-emotionProcessing_events.tsv.gz"
+          },
+          {
+            "relation": "7043bbbcd78adf0cc7baf6dad05d43d6",
+            "name": "sub-020_task-emotionProcessingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "7fab3783b35f2a4965cf7b92cabcf99c",
+            "name": "sub-020_task-emotionProcessingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "9696bd7cb2254077b09d1a659e634eef",
+            "name": "sub-020_task-emotionProcessingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "2f9286f8332bf92a2491e5ff12ef4680",
+            "name": "sub-020_task-emotionProcessingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "71d6b2d68cace2c79dda7774f55df7ec",
+            "name": "sub-020_task-emotionProcessingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "cf5c63c15cab2821cecf8856c4e2ef25",
+            "name": "sub-020_task-emotionProcessingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "b3077b1bd8ce0512419d6284e37f40c6",
+            "name": "sub-020_task-emotionProcessingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "0bf96f9d17dae1e39fe5c65b0e55ed9d",
+            "name": "sub-020_task-emotionProcessingImagined_physio.json"
+          },
+          {
+            "relation": "5d0319f59b05a52823b0c79e79eb8a52",
+            "name": "sub-020_task-emotionProcessingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "4788b62f42bca229f416979a1a70f3af",
+            "name": "sub-020_task-emotionProcessing_physio.json"
+          },
+          {
+            "relation": "37f51d06e4000f7cead83073bdb49c90",
+            "name": "sub-020_task-emotionProcessing_physio.tsv.gz"
+          },
+          {
+            "relation": "91e9a2070f99e72c49bdd5f067cad2c0",
+            "name": "sub-020_task-fingerTapping_echo-1_bold.json"
+          },
+          {
+            "relation": "2b3c91a743b6a6e4c5a0e74389ec45a1",
+            "name": "sub-020_task-fingerTapping_echo-1_bold.nii"
+          },
+          {
+            "relation": "299e79b9c488c38b8708d86e1ad3ea54",
+            "name": "sub-020_task-fingerTapping_echo-2_bold.json"
+          },
+          {
+            "relation": "47a984ac1c5b613e9a2d280ed1dfd925",
+            "name": "sub-020_task-fingerTapping_echo-2_bold.nii"
+          },
+          {
+            "relation": "b68ebef9beb3d443a8cda33c81eed151",
+            "name": "sub-020_task-fingerTapping_echo-3_bold.json"
+          },
+          {
+            "relation": "66ea37e8bb1555d1624e3a4e6a01ae64",
+            "name": "sub-020_task-fingerTapping_echo-3_bold.nii"
+          },
+          {
+            "relation": "470665491f9f9cc008c64311d0907b0f",
+            "name": "sub-020_task-fingerTapping_events.tsv.gz"
+          },
+          {
+            "relation": "fc7a4059aa5d62bc93ef8a2d4af7bfbd",
+            "name": "sub-020_task-fingerTappingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "b62010362a3182366cf429f65aca268b",
+            "name": "sub-020_task-fingerTappingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "b00ce22e507a1ef0de51435b0fc675b5",
+            "name": "sub-020_task-fingerTappingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "624d93602e8bdaa6b373a2851910dc7e",
+            "name": "sub-020_task-fingerTappingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "d497cf246c43221189d05e659d07387e",
+            "name": "sub-020_task-fingerTappingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "7f78ecccca242d27e608a4f7e5e6f716",
+            "name": "sub-020_task-fingerTappingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "31ca847b21f8e14a7dd11e8bb92d56d4",
+            "name": "sub-020_task-fingerTappingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "49b4f774348322000298d4f1fa57434b",
+            "name": "sub-020_task-fingerTappingImagined_physio.json"
+          },
+          {
+            "relation": "1268aae9d99d26faa2e0d0eb7cd9848e",
+            "name": "sub-020_task-fingerTappingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "6993ca98abbb4f4d0d8e666b7eb31d6f",
+            "name": "sub-020_task-fingerTapping_physio.json"
+          },
+          {
+            "relation": "ac252b88b9d7469952d7d62b7a53bc76",
+            "name": "sub-020_task-fingerTapping_physio.tsv.gz"
+          },
+          {
+            "relation": "ae71582204caffee278155a68df35674",
+            "name": "sub-020_task-rest_run-1_echo-1_bold.json"
+          },
+          {
+            "relation": "ba087d91bd1df4b312360e0a4923fea2",
+            "name": "sub-020_task-rest_run-1_echo-1_bold.nii"
+          },
+          {
+            "relation": "98d7f873c7cebfb8da8498c9e97b2810",
+            "name": "sub-020_task-rest_run-1_echo-2_bold.json"
+          },
+          {
+            "relation": "92b3f5ebc3d4f75af4fe5bf9b179f77f",
+            "name": "sub-020_task-rest_run-1_echo-2_bold.nii"
+          },
+          {
+            "relation": "5c3f69bccff20a48110b0e530030dfa9",
+            "name": "sub-020_task-rest_run-1_echo-3_bold.json"
+          },
+          {
+            "relation": "8763f410a5a6a7dd1cfdf98f04b3d97b",
+            "name": "sub-020_task-rest_run-1_echo-3_bold.nii"
+          },
+          {
+            "relation": "30032943c7e6d421b524177d8a1afcfa",
+            "name": "sub-020_task-rest_run-1_physio.json"
+          },
+          {
+            "relation": "c9cd7dd79bc049e4aca8997874ad5c3d",
+            "name": "sub-020_task-rest_run-1_physio.tsv.gz"
+          },
+          {
+            "relation": "e117073f0b47f4dcbd4cc1765c1aa582",
+            "name": "sub-020_task-rest_run-2_echo-1_bold.json"
+          },
+          {
+            "relation": "fb48a6a4aa6665b6908666ca166fa950",
+            "name": "sub-020_task-rest_run-2_echo-1_bold.nii"
+          },
+          {
+            "relation": "4db99ba729989081c0a195bfbf1ee245",
+            "name": "sub-020_task-rest_run-2_echo-2_bold.json"
+          },
+          {
+            "relation": "4e4e116169a7258dfc095073ce0079c3",
+            "name": "sub-020_task-rest_run-2_echo-2_bold.nii"
+          },
+          {
+            "relation": "bc6d8b1879a42ca35c758b7a0299916a",
+            "name": "sub-020_task-rest_run-2_echo-3_bold.json"
+          },
+          {
+            "relation": "997be2b101d7cd226bac1edc5af3cd09",
+            "name": "sub-020_task-rest_run-2_echo-3_bold.nii"
+          },
+          {
+            "relation": "3dc97a367484e8ab554c66df31b45fe8",
+            "name": "sub-020_task-rest_run-2_physio.json"
+          },
+          {
+            "relation": "e1aed881353ca29400e6a2190ced6f91",
+            "name": "sub-020_task-rest_run-2_physio.tsv.gz"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a9236393e1e47f0b93eec303465128cb",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a9236393e1e47f0b93eec303465128cb"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46100"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "68a0cc41e95d67371eaaea84c0dbc4a6",
+        "byte_size": 1041,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "68a0cc41e95d67371eaaea84c0dbc4a6"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46423"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a773cd7727a540c59e6f360646037c27",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a773cd7727a540c59e6f360646037c27"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45677"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6bc691ba3a1cdd343b8f316e59f79f0f",
+        "byte_size": 1041,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6bc691ba3a1cdd343b8f316e59f79f0f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46257"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4f896fe9c393d710e40dcea762abfb29",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4f896fe9c393d710e40dcea762abfb29"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45780"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "18d24a490dfd820a1fb7b01308a7ac6f",
+        "byte_size": 1895,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "18d24a490dfd820a1fb7b01308a7ac6f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46636"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "7043bbbcd78adf0cc7baf6dad05d43d6",
+        "byte_size": 1049,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "7043bbbcd78adf0cc7baf6dad05d43d6"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46316"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "7fab3783b35f2a4965cf7b92cabcf99c",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "7fab3783b35f2a4965cf7b92cabcf99c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45654"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "9696bd7cb2254077b09d1a659e634eef",
+        "byte_size": 1049,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "9696bd7cb2254077b09d1a659e634eef"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46252"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2f9286f8332bf92a2491e5ff12ef4680",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2f9286f8332bf92a2491e5ff12ef4680"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45835"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "71d6b2d68cace2c79dda7774f55df7ec",
+        "byte_size": 1049,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "71d6b2d68cace2c79dda7774f55df7ec"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46205"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "cf5c63c15cab2821cecf8856c4e2ef25",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "cf5c63c15cab2821cecf8856c4e2ef25"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46070"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b3077b1bd8ce0512419d6284e37f40c6",
+        "byte_size": 178,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b3077b1bd8ce0512419d6284e37f40c6"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46567"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "0bf96f9d17dae1e39fe5c65b0e55ed9d",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "0bf96f9d17dae1e39fe5c65b0e55ed9d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46191"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5d0319f59b05a52823b0c79e79eb8a52",
+        "byte_size": 456047,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5d0319f59b05a52823b0c79e79eb8a52"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45968"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4788b62f42bca229f416979a1a70f3af",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4788b62f42bca229f416979a1a70f3af"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45696"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "37f51d06e4000f7cead83073bdb49c90",
+        "byte_size": 480332,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "37f51d06e4000f7cead83073bdb49c90"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45632"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "91e9a2070f99e72c49bdd5f067cad2c0",
+        "byte_size": 1036,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "91e9a2070f99e72c49bdd5f067cad2c0"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45417"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2b3c91a743b6a6e4c5a0e74389ec45a1",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2b3c91a743b6a6e4c5a0e74389ec45a1"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45394"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "299e79b9c488c38b8708d86e1ad3ea54",
+        "byte_size": 1036,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "299e79b9c488c38b8708d86e1ad3ea54"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45776"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "47a984ac1c5b613e9a2d280ed1dfd925",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "47a984ac1c5b613e9a2d280ed1dfd925"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46305"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b68ebef9beb3d443a8cda33c81eed151",
+        "byte_size": 1036,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b68ebef9beb3d443a8cda33c81eed151"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45734"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "66ea37e8bb1555d1624e3a4e6a01ae64",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "66ea37e8bb1555d1624e3a4e6a01ae64"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45725"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "470665491f9f9cc008c64311d0907b0f",
+        "byte_size": 167,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "470665491f9f9cc008c64311d0907b0f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46563"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "fc7a4059aa5d62bc93ef8a2d4af7bfbd",
+        "byte_size": 1045,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "fc7a4059aa5d62bc93ef8a2d4af7bfbd"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45148"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b62010362a3182366cf429f65aca268b",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b62010362a3182366cf429f65aca268b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46360"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b00ce22e507a1ef0de51435b0fc675b5",
+        "byte_size": 1045,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b00ce22e507a1ef0de51435b0fc675b5"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45536"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "624d93602e8bdaa6b373a2851910dc7e",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "624d93602e8bdaa6b373a2851910dc7e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45623"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d497cf246c43221189d05e659d07387e",
+        "byte_size": 1045,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d497cf246c43221189d05e659d07387e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45936"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "7f78ecccca242d27e608a4f7e5e6f716",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "7f78ecccca242d27e608a4f7e5e6f716"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45643"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "31ca847b21f8e14a7dd11e8bb92d56d4",
+        "byte_size": 179,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "31ca847b21f8e14a7dd11e8bb92d56d4"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46650"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "49b4f774348322000298d4f1fa57434b",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "49b4f774348322000298d4f1fa57434b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45559"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1268aae9d99d26faa2e0d0eb7cd9848e",
+        "byte_size": 460768,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1268aae9d99d26faa2e0d0eb7cd9848e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45600"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6993ca98abbb4f4d0d8e666b7eb31d6f",
+        "byte_size": 142,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6993ca98abbb4f4d0d8e666b7eb31d6f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45455"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ac252b88b9d7469952d7d62b7a53bc76",
+        "byte_size": 464906,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ac252b88b9d7469952d7d62b7a53bc76"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45450"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ae71582204caffee278155a68df35674",
+        "byte_size": 1028,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ae71582204caffee278155a68df35674"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46544"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ba087d91bd1df4b312360e0a4923fea2",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ba087d91bd1df4b312360e0a4923fea2"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45170"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "98d7f873c7cebfb8da8498c9e97b2810",
+        "byte_size": 1028,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "98d7f873c7cebfb8da8498c9e97b2810"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45400"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "92b3f5ebc3d4f75af4fe5bf9b179f77f",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "92b3f5ebc3d4f75af4fe5bf9b179f77f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45385"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5c3f69bccff20a48110b0e530030dfa9",
+        "byte_size": 1028,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5c3f69bccff20a48110b0e530030dfa9"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45640"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8763f410a5a6a7dd1cfdf98f04b3d97b",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8763f410a5a6a7dd1cfdf98f04b3d97b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45882"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "30032943c7e6d421b524177d8a1afcfa",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "30032943c7e6d421b524177d8a1afcfa"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45333"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c9cd7dd79bc049e4aca8997874ad5c3d",
+        "byte_size": 462284,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c9cd7dd79bc049e4aca8997874ad5c3d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45693"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e117073f0b47f4dcbd4cc1765c1aa582",
+        "byte_size": 1026,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e117073f0b47f4dcbd4cc1765c1aa582"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45504"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "fb48a6a4aa6665b6908666ca166fa950",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "fb48a6a4aa6665b6908666ca166fa950"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45947"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4db99ba729989081c0a195bfbf1ee245",
+        "byte_size": 1026,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4db99ba729989081c0a195bfbf1ee245"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46152"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4e4e116169a7258dfc095073ce0079c3",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4e4e116169a7258dfc095073ce0079c3"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46278"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "bc6d8b1879a42ca35c758b7a0299916a",
+        "byte_size": 1026,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "bc6d8b1879a42ca35c758b7a0299916a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45892"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "997be2b101d7cd226bac1edc5af3cd09",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "997be2b101d7cd226bac1edc5af3cd09"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46404"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "3dc97a367484e8ab554c66df31b45fe8",
+        "byte_size": 142,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "3dc97a367484e8ab554c66df31b45fe8"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46174"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e1aed881353ca29400e6a2190ced6f91",
+        "byte_size": 457579,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e1aed881353ca29400e6a2190ced6f91"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45516"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "9591a73ee0d16e4b489af21b1bb91e05",
+        "byte_size": 20736352,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "9591a73ee0d16e4b489af21b1bb91e05"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45858"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-021/",
+        "qualified_part": [
+          {
+            "relation": "sub-021/anat/",
+            "name": "anat"
+          },
+          {
+            "relation": "sub-021/func/",
+            "name": "func"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-021/anat/",
+        "qualified_part": [
+          {
+            "relation": "9591a73ee0d16e4b489af21b1bb91e05",
+            "name": "sub-021_T1w.nii"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d0023eb081b190e3c8fc0dd8509bb0f9",
+        "byte_size": 1040,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d0023eb081b190e3c8fc0dd8509bb0f9"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45268"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-021/func/",
+        "qualified_part": [
+          {
+            "relation": "d0023eb081b190e3c8fc0dd8509bb0f9",
+            "name": "sub-021_task-emotionProcessing_echo-1_bold.json"
+          },
+          {
+            "relation": "57d9a3bf07cfe88fe10de40a8b4032d3",
+            "name": "sub-021_task-emotionProcessing_echo-1_bold.nii"
+          },
+          {
+            "relation": "645130bfc1161abba0de6ae3f3f4e6c9",
+            "name": "sub-021_task-emotionProcessing_echo-2_bold.json"
+          },
+          {
+            "relation": "8c0b8a19e338f222d0ce0ca1fda9588e",
+            "name": "sub-021_task-emotionProcessing_echo-2_bold.nii"
+          },
+          {
+            "relation": "debb30a678f8fe0afecf0266d2bf6adf",
+            "name": "sub-021_task-emotionProcessing_echo-3_bold.json"
+          },
+          {
+            "relation": "5cd16353333566365b09a317b6fa8f4d",
+            "name": "sub-021_task-emotionProcessing_echo-3_bold.nii"
+          },
+          {
+            "relation": "759a80d55b3aa2f2796f5a25790bf290",
+            "name": "sub-021_task-emotionProcessing_events.tsv.gz"
+          },
+          {
+            "relation": "a152a08f2e48f0b7b5cc243f7cc26f53",
+            "name": "sub-021_task-emotionProcessingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "1b82e698e524c8dcaa6b9e6bea44b1ca",
+            "name": "sub-021_task-emotionProcessingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "873d7d8d93c7c346f8f4f598cc4e15c0",
+            "name": "sub-021_task-emotionProcessingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "351d54c39476a6491885442fc63604ef",
+            "name": "sub-021_task-emotionProcessingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "89f70975ea2771e0ed50e8ea9720d55e",
+            "name": "sub-021_task-emotionProcessingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "8db1f89aba4a97bd203e827e4044318b",
+            "name": "sub-021_task-emotionProcessingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "67ed2f653f579202ed7340435c6ab73b",
+            "name": "sub-021_task-emotionProcessingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "4e10497094e60af65c678efe3925d47b",
+            "name": "sub-021_task-emotionProcessingImagined_physio.json"
+          },
+          {
+            "relation": "9b3bbbb443a9a48ef0c2d822cb1cb6b5",
+            "name": "sub-021_task-emotionProcessingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "32cd9758c3c70f30f9f6cf55829adc82",
+            "name": "sub-021_task-emotionProcessing_physio.json"
+          },
+          {
+            "relation": "6108f65d2b70c30e0d1175a95b20ad6c",
+            "name": "sub-021_task-emotionProcessing_physio.tsv.gz"
+          },
+          {
+            "relation": "8cf4e469e5ba11fa1919bee6736165ab",
+            "name": "sub-021_task-fingerTapping_echo-1_bold.json"
+          },
+          {
+            "relation": "5b2d8410ab537f6341837a8b7d43173f",
+            "name": "sub-021_task-fingerTapping_echo-1_bold.nii"
+          },
+          {
+            "relation": "438c6dba76ba2d63e2aaed7c147084ee",
+            "name": "sub-021_task-fingerTapping_echo-2_bold.json"
+          },
+          {
+            "relation": "8cdcaf74eede11999411bf9b662a7f00",
+            "name": "sub-021_task-fingerTapping_echo-2_bold.nii"
+          },
+          {
+            "relation": "b406dd2f244b6773f01dd9f39d0ec087",
+            "name": "sub-021_task-fingerTapping_echo-3_bold.json"
+          },
+          {
+            "relation": "e2c088d4f19fba0369901e56e3158501",
+            "name": "sub-021_task-fingerTapping_echo-3_bold.nii"
+          },
+          {
+            "relation": "e92392f12915a922a166216e0c8a799f",
+            "name": "sub-021_task-fingerTapping_events.tsv.gz"
+          },
+          {
+            "relation": "00f67e6452f7bbb3118454730dc6d317",
+            "name": "sub-021_task-fingerTappingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "2ce149c5a4af8b9957da0dc40dc715cb",
+            "name": "sub-021_task-fingerTappingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "43937553b0f8fad6ab85114f9b1fd135",
+            "name": "sub-021_task-fingerTappingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "2d838ecd17860236e958442999d380a6",
+            "name": "sub-021_task-fingerTappingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "70d0a2ff1effbbb17bb3148cdd5a1c65",
+            "name": "sub-021_task-fingerTappingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "57ca7c934b6dfc41c14ea723ba6c0424",
+            "name": "sub-021_task-fingerTappingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "5f2b58977057a2f8e8f3a63afdbf26cc",
+            "name": "sub-021_task-fingerTappingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "20674885589debb9c452b1e18fa23a0a",
+            "name": "sub-021_task-fingerTappingImagined_physio.json"
+          },
+          {
+            "relation": "c89e4808bbab12010f23016a0cf937ae",
+            "name": "sub-021_task-fingerTappingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "0a33dbb8d6e81df3efa76ea8a52b02bc",
+            "name": "sub-021_task-fingerTapping_physio.json"
+          },
+          {
+            "relation": "81ad87529d1a8598643ab6a282f424f1",
+            "name": "sub-021_task-fingerTapping_physio.tsv.gz"
+          },
+          {
+            "relation": "439532d80054b2f2b25bc5029f644101",
+            "name": "sub-021_task-rest_run-1_echo-1_bold.json"
+          },
+          {
+            "relation": "d16963c7dd0eec20ffc6b1d61262e0f8",
+            "name": "sub-021_task-rest_run-1_echo-1_bold.nii"
+          },
+          {
+            "relation": "482b1c24457a0da28096c2a4a99c3ae1",
+            "name": "sub-021_task-rest_run-1_echo-2_bold.json"
+          },
+          {
+            "relation": "ab844da48b9cd77cb915b4be5e32c053",
+            "name": "sub-021_task-rest_run-1_echo-2_bold.nii"
+          },
+          {
+            "relation": "a99b02aa878cfb5f143bb91d3ede0087",
+            "name": "sub-021_task-rest_run-1_echo-3_bold.json"
+          },
+          {
+            "relation": "e80f236e33afd69ae1b0f87ba29346b6",
+            "name": "sub-021_task-rest_run-1_echo-3_bold.nii"
+          },
+          {
+            "relation": "d79c73483b13c27b4c5ce1e06ac44473",
+            "name": "sub-021_task-rest_run-1_physio.json"
+          },
+          {
+            "relation": "7a2374c3a0b447ef4e822a9010dfb1d5",
+            "name": "sub-021_task-rest_run-1_physio.tsv.gz"
+          },
+          {
+            "relation": "56619e6f98a70ea32e028893cbe358da",
+            "name": "sub-021_task-rest_run-2_echo-1_bold.json"
+          },
+          {
+            "relation": "f4094fd68d34823fd6b4123c02129fa2",
+            "name": "sub-021_task-rest_run-2_echo-1_bold.nii"
+          },
+          {
+            "relation": "475d75d2c07d00ee4f24e4f9435bf949",
+            "name": "sub-021_task-rest_run-2_echo-2_bold.json"
+          },
+          {
+            "relation": "47e7d3ecfa69dc91f8316a1206bbb370",
+            "name": "sub-021_task-rest_run-2_echo-2_bold.nii"
+          },
+          {
+            "relation": "50722e2e70ab9b8e8f76933bc17604e5",
+            "name": "sub-021_task-rest_run-2_echo-3_bold.json"
+          },
+          {
+            "relation": "1c9f3613de8fb930b5f899b347062957",
+            "name": "sub-021_task-rest_run-2_echo-3_bold.nii"
+          },
+          {
+            "relation": "10a80fd8b46666dd4467720de4a113fb",
+            "name": "sub-021_task-rest_run-2_physio.json"
+          },
+          {
+            "relation": "7dfcc62dc4e2e6c62a344642dffa3d0d",
+            "name": "sub-021_task-rest_run-2_physio.tsv.gz"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "57d9a3bf07cfe88fe10de40a8b4032d3",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "57d9a3bf07cfe88fe10de40a8b4032d3"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45587"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "645130bfc1161abba0de6ae3f3f4e6c9",
+        "byte_size": 1040,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "645130bfc1161abba0de6ae3f3f4e6c9"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45307"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8c0b8a19e338f222d0ce0ca1fda9588e",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8c0b8a19e338f222d0ce0ca1fda9588e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45761"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "debb30a678f8fe0afecf0266d2bf6adf",
+        "byte_size": 1040,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "debb30a678f8fe0afecf0266d2bf6adf"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46479"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5cd16353333566365b09a317b6fa8f4d",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5cd16353333566365b09a317b6fa8f4d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46112"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "759a80d55b3aa2f2796f5a25790bf290",
+        "byte_size": 1938,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "759a80d55b3aa2f2796f5a25790bf290"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46616"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a152a08f2e48f0b7b5cc243f7cc26f53",
+        "byte_size": 1048,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a152a08f2e48f0b7b5cc243f7cc26f53"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45414"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1b82e698e524c8dcaa6b9e6bea44b1ca",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1b82e698e524c8dcaa6b9e6bea44b1ca"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45569"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "873d7d8d93c7c346f8f4f598cc4e15c0",
+        "byte_size": 1048,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "873d7d8d93c7c346f8f4f598cc4e15c0"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46459"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "351d54c39476a6491885442fc63604ef",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "351d54c39476a6491885442fc63604ef"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46246"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "89f70975ea2771e0ed50e8ea9720d55e",
+        "byte_size": 1048,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "89f70975ea2771e0ed50e8ea9720d55e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46418"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8db1f89aba4a97bd203e827e4044318b",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8db1f89aba4a97bd203e827e4044318b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46399"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "67ed2f653f579202ed7340435c6ab73b",
+        "byte_size": 173,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "67ed2f653f579202ed7340435c6ab73b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46575"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4e10497094e60af65c678efe3925d47b",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4e10497094e60af65c678efe3925d47b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46525"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "9b3bbbb443a9a48ef0c2d822cb1cb6b5",
+        "byte_size": 481794,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "9b3bbbb443a9a48ef0c2d822cb1cb6b5"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46501"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "32cd9758c3c70f30f9f6cf55829adc82",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "32cd9758c3c70f30f9f6cf55829adc82"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45145"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6108f65d2b70c30e0d1175a95b20ad6c",
+        "byte_size": 515684,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6108f65d2b70c30e0d1175a95b20ad6c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46220"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8cf4e469e5ba11fa1919bee6736165ab",
+        "byte_size": 1036,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8cf4e469e5ba11fa1919bee6736165ab"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45663"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5b2d8410ab537f6341837a8b7d43173f",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5b2d8410ab537f6341837a8b7d43173f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45670"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "438c6dba76ba2d63e2aaed7c147084ee",
+        "byte_size": 1036,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "438c6dba76ba2d63e2aaed7c147084ee"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45727"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8cdcaf74eede11999411bf9b662a7f00",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8cdcaf74eede11999411bf9b662a7f00"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45684"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b406dd2f244b6773f01dd9f39d0ec087",
+        "byte_size": 1036,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b406dd2f244b6773f01dd9f39d0ec087"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45902"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e2c088d4f19fba0369901e56e3158501",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e2c088d4f19fba0369901e56e3158501"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45685"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e92392f12915a922a166216e0c8a799f",
+        "byte_size": 161,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e92392f12915a922a166216e0c8a799f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46639"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "00f67e6452f7bbb3118454730dc6d317",
+        "byte_size": 1044,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "00f67e6452f7bbb3118454730dc6d317"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45179"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2ce149c5a4af8b9957da0dc40dc715cb",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2ce149c5a4af8b9957da0dc40dc715cb"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45209"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "43937553b0f8fad6ab85114f9b1fd135",
+        "byte_size": 1044,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "43937553b0f8fad6ab85114f9b1fd135"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45134"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2d838ecd17860236e958442999d380a6",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2d838ecd17860236e958442999d380a6"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45697"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "70d0a2ff1effbbb17bb3148cdd5a1c65",
+        "byte_size": 1044,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "70d0a2ff1effbbb17bb3148cdd5a1c65"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45842"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "57ca7c934b6dfc41c14ea723ba6c0424",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "57ca7c934b6dfc41c14ea723ba6c0424"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45403"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5f2b58977057a2f8e8f3a63afdbf26cc",
+        "byte_size": 177,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5f2b58977057a2f8e8f3a63afdbf26cc"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46559"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "20674885589debb9c452b1e18fa23a0a",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "20674885589debb9c452b1e18fa23a0a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45768"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c89e4808bbab12010f23016a0cf937ae",
+        "byte_size": 503755,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c89e4808bbab12010f23016a0cf937ae"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46371"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "0a33dbb8d6e81df3efa76ea8a52b02bc",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "0a33dbb8d6e81df3efa76ea8a52b02bc"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46469"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "81ad87529d1a8598643ab6a282f424f1",
+        "byte_size": 493542,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "81ad87529d1a8598643ab6a282f424f1"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46045"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "439532d80054b2f2b25bc5029f644101",
+        "byte_size": 1027,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "439532d80054b2f2b25bc5029f644101"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45224"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d16963c7dd0eec20ffc6b1d61262e0f8",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d16963c7dd0eec20ffc6b1d61262e0f8"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46393"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "482b1c24457a0da28096c2a4a99c3ae1",
+        "byte_size": 1027,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "482b1c24457a0da28096c2a4a99c3ae1"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45913"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ab844da48b9cd77cb915b4be5e32c053",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ab844da48b9cd77cb915b4be5e32c053"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45702"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a99b02aa878cfb5f143bb91d3ede0087",
+        "byte_size": 1027,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a99b02aa878cfb5f143bb91d3ede0087"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45427"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e80f236e33afd69ae1b0f87ba29346b6",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e80f236e33afd69ae1b0f87ba29346b6"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45987"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d79c73483b13c27b4c5ce1e06ac44473",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d79c73483b13c27b4c5ce1e06ac44473"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45360"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "7a2374c3a0b447ef4e822a9010dfb1d5",
+        "byte_size": 472964,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "7a2374c3a0b447ef4e822a9010dfb1d5"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45548"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "56619e6f98a70ea32e028893cbe358da",
+        "byte_size": 1027,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "56619e6f98a70ea32e028893cbe358da"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46276"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f4094fd68d34823fd6b4123c02129fa2",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f4094fd68d34823fd6b4123c02129fa2"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45474"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "475d75d2c07d00ee4f24e4f9435bf949",
+        "byte_size": 1027,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "475d75d2c07d00ee4f24e4f9435bf949"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45540"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "47e7d3ecfa69dc91f8316a1206bbb370",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "47e7d3ecfa69dc91f8316a1206bbb370"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45612"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "50722e2e70ab9b8e8f76933bc17604e5",
+        "byte_size": 1027,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "50722e2e70ab9b8e8f76933bc17604e5"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46202"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1c9f3613de8fb930b5f899b347062957",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1c9f3613de8fb930b5f899b347062957"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45272"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "10a80fd8b46666dd4467720de4a113fb",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "10a80fd8b46666dd4467720de4a113fb"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46237"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "7dfcc62dc4e2e6c62a344642dffa3d0d",
+        "byte_size": 466392,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "7dfcc62dc4e2e6c62a344642dffa3d0d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45168"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "485d9f7ff0ca722ebdb751023d3206f1",
+        "byte_size": 20736352,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "485d9f7ff0ca722ebdb751023d3206f1"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45406"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-022/",
+        "qualified_part": [
+          {
+            "relation": "sub-022/anat/",
+            "name": "anat"
+          },
+          {
+            "relation": "sub-022/func/",
+            "name": "func"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-022/anat/",
+        "qualified_part": [
+          {
+            "relation": "485d9f7ff0ca722ebdb751023d3206f1",
+            "name": "sub-022_T1w.nii"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e9bb70745528c4630bac456ea0b0c3e7",
+        "byte_size": 1040,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e9bb70745528c4630bac456ea0b0c3e7"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46392"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-022/func/",
+        "qualified_part": [
+          {
+            "relation": "e9bb70745528c4630bac456ea0b0c3e7",
+            "name": "sub-022_task-emotionProcessing_echo-1_bold.json"
+          },
+          {
+            "relation": "90c647375623883b3b8413095208c276",
+            "name": "sub-022_task-emotionProcessing_echo-1_bold.nii"
+          },
+          {
+            "relation": "857a1942641a85653c9ce048d46767ea",
+            "name": "sub-022_task-emotionProcessing_echo-2_bold.json"
+          },
+          {
+            "relation": "bb86f022f1ebf2b26365d437ebe105df",
+            "name": "sub-022_task-emotionProcessing_echo-2_bold.nii"
+          },
+          {
+            "relation": "2bb9650a47d89ce97ca95a1a5fa6a3b1",
+            "name": "sub-022_task-emotionProcessing_echo-3_bold.json"
+          },
+          {
+            "relation": "17f5f08163012f6a580f98e82e87eb2c",
+            "name": "sub-022_task-emotionProcessing_echo-3_bold.nii"
+          },
+          {
+            "relation": "8189057888af59647daccefdc59e4eb4",
+            "name": "sub-022_task-emotionProcessing_events.tsv.gz"
+          },
+          {
+            "relation": "dc7224e4a5ea9828b7ea312aaf7ba646",
+            "name": "sub-022_task-emotionProcessingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "823032ce07d962c4a133f74e121b3761",
+            "name": "sub-022_task-emotionProcessingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "026cb0721fd8bf78490e741ea5d91794",
+            "name": "sub-022_task-emotionProcessingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "24a26e779af8ea625527291f9046aefb",
+            "name": "sub-022_task-emotionProcessingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "ce7c422b09e0f0b02f34d4613ccc4229",
+            "name": "sub-022_task-emotionProcessingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "1845ba28a5fc280f36b605043a38541b",
+            "name": "sub-022_task-emotionProcessingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "b241742b7e85b01450282a2e7aa4e058",
+            "name": "sub-022_task-emotionProcessingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "32828a99a87019d6f9078e03c648c68d",
+            "name": "sub-022_task-emotionProcessingImagined_physio.json"
+          },
+          {
+            "relation": "82af247c3278288279a833073b9066db",
+            "name": "sub-022_task-emotionProcessingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "fe69e80cf45f5e9d5310ed1a738a696e",
+            "name": "sub-022_task-emotionProcessing_physio.json"
+          },
+          {
+            "relation": "dad4fcc69a0b3469fbf3a26b71965b55",
+            "name": "sub-022_task-emotionProcessing_physio.tsv.gz"
+          },
+          {
+            "relation": "7d197f0669600972b57583e3532570dd",
+            "name": "sub-022_task-fingerTapping_echo-1_bold.json"
+          },
+          {
+            "relation": "fe849a80e4cd766fd6835344b8bd1f3d",
+            "name": "sub-022_task-fingerTapping_echo-1_bold.nii"
+          },
+          {
+            "relation": "52a2f13d5077977571bf6496be1c32a5",
+            "name": "sub-022_task-fingerTapping_echo-2_bold.json"
+          },
+          {
+            "relation": "f210ac99e2c99a5bfa20be2b781f89ff",
+            "name": "sub-022_task-fingerTapping_echo-2_bold.nii"
+          },
+          {
+            "relation": "8e7a2146ec718c117d2b903b43af828a",
+            "name": "sub-022_task-fingerTapping_echo-3_bold.json"
+          },
+          {
+            "relation": "c0b91f1e9a73301ba10b8eccff10a605",
+            "name": "sub-022_task-fingerTapping_echo-3_bold.nii"
+          },
+          {
+            "relation": "0aefea2893935c3e98e5c277f766941f",
+            "name": "sub-022_task-fingerTapping_events.tsv.gz"
+          },
+          {
+            "relation": "5533bdd647e1a2cabd33ed8d1acdde59",
+            "name": "sub-022_task-fingerTappingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "dc4d3bc21a3c8ed6d4a7e65d2ac3199b",
+            "name": "sub-022_task-fingerTappingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "a13d744ad4c709cf59dc9e1b10a1b1f1",
+            "name": "sub-022_task-fingerTappingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "e869e8e8559023be1856f208982d05d7",
+            "name": "sub-022_task-fingerTappingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "d1908bea5803e84906ad952c234953bb",
+            "name": "sub-022_task-fingerTappingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "e49be718e9fb740f14a2bc7a4d3f0e3d",
+            "name": "sub-022_task-fingerTappingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "ad3350bfe793a923b57adc825e721fe0",
+            "name": "sub-022_task-fingerTappingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "87ad0780b5acc158fd21bd4806f54b8c",
+            "name": "sub-022_task-fingerTappingImagined_physio.json"
+          },
+          {
+            "relation": "06420ff40545291d3103f32844fa3e8e",
+            "name": "sub-022_task-fingerTappingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "1293460b4ce9a1b3ae3e197acb543c0c",
+            "name": "sub-022_task-fingerTapping_physio.json"
+          },
+          {
+            "relation": "ea398a208034c539761c427021944b9f",
+            "name": "sub-022_task-fingerTapping_physio.tsv.gz"
+          },
+          {
+            "relation": "b5e25fbbb45223cccae01bd64ff64c06",
+            "name": "sub-022_task-rest_run-1_echo-1_bold.json"
+          },
+          {
+            "relation": "ad1fcb25847e6546bdd84ec40742ae27",
+            "name": "sub-022_task-rest_run-1_echo-1_bold.nii"
+          },
+          {
+            "relation": "383dfc8610f1c4ac70ed6380d6024ada",
+            "name": "sub-022_task-rest_run-1_echo-2_bold.json"
+          },
+          {
+            "relation": "1209b5fd6974ffee065a3a6c5767fab5",
+            "name": "sub-022_task-rest_run-1_echo-2_bold.nii"
+          },
+          {
+            "relation": "6ff7e84e984a2a7a283ae0550acf5fa0",
+            "name": "sub-022_task-rest_run-1_echo-3_bold.json"
+          },
+          {
+            "relation": "215134b08c99ad535e216dce3cecef73",
+            "name": "sub-022_task-rest_run-1_echo-3_bold.nii"
+          },
+          {
+            "relation": "4f6504f90de8cc8caa5ed4eec7fc7a55",
+            "name": "sub-022_task-rest_run-1_physio.json"
+          },
+          {
+            "relation": "dd889f338e9721209a5c7494ea542a48",
+            "name": "sub-022_task-rest_run-1_physio.tsv.gz"
+          },
+          {
+            "relation": "8a7a7e378d88a320bc13aa573e33e9cf",
+            "name": "sub-022_task-rest_run-2_echo-1_bold.json"
+          },
+          {
+            "relation": "f26b54d5131b4150f67442ba57d247e1",
+            "name": "sub-022_task-rest_run-2_echo-1_bold.nii"
+          },
+          {
+            "relation": "794ddb9e826cd7224e77a581d33b2af5",
+            "name": "sub-022_task-rest_run-2_echo-2_bold.json"
+          },
+          {
+            "relation": "f65dc11611257fa72e9ae4a1fa1061f9",
+            "name": "sub-022_task-rest_run-2_echo-2_bold.nii"
+          },
+          {
+            "relation": "a21e290d360f3207465b7919fe9f97c4",
+            "name": "sub-022_task-rest_run-2_echo-3_bold.json"
+          },
+          {
+            "relation": "69773a651271d49947757f38d3a8a144",
+            "name": "sub-022_task-rest_run-2_echo-3_bold.nii"
+          },
+          {
+            "relation": "1b07b0c2da81eab7a599744912d99a4a",
+            "name": "sub-022_task-rest_run-2_physio.json"
+          },
+          {
+            "relation": "3ca0ba152166f56d7289348c95c3ff44",
+            "name": "sub-022_task-rest_run-2_physio.tsv.gz"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "90c647375623883b3b8413095208c276",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "90c647375623883b3b8413095208c276"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45206"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "857a1942641a85653c9ce048d46767ea",
+        "byte_size": 1040,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "857a1942641a85653c9ce048d46767ea"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45141"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "bb86f022f1ebf2b26365d437ebe105df",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "bb86f022f1ebf2b26365d437ebe105df"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45822"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2bb9650a47d89ce97ca95a1a5fa6a3b1",
+        "byte_size": 1040,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2bb9650a47d89ce97ca95a1a5fa6a3b1"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46114"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "17f5f08163012f6a580f98e82e87eb2c",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "17f5f08163012f6a580f98e82e87eb2c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45845"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8189057888af59647daccefdc59e4eb4",
+        "byte_size": 1899,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8189057888af59647daccefdc59e4eb4"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46658"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "dc7224e4a5ea9828b7ea312aaf7ba646",
+        "byte_size": 1049,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "dc7224e4a5ea9828b7ea312aaf7ba646"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46016"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "823032ce07d962c4a133f74e121b3761",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "823032ce07d962c4a133f74e121b3761"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45906"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "026cb0721fd8bf78490e741ea5d91794",
+        "byte_size": 1049,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "026cb0721fd8bf78490e741ea5d91794"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45798"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "24a26e779af8ea625527291f9046aefb",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "24a26e779af8ea625527291f9046aefb"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46133"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ce7c422b09e0f0b02f34d4613ccc4229",
+        "byte_size": 1049,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ce7c422b09e0f0b02f34d4613ccc4229"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45688"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1845ba28a5fc280f36b605043a38541b",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1845ba28a5fc280f36b605043a38541b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46101"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b241742b7e85b01450282a2e7aa4e058",
+        "byte_size": 174,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b241742b7e85b01450282a2e7aa4e058"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46597"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "32828a99a87019d6f9078e03c648c68d",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "32828a99a87019d6f9078e03c648c68d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46389"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "82af247c3278288279a833073b9066db",
+        "byte_size": 461489,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "82af247c3278288279a833073b9066db"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45338"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "fe69e80cf45f5e9d5310ed1a738a696e",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "fe69e80cf45f5e9d5310ed1a738a696e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45655"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "dad4fcc69a0b3469fbf3a26b71965b55",
+        "byte_size": 568493,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "dad4fcc69a0b3469fbf3a26b71965b55"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45300"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "7d197f0669600972b57583e3532570dd",
+        "byte_size": 1037,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "7d197f0669600972b57583e3532570dd"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45384"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "fe849a80e4cd766fd6835344b8bd1f3d",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "fe849a80e4cd766fd6835344b8bd1f3d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45472"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "52a2f13d5077977571bf6496be1c32a5",
+        "byte_size": 1037,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "52a2f13d5077977571bf6496be1c32a5"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45649"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f210ac99e2c99a5bfa20be2b781f89ff",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f210ac99e2c99a5bfa20be2b781f89ff"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45195"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8e7a2146ec718c117d2b903b43af828a",
+        "byte_size": 1037,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8e7a2146ec718c117d2b903b43af828a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46445"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c0b91f1e9a73301ba10b8eccff10a605",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c0b91f1e9a73301ba10b8eccff10a605"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46131"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "0aefea2893935c3e98e5c277f766941f",
+        "byte_size": 163,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "0aefea2893935c3e98e5c277f766941f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46635"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5533bdd647e1a2cabd33ed8d1acdde59",
+        "byte_size": 1045,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5533bdd647e1a2cabd33ed8d1acdde59"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46308"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "dc4d3bc21a3c8ed6d4a7e65d2ac3199b",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "dc4d3bc21a3c8ed6d4a7e65d2ac3199b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45788"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a13d744ad4c709cf59dc9e1b10a1b1f1",
+        "byte_size": 1045,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a13d744ad4c709cf59dc9e1b10a1b1f1"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45922"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e869e8e8559023be1856f208982d05d7",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e869e8e8559023be1856f208982d05d7"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46233"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d1908bea5803e84906ad952c234953bb",
+        "byte_size": 1045,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d1908bea5803e84906ad952c234953bb"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45939"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e49be718e9fb740f14a2bc7a4d3f0e3d",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e49be718e9fb740f14a2bc7a4d3f0e3d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45797"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ad3350bfe793a923b57adc825e721fe0",
+        "byte_size": 177,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ad3350bfe793a923b57adc825e721fe0"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46625"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "87ad0780b5acc158fd21bd4806f54b8c",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "87ad0780b5acc158fd21bd4806f54b8c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45165"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "06420ff40545291d3103f32844fa3e8e",
+        "byte_size": 469899,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "06420ff40545291d3103f32844fa3e8e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45556"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1293460b4ce9a1b3ae3e197acb543c0c",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1293460b4ce9a1b3ae3e197acb543c0c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46109"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ea398a208034c539761c427021944b9f",
+        "byte_size": 485107,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ea398a208034c539761c427021944b9f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45383"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b5e25fbbb45223cccae01bd64ff64c06",
+        "byte_size": 1027,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b5e25fbbb45223cccae01bd64ff64c06"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46473"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ad1fcb25847e6546bdd84ec40742ae27",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ad1fcb25847e6546bdd84ec40742ae27"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45419"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "383dfc8610f1c4ac70ed6380d6024ada",
+        "byte_size": 1027,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "383dfc8610f1c4ac70ed6380d6024ada"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45781"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1209b5fd6974ffee065a3a6c5767fab5",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1209b5fd6974ffee065a3a6c5767fab5"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46213"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6ff7e84e984a2a7a283ae0550acf5fa0",
+        "byte_size": 1027,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6ff7e84e984a2a7a283ae0550acf5fa0"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45930"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "215134b08c99ad535e216dce3cecef73",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "215134b08c99ad535e216dce3cecef73"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45795"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4f6504f90de8cc8caa5ed4eec7fc7a55",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4f6504f90de8cc8caa5ed4eec7fc7a55"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45989"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "dd889f338e9721209a5c7494ea542a48",
+        "byte_size": 456033,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "dd889f338e9721209a5c7494ea542a48"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45891"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8a7a7e378d88a320bc13aa573e33e9cf",
+        "byte_size": 1028,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8a7a7e378d88a320bc13aa573e33e9cf"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45988"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f26b54d5131b4150f67442ba57d247e1",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f26b54d5131b4150f67442ba57d247e1"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45375"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "794ddb9e826cd7224e77a581d33b2af5",
+        "byte_size": 1028,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "794ddb9e826cd7224e77a581d33b2af5"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46068"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f65dc11611257fa72e9ae4a1fa1061f9",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f65dc11611257fa72e9ae4a1fa1061f9"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45813"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a21e290d360f3207465b7919fe9f97c4",
+        "byte_size": 1028,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a21e290d360f3207465b7919fe9f97c4"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45513"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "69773a651271d49947757f38d3a8a144",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "69773a651271d49947757f38d3a8a144"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46054"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1b07b0c2da81eab7a599744912d99a4a",
+        "byte_size": 142,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1b07b0c2da81eab7a599744912d99a4a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45850"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "3ca0ba152166f56d7289348c95c3ff44",
+        "byte_size": 462313,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "3ca0ba152166f56d7289348c95c3ff44"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46035"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a8bd0a40d6efca07de5655eac124c64e",
+        "byte_size": 20736352,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a8bd0a40d6efca07de5655eac124c64e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46507"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-023/",
+        "qualified_part": [
+          {
+            "relation": "sub-023/anat/",
+            "name": "anat"
+          },
+          {
+            "relation": "sub-023/func/",
+            "name": "func"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-023/anat/",
+        "qualified_part": [
+          {
+            "relation": "a8bd0a40d6efca07de5655eac124c64e",
+            "name": "sub-023_T1w.nii"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f37ca22703b567972aed652faea49d66",
+        "byte_size": 1039,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f37ca22703b567972aed652faea49d66"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45202"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-023/func/",
+        "qualified_part": [
+          {
+            "relation": "f37ca22703b567972aed652faea49d66",
+            "name": "sub-023_task-emotionProcessing_echo-1_bold.json"
+          },
+          {
+            "relation": "4342d0862f957a5f96fce660bac4e3af",
+            "name": "sub-023_task-emotionProcessing_echo-1_bold.nii"
+          },
+          {
+            "relation": "4792b52cd808c53813848c4abdd6f864",
+            "name": "sub-023_task-emotionProcessing_echo-2_bold.json"
+          },
+          {
+            "relation": "7c9f2a572ffc612408e129f3cfea236d",
+            "name": "sub-023_task-emotionProcessing_echo-2_bold.nii"
+          },
+          {
+            "relation": "69c92241ea01045e326f37299420d86d",
+            "name": "sub-023_task-emotionProcessing_echo-3_bold.json"
+          },
+          {
+            "relation": "51b324dfec485e2ff3e75c5cef9d20c7",
+            "name": "sub-023_task-emotionProcessing_echo-3_bold.nii"
+          },
+          {
+            "relation": "abba89ac8fe77c31ff817fef92353cf6",
+            "name": "sub-023_task-emotionProcessing_events.tsv.gz"
+          },
+          {
+            "relation": "7a3ccbf6ebd56048969bb4c05f2a8182",
+            "name": "sub-023_task-emotionProcessingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "fb4709163f5988471ffbe97dad8fd3da",
+            "name": "sub-023_task-emotionProcessingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "693618fec310822d37d31a98f147884f",
+            "name": "sub-023_task-emotionProcessingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "daca30ebb1bc9a4f3d08dcc91cfde3a2",
+            "name": "sub-023_task-emotionProcessingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "3b2916f1db199f0ca145a15e09dd1a42",
+            "name": "sub-023_task-emotionProcessingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "70acf8b330aa822ed8eb3a9c15823317",
+            "name": "sub-023_task-emotionProcessingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "6d33cc5bb73b310d1b1e36a0d53f7aba",
+            "name": "sub-023_task-emotionProcessingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "19f64e4eb05f5fb5695085f7d85ec0a1",
+            "name": "sub-023_task-emotionProcessingImagined_physio.json"
+          },
+          {
+            "relation": "c82c6f370103863643536b403619d87f",
+            "name": "sub-023_task-emotionProcessingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "3b2eb7eab727d8085bc51a521a7cd27c",
+            "name": "sub-023_task-emotionProcessing_physio.json"
+          },
+          {
+            "relation": "3885b28dbcccae475ad7dd0e70a1227e",
+            "name": "sub-023_task-emotionProcessing_physio.tsv.gz"
+          },
+          {
+            "relation": "f6862966e25b9d2d40fa354843b873de",
+            "name": "sub-023_task-fingerTapping_echo-1_bold.json"
+          },
+          {
+            "relation": "44dd15ffab91487d67e8a82011de9b60",
+            "name": "sub-023_task-fingerTapping_echo-1_bold.nii"
+          },
+          {
+            "relation": "dd25a8138eae63f4273b92f390706048",
+            "name": "sub-023_task-fingerTapping_echo-2_bold.json"
+          },
+          {
+            "relation": "bfb8ba562c522a0c015a3df39391d4fd",
+            "name": "sub-023_task-fingerTapping_echo-2_bold.nii"
+          },
+          {
+            "relation": "2176277f29fc8dcc3e19f93da85b9197",
+            "name": "sub-023_task-fingerTapping_echo-3_bold.json"
+          },
+          {
+            "relation": "dc634a1d9f10316e2278751c8473c0be",
+            "name": "sub-023_task-fingerTapping_echo-3_bold.nii"
+          },
+          {
+            "relation": "d241154c30bcb0493e2d418d13f8c05f",
+            "name": "sub-023_task-fingerTapping_events.tsv.gz"
+          },
+          {
+            "relation": "b69eed079d6bccffaf00bcb2cda51f57",
+            "name": "sub-023_task-fingerTappingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "8d92bad5d493f07867d69f7c5f6051b8",
+            "name": "sub-023_task-fingerTappingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "44a46805d160d5767824d8cd4b070d58",
+            "name": "sub-023_task-fingerTappingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "00b2cad2433c881267fdfa02a43a2e45",
+            "name": "sub-023_task-fingerTappingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "183ab485778295db7fd46441eacc886c",
+            "name": "sub-023_task-fingerTappingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "4d944b7ac858f2e9662476c1bf995b42",
+            "name": "sub-023_task-fingerTappingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "70e60fa9882a8d30488b374824af6499",
+            "name": "sub-023_task-fingerTappingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "0f0086173d1dcc8bb7d8ec9bdceeb315",
+            "name": "sub-023_task-fingerTappingImagined_physio.json"
+          },
+          {
+            "relation": "042cbbfef09292ac25d134d9135742b4",
+            "name": "sub-023_task-fingerTappingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "3c151582dfa12935a3e94fa555464670",
+            "name": "sub-023_task-fingerTapping_physio.json"
+          },
+          {
+            "relation": "e31a50e5585dac5f86b14c40c44c4641",
+            "name": "sub-023_task-fingerTapping_physio.tsv.gz"
+          },
+          {
+            "relation": "09d9cda61bdca32169b87036a74e4493",
+            "name": "sub-023_task-rest_run-1_echo-1_bold.json"
+          },
+          {
+            "relation": "b184d8b79dfd12b9faf0ab04261a1a8b",
+            "name": "sub-023_task-rest_run-1_echo-1_bold.nii"
+          },
+          {
+            "relation": "c528f0904f8f45b0f3439a80555fe137",
+            "name": "sub-023_task-rest_run-1_echo-2_bold.json"
+          },
+          {
+            "relation": "b0a4fb582ff06cb91fc852ae7e8c12c8",
+            "name": "sub-023_task-rest_run-1_echo-2_bold.nii"
+          },
+          {
+            "relation": "02b896802ac19ea84fb72bee5a6c5fa0",
+            "name": "sub-023_task-rest_run-1_echo-3_bold.json"
+          },
+          {
+            "relation": "5e311054a6aca83fedd5d9f8b2569212",
+            "name": "sub-023_task-rest_run-1_echo-3_bold.nii"
+          },
+          {
+            "relation": "e030b0f4a3d319892d065cd5d6bc7494",
+            "name": "sub-023_task-rest_run-1_physio.json"
+          },
+          {
+            "relation": "9a120a93187292ef4529d19b1f18066a",
+            "name": "sub-023_task-rest_run-1_physio.tsv.gz"
+          },
+          {
+            "relation": "8bbcfc3a334247aa457bb6a6933500d4",
+            "name": "sub-023_task-rest_run-2_echo-1_bold.json"
+          },
+          {
+            "relation": "8b2d236b9fc049bc1e73c5f272803665",
+            "name": "sub-023_task-rest_run-2_echo-1_bold.nii"
+          },
+          {
+            "relation": "1560ffeb235caa9c32ac0b9fcb036329",
+            "name": "sub-023_task-rest_run-2_echo-2_bold.json"
+          },
+          {
+            "relation": "eb6400394e46f8e946cac3f4ab9a9801",
+            "name": "sub-023_task-rest_run-2_echo-2_bold.nii"
+          },
+          {
+            "relation": "059ef7e442bd839ee701943a2610491b",
+            "name": "sub-023_task-rest_run-2_echo-3_bold.json"
+          },
+          {
+            "relation": "cfba33beea207804ebb08ce5671d388f",
+            "name": "sub-023_task-rest_run-2_echo-3_bold.nii"
+          },
+          {
+            "relation": "21df412a6b8ed1f09cdcaa771100053e",
+            "name": "sub-023_task-rest_run-2_physio.json"
+          },
+          {
+            "relation": "df611445b7a2a0b8c819f3f22303e501",
+            "name": "sub-023_task-rest_run-2_physio.tsv.gz"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4342d0862f957a5f96fce660bac4e3af",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4342d0862f957a5f96fce660bac4e3af"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45222"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4792b52cd808c53813848c4abdd6f864",
+        "byte_size": 1039,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4792b52cd808c53813848c4abdd6f864"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46387"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "7c9f2a572ffc612408e129f3cfea236d",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "7c9f2a572ffc612408e129f3cfea236d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45621"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "69c92241ea01045e326f37299420d86d",
+        "byte_size": 1039,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "69c92241ea01045e326f37299420d86d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45317"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "51b324dfec485e2ff3e75c5cef9d20c7",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "51b324dfec485e2ff3e75c5cef9d20c7"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45388"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "abba89ac8fe77c31ff817fef92353cf6",
+        "byte_size": 1906,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "abba89ac8fe77c31ff817fef92353cf6"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46637"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "7a3ccbf6ebd56048969bb4c05f2a8182",
+        "byte_size": 1047,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "7a3ccbf6ebd56048969bb4c05f2a8182"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46022"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "fb4709163f5988471ffbe97dad8fd3da",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "fb4709163f5988471ffbe97dad8fd3da"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45187"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "693618fec310822d37d31a98f147884f",
+        "byte_size": 1047,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "693618fec310822d37d31a98f147884f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46208"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "daca30ebb1bc9a4f3d08dcc91cfde3a2",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "daca30ebb1bc9a4f3d08dcc91cfde3a2"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45980"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "3b2916f1db199f0ca145a15e09dd1a42",
+        "byte_size": 1047,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "3b2916f1db199f0ca145a15e09dd1a42"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45739"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "70acf8b330aa822ed8eb3a9c15823317",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "70acf8b330aa822ed8eb3a9c15823317"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45533"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6d33cc5bb73b310d1b1e36a0d53f7aba",
+        "byte_size": 177,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6d33cc5bb73b310d1b1e36a0d53f7aba"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46619"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "19f64e4eb05f5fb5695085f7d85ec0a1",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "19f64e4eb05f5fb5695085f7d85ec0a1"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46323"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c82c6f370103863643536b403619d87f",
+        "byte_size": 496920,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c82c6f370103863643536b403619d87f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45298"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "3b2eb7eab727d8085bc51a521a7cd27c",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "3b2eb7eab727d8085bc51a521a7cd27c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46053"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "3885b28dbcccae475ad7dd0e70a1227e",
+        "byte_size": 488767,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "3885b28dbcccae475ad7dd0e70a1227e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46283"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f6862966e25b9d2d40fa354843b873de",
+        "byte_size": 1034,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f6862966e25b9d2d40fa354843b873de"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45410"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "44dd15ffab91487d67e8a82011de9b60",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "44dd15ffab91487d67e8a82011de9b60"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45103"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "dd25a8138eae63f4273b92f390706048",
+        "byte_size": 1034,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "dd25a8138eae63f4273b92f390706048"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45638"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "bfb8ba562c522a0c015a3df39391d4fd",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "bfb8ba562c522a0c015a3df39391d4fd"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46147"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2176277f29fc8dcc3e19f93da85b9197",
+        "byte_size": 1034,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2176277f29fc8dcc3e19f93da85b9197"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46406"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "dc634a1d9f10316e2278751c8473c0be",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "dc634a1d9f10316e2278751c8473c0be"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46448"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d241154c30bcb0493e2d418d13f8c05f",
+        "byte_size": 161,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d241154c30bcb0493e2d418d13f8c05f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46649"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b69eed079d6bccffaf00bcb2cda51f57",
+        "byte_size": 1043,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b69eed079d6bccffaf00bcb2cda51f57"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45847"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8d92bad5d493f07867d69f7c5f6051b8",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8d92bad5d493f07867d69f7c5f6051b8"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45690"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "44a46805d160d5767824d8cd4b070d58",
+        "byte_size": 1043,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "44a46805d160d5767824d8cd4b070d58"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46212"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "00b2cad2433c881267fdfa02a43a2e45",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "00b2cad2433c881267fdfa02a43a2e45"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45457"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "183ab485778295db7fd46441eacc886c",
+        "byte_size": 1043,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "183ab485778295db7fd46441eacc886c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45785"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4d944b7ac858f2e9662476c1bf995b42",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4d944b7ac858f2e9662476c1bf995b42"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45219"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "70e60fa9882a8d30488b374824af6499",
+        "byte_size": 178,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "70e60fa9882a8d30488b374824af6499"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46592"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "0f0086173d1dcc8bb7d8ec9bdceeb315",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "0f0086173d1dcc8bb7d8ec9bdceeb315"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46366"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "042cbbfef09292ac25d134d9135742b4",
+        "byte_size": 512377,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "042cbbfef09292ac25d134d9135742b4"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45932"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "3c151582dfa12935a3e94fa555464670",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "3c151582dfa12935a3e94fa555464670"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46375"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e31a50e5585dac5f86b14c40c44c4641",
+        "byte_size": 573250,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e31a50e5585dac5f86b14c40c44c4641"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46026"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "09d9cda61bdca32169b87036a74e4493",
+        "byte_size": 1026,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "09d9cda61bdca32169b87036a74e4493"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45468"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b184d8b79dfd12b9faf0ab04261a1a8b",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b184d8b79dfd12b9faf0ab04261a1a8b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45849"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c528f0904f8f45b0f3439a80555fe137",
+        "byte_size": 1026,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c528f0904f8f45b0f3439a80555fe137"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45499"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b0a4fb582ff06cb91fc852ae7e8c12c8",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b0a4fb582ff06cb91fc852ae7e8c12c8"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46210"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "02b896802ac19ea84fb72bee5a6c5fa0",
+        "byte_size": 1026,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "02b896802ac19ea84fb72bee5a6c5fa0"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46452"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5e311054a6aca83fedd5d9f8b2569212",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5e311054a6aca83fedd5d9f8b2569212"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46135"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e030b0f4a3d319892d065cd5d6bc7494",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e030b0f4a3d319892d065cd5d6bc7494"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45127"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "9a120a93187292ef4529d19b1f18066a",
+        "byte_size": 464020,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "9a120a93187292ef4529d19b1f18066a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46312"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8bbcfc3a334247aa457bb6a6933500d4",
+        "byte_size": 1026,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8bbcfc3a334247aa457bb6a6933500d4"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46167"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8b2d236b9fc049bc1e73c5f272803665",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8b2d236b9fc049bc1e73c5f272803665"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45755"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1560ffeb235caa9c32ac0b9fcb036329",
+        "byte_size": 1026,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1560ffeb235caa9c32ac0b9fcb036329"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46424"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "eb6400394e46f8e946cac3f4ab9a9801",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "eb6400394e46f8e946cac3f4ab9a9801"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46482"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "059ef7e442bd839ee701943a2610491b",
+        "byte_size": 1026,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "059ef7e442bd839ee701943a2610491b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45909"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "cfba33beea207804ebb08ce5671d388f",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "cfba33beea207804ebb08ce5671d388f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46234"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "21df412a6b8ed1f09cdcaa771100053e",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "21df412a6b8ed1f09cdcaa771100053e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46072"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "df611445b7a2a0b8c819f3f22303e501",
+        "byte_size": 472513,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "df611445b7a2a0b8c819f3f22303e501"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45943"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "190f6c4c0377b05944ce2878ec313e21",
+        "byte_size": 20736352,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "190f6c4c0377b05944ce2878ec313e21"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45183"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-024/",
+        "qualified_part": [
+          {
+            "relation": "sub-024/anat/",
+            "name": "anat"
+          },
+          {
+            "relation": "sub-024/func/",
+            "name": "func"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-024/anat/",
+        "qualified_part": [
+          {
+            "relation": "190f6c4c0377b05944ce2878ec313e21",
+            "name": "sub-024_T1w.nii"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "68900c5905293046b114fca82ab7d937",
+        "byte_size": 1034,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "68900c5905293046b114fca82ab7d937"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45242"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-024/func/",
+        "qualified_part": [
+          {
+            "relation": "68900c5905293046b114fca82ab7d937",
+            "name": "sub-024_task-emotionProcessing_echo-1_bold.json"
+          },
+          {
+            "relation": "851427f1f7c032e5906507f7d0405bd5",
+            "name": "sub-024_task-emotionProcessing_echo-1_bold.nii"
+          },
+          {
+            "relation": "e596a8ec961747ea3d4b3b1de556d7b0",
+            "name": "sub-024_task-emotionProcessing_echo-2_bold.json"
+          },
+          {
+            "relation": "4d38e51a3708d660e41987da08c79983",
+            "name": "sub-024_task-emotionProcessing_echo-2_bold.nii"
+          },
+          {
+            "relation": "5745803b05c755cfd680e0f53019ef27",
+            "name": "sub-024_task-emotionProcessing_echo-3_bold.json"
+          },
+          {
+            "relation": "e15de8fbb70e212620b8493fd6ecc49b",
+            "name": "sub-024_task-emotionProcessing_echo-3_bold.nii"
+          },
+          {
+            "relation": "701119b52cf299609c5a915e6e2ffd51",
+            "name": "sub-024_task-emotionProcessing_events.tsv.gz"
+          },
+          {
+            "relation": "4a8d9600a8bf9a814c53283b0a8ff9be",
+            "name": "sub-024_task-emotionProcessingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "d3bf097795db1903df7186d7f1e0bf1c",
+            "name": "sub-024_task-emotionProcessingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "33809dec60e32503256f7c45c17797b3",
+            "name": "sub-024_task-emotionProcessingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "67d380c3bd9daeeb8460387ed87a29e8",
+            "name": "sub-024_task-emotionProcessingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "f62132b9d9a3dba3780c37681502185f",
+            "name": "sub-024_task-emotionProcessingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "639095cdb453f2822378e0bb565d37e4",
+            "name": "sub-024_task-emotionProcessingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "ce6d682d4ed61ae643a4a035008d7815",
+            "name": "sub-024_task-emotionProcessingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "5688150bd72bd5aaaf6d4356ecafcf4a",
+            "name": "sub-024_task-emotionProcessingImagined_physio.json"
+          },
+          {
+            "relation": "39de7e6e8e2d3f2cfc6444da6338b4dd",
+            "name": "sub-024_task-emotionProcessingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "569846b608131148ba2ff54e8d610d04",
+            "name": "sub-024_task-emotionProcessing_physio.json"
+          },
+          {
+            "relation": "0cf2d5a06375a9955838110f934deb1b",
+            "name": "sub-024_task-emotionProcessing_physio.tsv.gz"
+          },
+          {
+            "relation": "3642c5b258b8fe806138da050fab7577",
+            "name": "sub-024_task-fingerTapping_echo-1_bold.json"
+          },
+          {
+            "relation": "867676e8bda9acb30d89a4f7ddbb270d",
+            "name": "sub-024_task-fingerTapping_echo-1_bold.nii"
+          },
+          {
+            "relation": "9dc29fcf832822fde8f681b6915eba97",
+            "name": "sub-024_task-fingerTapping_echo-2_bold.json"
+          },
+          {
+            "relation": "fba3ceef317bd3f6b4e952fbe8e95f60",
+            "name": "sub-024_task-fingerTapping_echo-2_bold.nii"
+          },
+          {
+            "relation": "e8b15f05c6532ff094f30434e58ecd54",
+            "name": "sub-024_task-fingerTapping_echo-3_bold.json"
+          },
+          {
+            "relation": "1926d0d618f52d3002e1e66a5760b540",
+            "name": "sub-024_task-fingerTapping_echo-3_bold.nii"
+          },
+          {
+            "relation": "2f57b6782192a800c7065db2a988071c",
+            "name": "sub-024_task-fingerTapping_events.tsv.gz"
+          },
+          {
+            "relation": "25d5c66a770a017ee0ae4663c77b1bd7",
+            "name": "sub-024_task-fingerTappingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "1cbb35815c5f6630a1a068598f67da0c",
+            "name": "sub-024_task-fingerTappingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "6c1a5de28e56da183e2ee15608671ed1",
+            "name": "sub-024_task-fingerTappingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "ad84562e4b9beb78396c96c2e1fda3d4",
+            "name": "sub-024_task-fingerTappingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "c59422134a338595b729c746363dbfaf",
+            "name": "sub-024_task-fingerTappingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "e6e1463f8a5543ce4211ea9434bb0f84",
+            "name": "sub-024_task-fingerTappingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "1112eaa2187cf14649e60accef58ce48",
+            "name": "sub-024_task-fingerTappingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "7de904e51a84a1e94f4080c9dc80bae7",
+            "name": "sub-024_task-fingerTappingImagined_physio.json"
+          },
+          {
+            "relation": "dbc6c08de56357e98e8fab751ec459ae",
+            "name": "sub-024_task-fingerTappingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "96cd7e0c51001877967102a056c08652",
+            "name": "sub-024_task-fingerTapping_physio.json"
+          },
+          {
+            "relation": "5bb5eb74cb99f2cc266f3439c9f1240e",
+            "name": "sub-024_task-fingerTapping_physio.tsv.gz"
+          },
+          {
+            "relation": "f5c7158e1de14a6243ccb67928bf4a15",
+            "name": "sub-024_task-rest_run-1_echo-1_bold.json"
+          },
+          {
+            "relation": "c7bf87ca41c8aa7eb8018a8b4e9c6571",
+            "name": "sub-024_task-rest_run-1_echo-1_bold.nii"
+          },
+          {
+            "relation": "0500137347eae1b221aa40a87a900413",
+            "name": "sub-024_task-rest_run-1_echo-2_bold.json"
+          },
+          {
+            "relation": "1d131b1c3c9d87d0260bcc1618485fe1",
+            "name": "sub-024_task-rest_run-1_echo-2_bold.nii"
+          },
+          {
+            "relation": "4141f90fef546e2fb5c9aad9ddd7b774",
+            "name": "sub-024_task-rest_run-1_echo-3_bold.json"
+          },
+          {
+            "relation": "d0faca977d58aa06eff58b637cf9b906",
+            "name": "sub-024_task-rest_run-1_echo-3_bold.nii"
+          },
+          {
+            "relation": "7784a62a3163771005cac907491c3151",
+            "name": "sub-024_task-rest_run-1_physio.json"
+          },
+          {
+            "relation": "eb419260bf47beaac73513690fbd877e",
+            "name": "sub-024_task-rest_run-1_physio.tsv.gz"
+          },
+          {
+            "relation": "1494bc84b63d4b5f16a1111227e6034d",
+            "name": "sub-024_task-rest_run-2_echo-1_bold.json"
+          },
+          {
+            "relation": "132d374f5df768f4109ad49ebc68b957",
+            "name": "sub-024_task-rest_run-2_echo-1_bold.nii"
+          },
+          {
+            "relation": "70c0a25802f20891aca37f2086d2f36d",
+            "name": "sub-024_task-rest_run-2_echo-2_bold.json"
+          },
+          {
+            "relation": "20b27c94c65afe4b35f4c69463b27f7c",
+            "name": "sub-024_task-rest_run-2_echo-2_bold.nii"
+          },
+          {
+            "relation": "c8ee7ca3c82e8aeeee940a21ea760fd9",
+            "name": "sub-024_task-rest_run-2_echo-3_bold.json"
+          },
+          {
+            "relation": "681bd5c0caa8ab71f905c238ce037af3",
+            "name": "sub-024_task-rest_run-2_echo-3_bold.nii"
+          },
+          {
+            "relation": "15cc74fd2352e18be8675e2ffd1a327a",
+            "name": "sub-024_task-rest_run-2_physio.json"
+          },
+          {
+            "relation": "32435ea664e7ada98f766f86540c042a",
+            "name": "sub-024_task-rest_run-2_physio.tsv.gz"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "851427f1f7c032e5906507f7d0405bd5",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "851427f1f7c032e5906507f7d0405bd5"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45597"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e596a8ec961747ea3d4b3b1de556d7b0",
+        "byte_size": 1034,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e596a8ec961747ea3d4b3b1de556d7b0"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45549"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4d38e51a3708d660e41987da08c79983",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4d38e51a3708d660e41987da08c79983"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45641"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5745803b05c755cfd680e0f53019ef27",
+        "byte_size": 1034,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5745803b05c755cfd680e0f53019ef27"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45512"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e15de8fbb70e212620b8493fd6ecc49b",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e15de8fbb70e212620b8493fd6ecc49b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45518"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "701119b52cf299609c5a915e6e2ffd51",
+        "byte_size": 1897,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "701119b52cf299609c5a915e6e2ffd51"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46606"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4a8d9600a8bf9a814c53283b0a8ff9be",
+        "byte_size": 1042,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4a8d9600a8bf9a814c53283b0a8ff9be"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46201"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d3bf097795db1903df7186d7f1e0bf1c",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d3bf097795db1903df7186d7f1e0bf1c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45421"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "33809dec60e32503256f7c45c17797b3",
+        "byte_size": 1042,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "33809dec60e32503256f7c45c17797b3"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45979"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "67d380c3bd9daeeb8460387ed87a29e8",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "67d380c3bd9daeeb8460387ed87a29e8"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45260"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f62132b9d9a3dba3780c37681502185f",
+        "byte_size": 1042,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f62132b9d9a3dba3780c37681502185f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46287"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "639095cdb453f2822378e0bb565d37e4",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "639095cdb453f2822378e0bb565d37e4"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45766"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ce6d682d4ed61ae643a4a035008d7815",
+        "byte_size": 180,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ce6d682d4ed61ae643a4a035008d7815"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46551"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5688150bd72bd5aaaf6d4356ecafcf4a",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5688150bd72bd5aaaf6d4356ecafcf4a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46309"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "39de7e6e8e2d3f2cfc6444da6338b4dd",
+        "byte_size": 456438,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "39de7e6e8e2d3f2cfc6444da6338b4dd"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45481"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "569846b608131148ba2ff54e8d610d04",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "569846b608131148ba2ff54e8d610d04"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45353"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "0cf2d5a06375a9955838110f934deb1b",
+        "byte_size": 524926,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "0cf2d5a06375a9955838110f934deb1b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46080"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "3642c5b258b8fe806138da050fab7577",
+        "byte_size": 1031,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "3642c5b258b8fe806138da050fab7577"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45441"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "867676e8bda9acb30d89a4f7ddbb270d",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "867676e8bda9acb30d89a4f7ddbb270d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46486"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "9dc29fcf832822fde8f681b6915eba97",
+        "byte_size": 1031,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "9dc29fcf832822fde8f681b6915eba97"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45453"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "fba3ceef317bd3f6b4e952fbe8e95f60",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "fba3ceef317bd3f6b4e952fbe8e95f60"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45546"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e8b15f05c6532ff094f30434e58ecd54",
+        "byte_size": 1031,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e8b15f05c6532ff094f30434e58ecd54"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45565"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1926d0d618f52d3002e1e66a5760b540",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1926d0d618f52d3002e1e66a5760b540"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45679"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2f57b6782192a800c7065db2a988071c",
+        "byte_size": 168,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2f57b6782192a800c7065db2a988071c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46654"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "25d5c66a770a017ee0ae4663c77b1bd7",
+        "byte_size": 1039,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "25d5c66a770a017ee0ae4663c77b1bd7"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45602"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1cbb35815c5f6630a1a068598f67da0c",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1cbb35815c5f6630a1a068598f67da0c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45794"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6c1a5de28e56da183e2ee15608671ed1",
+        "byte_size": 1039,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6c1a5de28e56da183e2ee15608671ed1"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45511"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ad84562e4b9beb78396c96c2e1fda3d4",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ad84562e4b9beb78396c96c2e1fda3d4"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46254"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c59422134a338595b729c746363dbfaf",
+        "byte_size": 1039,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c59422134a338595b729c746363dbfaf"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46268"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e6e1463f8a5543ce4211ea9434bb0f84",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e6e1463f8a5543ce4211ea9434bb0f84"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45870"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1112eaa2187cf14649e60accef58ce48",
+        "byte_size": 180,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1112eaa2187cf14649e60accef58ce48"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46622"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "7de904e51a84a1e94f4080c9dc80bae7",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "7de904e51a84a1e94f4080c9dc80bae7"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46104"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "dbc6c08de56357e98e8fab751ec459ae",
+        "byte_size": 459731,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "dbc6c08de56357e98e8fab751ec459ae"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45215"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "96cd7e0c51001877967102a056c08652",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "96cd7e0c51001877967102a056c08652"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46182"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5bb5eb74cb99f2cc266f3439c9f1240e",
+        "byte_size": 473161,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5bb5eb74cb99f2cc266f3439c9f1240e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45405"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f5c7158e1de14a6243ccb67928bf4a15",
+        "byte_size": 1022,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f5c7158e1de14a6243ccb67928bf4a15"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46189"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c7bf87ca41c8aa7eb8018a8b4e9c6571",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c7bf87ca41c8aa7eb8018a8b4e9c6571"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46019"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "0500137347eae1b221aa40a87a900413",
+        "byte_size": 1022,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "0500137347eae1b221aa40a87a900413"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46085"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1d131b1c3c9d87d0260bcc1618485fe1",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1d131b1c3c9d87d0260bcc1618485fe1"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45413"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4141f90fef546e2fb5c9aad9ddd7b774",
+        "byte_size": 1022,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4141f90fef546e2fb5c9aad9ddd7b774"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45310"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d0faca977d58aa06eff58b637cf9b906",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d0faca977d58aa06eff58b637cf9b906"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45726"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "7784a62a3163771005cac907491c3151",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "7784a62a3163771005cac907491c3151"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46221"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "eb419260bf47beaac73513690fbd877e",
+        "byte_size": 447685,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "eb419260bf47beaac73513690fbd877e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45352"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1494bc84b63d4b5f16a1111227e6034d",
+        "byte_size": 1022,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1494bc84b63d4b5f16a1111227e6034d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46310"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "132d374f5df768f4109ad49ebc68b957",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "132d374f5df768f4109ad49ebc68b957"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45289"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "70c0a25802f20891aca37f2086d2f36d",
+        "byte_size": 1022,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "70c0a25802f20891aca37f2086d2f36d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45214"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "20b27c94c65afe4b35f4c69463b27f7c",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "20b27c94c65afe4b35f4c69463b27f7c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45236"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c8ee7ca3c82e8aeeee940a21ea760fd9",
+        "byte_size": 1022,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c8ee7ca3c82e8aeeee940a21ea760fd9"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45894"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "681bd5c0caa8ab71f905c238ce037af3",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "681bd5c0caa8ab71f905c238ce037af3"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45267"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "15cc74fd2352e18be8675e2ffd1a327a",
+        "byte_size": 141,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "15cc74fd2352e18be8675e2ffd1a327a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45125"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "32435ea664e7ada98f766f86540c042a",
+        "byte_size": 462496,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "32435ea664e7ada98f766f86540c042a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45692"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "7f7a942231041371976b996b0baadb9e",
+        "byte_size": 20736352,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "7f7a942231041371976b996b0baadb9e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45306"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-025/",
+        "qualified_part": [
+          {
+            "relation": "sub-025/anat/",
+            "name": "anat"
+          },
+          {
+            "relation": "sub-025/func/",
+            "name": "func"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-025/anat/",
+        "qualified_part": [
+          {
+            "relation": "7f7a942231041371976b996b0baadb9e",
+            "name": "sub-025_T1w.nii"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "73a60ea9762e960d7701531a74a2ed9d",
+        "byte_size": 1042,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "73a60ea9762e960d7701531a74a2ed9d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45958"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-025/func/",
+        "qualified_part": [
+          {
+            "relation": "73a60ea9762e960d7701531a74a2ed9d",
+            "name": "sub-025_task-emotionProcessing_echo-1_bold.json"
+          },
+          {
+            "relation": "240a45381b94d5ca4d4ade6eaaf7c534",
+            "name": "sub-025_task-emotionProcessing_echo-1_bold.nii"
+          },
+          {
+            "relation": "18f17176166efa9151bb8ca293698c6c",
+            "name": "sub-025_task-emotionProcessing_echo-2_bold.json"
+          },
+          {
+            "relation": "feca4cabeb9b08cf58eeb4c8ba952f77",
+            "name": "sub-025_task-emotionProcessing_echo-2_bold.nii"
+          },
+          {
+            "relation": "79a76423364b453c79bee24ab27fddaa",
+            "name": "sub-025_task-emotionProcessing_echo-3_bold.json"
+          },
+          {
+            "relation": "9f4e28cd101143505ac5185185124158",
+            "name": "sub-025_task-emotionProcessing_echo-3_bold.nii"
+          },
+          {
+            "relation": "74b10e4d7333f58ed1b380af45c84266",
+            "name": "sub-025_task-emotionProcessing_events.tsv.gz"
+          },
+          {
+            "relation": "f53925e9fa6a24259e91d0537d5d725b",
+            "name": "sub-025_task-emotionProcessingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "0577b1e7ea6786bae61031a06220a810",
+            "name": "sub-025_task-emotionProcessingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "e13ebf196f9e07478266674ac5ead24e",
+            "name": "sub-025_task-emotionProcessingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "a994b10225ee41df351809c9358faf85",
+            "name": "sub-025_task-emotionProcessingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "c7b24e636a25b4d08c411f949ab0ef5a",
+            "name": "sub-025_task-emotionProcessingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "15d6eaa340a866de7e64b32cee611a03",
+            "name": "sub-025_task-emotionProcessingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "037993522fb30018c40367a704483687",
+            "name": "sub-025_task-emotionProcessingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "f2ea0de36ad20fbd34744be2686ef790",
+            "name": "sub-025_task-emotionProcessingImagined_physio.json"
+          },
+          {
+            "relation": "5aeaf61ce59c611def6ca7200925fcad",
+            "name": "sub-025_task-emotionProcessingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "495e70560c2f494854fc9dcac2abf81b",
+            "name": "sub-025_task-emotionProcessing_physio.json"
+          },
+          {
+            "relation": "ca9ef6362d3c02e157aa2b5b31663737",
+            "name": "sub-025_task-emotionProcessing_physio.tsv.gz"
+          },
+          {
+            "relation": "2a4112c592ddeeffa7b0d609eaa48472",
+            "name": "sub-025_task-fingerTapping_echo-1_bold.json"
+          },
+          {
+            "relation": "7a4989302353c2507229aa6e1a36a2d9",
+            "name": "sub-025_task-fingerTapping_echo-1_bold.nii"
+          },
+          {
+            "relation": "049d6292f471d9725b1bb562b3f48b20",
+            "name": "sub-025_task-fingerTapping_echo-2_bold.json"
+          },
+          {
+            "relation": "62d567a6946e8f2f95e45e70b33da544",
+            "name": "sub-025_task-fingerTapping_echo-2_bold.nii"
+          },
+          {
+            "relation": "9b661b4cd4ef743034cfef2427b76d08",
+            "name": "sub-025_task-fingerTapping_echo-3_bold.json"
+          },
+          {
+            "relation": "91b40c8fead0371648bd2b77154f9dd1",
+            "name": "sub-025_task-fingerTapping_echo-3_bold.nii"
+          },
+          {
+            "relation": "575dcf28dc7c1641f5117121b99bfb5b",
+            "name": "sub-025_task-fingerTapping_events.tsv.gz"
+          },
+          {
+            "relation": "c2ba2164df29bcb46e163701354cc111",
+            "name": "sub-025_task-fingerTappingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "065a74091eb867a4b9165209bd271403",
+            "name": "sub-025_task-fingerTappingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "45d501c3ef2f6c388b26b5165818aa51",
+            "name": "sub-025_task-fingerTappingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "18bd02a9fc512830f0a2a0f00f23023a",
+            "name": "sub-025_task-fingerTappingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "b555c9c1024633c1267d0bb87060f4a5",
+            "name": "sub-025_task-fingerTappingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "2152b72ca956bf7a8c9ba8392fe4dcf7",
+            "name": "sub-025_task-fingerTappingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "c3721d501643fa74c63a2849bbe0fc29",
+            "name": "sub-025_task-fingerTappingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "bc7ea47540ecc5fd483cea3751596558",
+            "name": "sub-025_task-fingerTappingImagined_physio.json"
+          },
+          {
+            "relation": "2ddca451eda2d8d03218a82b70c566ca",
+            "name": "sub-025_task-fingerTappingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "8ef8c83c58f8e3b5b6118e0b84e00404",
+            "name": "sub-025_task-fingerTapping_physio.json"
+          },
+          {
+            "relation": "ce57f859bfd8c3ce710253e4daa4dd60",
+            "name": "sub-025_task-fingerTapping_physio.tsv.gz"
+          },
+          {
+            "relation": "2c9dcd69ba60afc1907ff85b249312b6",
+            "name": "sub-025_task-rest_run-1_echo-1_bold.json"
+          },
+          {
+            "relation": "60d5dd81c35de9876e0f66908461cbc6",
+            "name": "sub-025_task-rest_run-1_echo-1_bold.nii"
+          },
+          {
+            "relation": "c8e33ac93b50f58fa0687b474791e7d3",
+            "name": "sub-025_task-rest_run-1_echo-2_bold.json"
+          },
+          {
+            "relation": "3a646ee3c1b543a56a0f21176be2efdd",
+            "name": "sub-025_task-rest_run-1_echo-2_bold.nii"
+          },
+          {
+            "relation": "8c21a8507b6cb565588c0140180d2772",
+            "name": "sub-025_task-rest_run-1_echo-3_bold.json"
+          },
+          {
+            "relation": "a147274fd35661aa0c1fa1d7f0b308b1",
+            "name": "sub-025_task-rest_run-1_echo-3_bold.nii"
+          },
+          {
+            "relation": "e53241984863a44ace80f7ae64b587ef",
+            "name": "sub-025_task-rest_run-1_physio.json"
+          },
+          {
+            "relation": "807f681d4fd68b0f5b7bd9a208e0619f",
+            "name": "sub-025_task-rest_run-1_physio.tsv.gz"
+          },
+          {
+            "relation": "b2ef37dc700fe8774b2c78aa3033676b",
+            "name": "sub-025_task-rest_run-2_echo-1_bold.json"
+          },
+          {
+            "relation": "86f7de0aab6e037b267cb59be01522e9",
+            "name": "sub-025_task-rest_run-2_echo-1_bold.nii"
+          },
+          {
+            "relation": "77076e6d43c5ef3e1c1fd7bd96098a54",
+            "name": "sub-025_task-rest_run-2_echo-2_bold.json"
+          },
+          {
+            "relation": "27a372721c92ce378d24b66dc45177a2",
+            "name": "sub-025_task-rest_run-2_echo-2_bold.nii"
+          },
+          {
+            "relation": "a26b09276b6ebf55dcafcc93a40391a9",
+            "name": "sub-025_task-rest_run-2_echo-3_bold.json"
+          },
+          {
+            "relation": "2c415447bbfe53ac60adf92aad2d998e",
+            "name": "sub-025_task-rest_run-2_echo-3_bold.nii"
+          },
+          {
+            "relation": "7dd438d04b16055b2fd0ae4459538b3a",
+            "name": "sub-025_task-rest_run-2_physio.json"
+          },
+          {
+            "relation": "56668a26291c7bd6af6901f2942bc7ba",
+            "name": "sub-025_task-rest_run-2_physio.tsv.gz"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "240a45381b94d5ca4d4ade6eaaf7c534",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "240a45381b94d5ca4d4ade6eaaf7c534"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45351"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "18f17176166efa9151bb8ca293698c6c",
+        "byte_size": 1042,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "18f17176166efa9151bb8ca293698c6c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45198"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "feca4cabeb9b08cf58eeb4c8ba952f77",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "feca4cabeb9b08cf58eeb4c8ba952f77"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46275"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "79a76423364b453c79bee24ab27fddaa",
+        "byte_size": 1042,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "79a76423364b453c79bee24ab27fddaa"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46298"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "9f4e28cd101143505ac5185185124158",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "9f4e28cd101143505ac5185185124158"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45341"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "74b10e4d7333f58ed1b380af45c84266",
+        "byte_size": 1896,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "74b10e4d7333f58ed1b380af45c84266"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46576"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f53925e9fa6a24259e91d0537d5d725b",
+        "byte_size": 1050,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f53925e9fa6a24259e91d0537d5d725b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46037"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "0577b1e7ea6786bae61031a06220a810",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "0577b1e7ea6786bae61031a06220a810"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45491"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e13ebf196f9e07478266674ac5ead24e",
+        "byte_size": 1050,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e13ebf196f9e07478266674ac5ead24e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45898"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a994b10225ee41df351809c9358faf85",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a994b10225ee41df351809c9358faf85"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45929"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c7b24e636a25b4d08c411f949ab0ef5a",
+        "byte_size": 1050,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c7b24e636a25b4d08c411f949ab0ef5a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45743"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "15d6eaa340a866de7e64b32cee611a03",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "15d6eaa340a866de7e64b32cee611a03"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46194"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "037993522fb30018c40367a704483687",
+        "byte_size": 180,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "037993522fb30018c40367a704483687"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46641"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f2ea0de36ad20fbd34744be2686ef790",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f2ea0de36ad20fbd34744be2686ef790"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46062"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5aeaf61ce59c611def6ca7200925fcad",
+        "byte_size": 450969,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5aeaf61ce59c611def6ca7200925fcad"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45662"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "495e70560c2f494854fc9dcac2abf81b",
+        "byte_size": 142,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "495e70560c2f494854fc9dcac2abf81b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45584"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ca9ef6362d3c02e157aa2b5b31663737",
+        "byte_size": 505872,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ca9ef6362d3c02e157aa2b5b31663737"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46348"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2a4112c592ddeeffa7b0d609eaa48472",
+        "byte_size": 1038,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2a4112c592ddeeffa7b0d609eaa48472"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45888"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "7a4989302353c2507229aa6e1a36a2d9",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "7a4989302353c2507229aa6e1a36a2d9"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45181"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "049d6292f471d9725b1bb562b3f48b20",
+        "byte_size": 1038,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "049d6292f471d9725b1bb562b3f48b20"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45500"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "62d567a6946e8f2f95e45e70b33da544",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "62d567a6946e8f2f95e45e70b33da544"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45463"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "9b661b4cd4ef743034cfef2427b76d08",
+        "byte_size": 1038,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "9b661b4cd4ef743034cfef2427b76d08"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45337"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "91b40c8fead0371648bd2b77154f9dd1",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "91b40c8fead0371648bd2b77154f9dd1"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45204"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "575dcf28dc7c1641f5117121b99bfb5b",
+        "byte_size": 167,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "575dcf28dc7c1641f5117121b99bfb5b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46632"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c2ba2164df29bcb46e163701354cc111",
+        "byte_size": 1046,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c2ba2164df29bcb46e163701354cc111"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45925"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "065a74091eb867a4b9165209bd271403",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "065a74091eb867a4b9165209bd271403"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45927"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "45d501c3ef2f6c388b26b5165818aa51",
+        "byte_size": 1046,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "45d501c3ef2f6c388b26b5165818aa51"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45340"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "18bd02a9fc512830f0a2a0f00f23023a",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "18bd02a9fc512830f0a2a0f00f23023a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45567"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b555c9c1024633c1267d0bb87060f4a5",
+        "byte_size": 1046,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b555c9c1024633c1267d0bb87060f4a5"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45978"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2152b72ca956bf7a8c9ba8392fe4dcf7",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2152b72ca956bf7a8c9ba8392fe4dcf7"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45096"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c3721d501643fa74c63a2849bbe0fc29",
+        "byte_size": 179,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c3721d501643fa74c63a2849bbe0fc29"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46555"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "bc7ea47540ecc5fd483cea3751596558",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "bc7ea47540ecc5fd483cea3751596558"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45250"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2ddca451eda2d8d03218a82b70c566ca",
+        "byte_size": 479333,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2ddca451eda2d8d03218a82b70c566ca"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45534"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8ef8c83c58f8e3b5b6118e0b84e00404",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8ef8c83c58f8e3b5b6118e0b84e00404"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45823"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ce57f859bfd8c3ce710253e4daa4dd60",
+        "byte_size": 496050,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ce57f859bfd8c3ce710253e4daa4dd60"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46039"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2c9dcd69ba60afc1907ff85b249312b6",
+        "byte_size": 1029,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2c9dcd69ba60afc1907ff85b249312b6"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45938"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "60d5dd81c35de9876e0f66908461cbc6",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "60d5dd81c35de9876e0f66908461cbc6"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45311"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c8e33ac93b50f58fa0687b474791e7d3",
+        "byte_size": 1029,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c8e33ac93b50f58fa0687b474791e7d3"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45475"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "3a646ee3c1b543a56a0f21176be2efdd",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "3a646ee3c1b543a56a0f21176be2efdd"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46370"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8c21a8507b6cb565588c0140180d2772",
+        "byte_size": 1029,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8c21a8507b6cb565588c0140180d2772"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45753"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a147274fd35661aa0c1fa1d7f0b308b1",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a147274fd35661aa0c1fa1d7f0b308b1"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46272"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e53241984863a44ace80f7ae64b587ef",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e53241984863a44ace80f7ae64b587ef"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45211"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "807f681d4fd68b0f5b7bd9a208e0619f",
+        "byte_size": 457356,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "807f681d4fd68b0f5b7bd9a208e0619f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46116"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b2ef37dc700fe8774b2c78aa3033676b",
+        "byte_size": 1029,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b2ef37dc700fe8774b2c78aa3033676b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46521"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "86f7de0aab6e037b267cb59be01522e9",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "86f7de0aab6e037b267cb59be01522e9"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45322"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "77076e6d43c5ef3e1c1fd7bd96098a54",
+        "byte_size": 1029,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "77076e6d43c5ef3e1c1fd7bd96098a54"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45656"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "27a372721c92ce378d24b66dc45177a2",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "27a372721c92ce378d24b66dc45177a2"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45931"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a26b09276b6ebf55dcafcc93a40391a9",
+        "byte_size": 1029,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a26b09276b6ebf55dcafcc93a40391a9"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46458"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2c415447bbfe53ac60adf92aad2d998e",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2c415447bbfe53ac60adf92aad2d998e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45113"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "7dd438d04b16055b2fd0ae4459538b3a",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "7dd438d04b16055b2fd0ae4459538b3a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45592"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "56668a26291c7bd6af6901f2942bc7ba",
+        "byte_size": 448369,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "56668a26291c7bd6af6901f2942bc7ba"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45367"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b0393dbc149581f72e5faec4f4010dd1",
+        "byte_size": 20736352,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b0393dbc149581f72e5faec4f4010dd1"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45775"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-026/",
+        "qualified_part": [
+          {
+            "relation": "sub-026/anat/",
+            "name": "anat"
+          },
+          {
+            "relation": "sub-026/func/",
+            "name": "func"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-026/anat/",
+        "qualified_part": [
+          {
+            "relation": "b0393dbc149581f72e5faec4f4010dd1",
+            "name": "sub-026_T1w.nii"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c3c5a4acf31d2c108256ac46d603f2e0",
+        "byte_size": 1041,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c3c5a4acf31d2c108256ac46d603f2e0"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46180"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-026/func/",
+        "qualified_part": [
+          {
+            "relation": "c3c5a4acf31d2c108256ac46d603f2e0",
+            "name": "sub-026_task-emotionProcessing_echo-1_bold.json"
+          },
+          {
+            "relation": "770c0aab148ac49b357464c9b08789c1",
+            "name": "sub-026_task-emotionProcessing_echo-1_bold.nii"
+          },
+          {
+            "relation": "22ff64eb37754e5c041c65e50d73e027",
+            "name": "sub-026_task-emotionProcessing_echo-2_bold.json"
+          },
+          {
+            "relation": "e0745a6a4926df590506751ab2f87f2f",
+            "name": "sub-026_task-emotionProcessing_echo-2_bold.nii"
+          },
+          {
+            "relation": "61bcc9bddf6122c8bf7713df4eeca7ae",
+            "name": "sub-026_task-emotionProcessing_echo-3_bold.json"
+          },
+          {
+            "relation": "02180f5df7a7e039eb6be0af5fd144b9",
+            "name": "sub-026_task-emotionProcessing_echo-3_bold.nii"
+          },
+          {
+            "relation": "ad78412b62e046c2d7f46e70c84f0a35",
+            "name": "sub-026_task-emotionProcessing_events.tsv.gz"
+          },
+          {
+            "relation": "5b9a67934af122a9f8a7046d14aac605",
+            "name": "sub-026_task-emotionProcessingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "8604e9da34c047ae16fdeaa56782c720",
+            "name": "sub-026_task-emotionProcessingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "636b783ce7993c116e8df06a0868f804",
+            "name": "sub-026_task-emotionProcessingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "1d0165578e7797307cf5b82d6b546298",
+            "name": "sub-026_task-emotionProcessingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "51c9f9c4f068f84d0d6fc62daae340dd",
+            "name": "sub-026_task-emotionProcessingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "40e7a5baf0522ff99a61028781f06564",
+            "name": "sub-026_task-emotionProcessingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "66f9c2461d4904750d29717f18771847",
+            "name": "sub-026_task-emotionProcessingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "cf612fd13dec932183d848f4b1c211a5",
+            "name": "sub-026_task-emotionProcessingImagined_physio.json"
+          },
+          {
+            "relation": "60bca3447bb980e7b21b9d5d84ac16d0",
+            "name": "sub-026_task-emotionProcessingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "a47ab5b3cf57e4d1dc9923f36acfb62b",
+            "name": "sub-026_task-emotionProcessing_physio.json"
+          },
+          {
+            "relation": "bd2ef171a4203d82411f72eddb69bb55",
+            "name": "sub-026_task-emotionProcessing_physio.tsv.gz"
+          },
+          {
+            "relation": "16cd0167b36edbc8355d6eddf70652a0",
+            "name": "sub-026_task-fingerTapping_echo-1_bold.json"
+          },
+          {
+            "relation": "4e8e0e382d40a67f712be2ddf6978c68",
+            "name": "sub-026_task-fingerTapping_echo-1_bold.nii"
+          },
+          {
+            "relation": "1f7fbd1bd9df0d59e61c5a951a193129",
+            "name": "sub-026_task-fingerTapping_echo-2_bold.json"
+          },
+          {
+            "relation": "584623c4e56b1e15ba62c79455eb934c",
+            "name": "sub-026_task-fingerTapping_echo-2_bold.nii"
+          },
+          {
+            "relation": "380c897d6ec1474bc749b4f529ac5648",
+            "name": "sub-026_task-fingerTapping_echo-3_bold.json"
+          },
+          {
+            "relation": "54414da1d6c300555e243927fd85fa04",
+            "name": "sub-026_task-fingerTapping_echo-3_bold.nii"
+          },
+          {
+            "relation": "b758cca6a704f1302b8830893618918b",
+            "name": "sub-026_task-fingerTapping_events.tsv.gz"
+          },
+          {
+            "relation": "4d3fdda5ac93b7abaded38f5dcb36a1a",
+            "name": "sub-026_task-fingerTappingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "a2d337bf912bd286970e48b179d1eb67",
+            "name": "sub-026_task-fingerTappingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "61aaeafeb068f2e4474db1ddc062709f",
+            "name": "sub-026_task-fingerTappingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "43469f452f999528b527ddbb5781ca8c",
+            "name": "sub-026_task-fingerTappingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "ec8247219a8d162e6b41a79edb16b048",
+            "name": "sub-026_task-fingerTappingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "97553d139ca593353f3a0137b66678e3",
+            "name": "sub-026_task-fingerTappingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "4a4be477b2f82edd56c569aef703b1ea",
+            "name": "sub-026_task-fingerTappingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "8ebb24c7fcc1281d2306572f11ab4a82",
+            "name": "sub-026_task-fingerTappingImagined_physio.json"
+          },
+          {
+            "relation": "6950b366743ab0a636aaa9caf8acf961",
+            "name": "sub-026_task-fingerTappingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "5020aca0469a7eda04d8cf6e4ef3d87d",
+            "name": "sub-026_task-fingerTapping_physio.json"
+          },
+          {
+            "relation": "878f685f595fa9dc696feef4789bb331",
+            "name": "sub-026_task-fingerTapping_physio.tsv.gz"
+          },
+          {
+            "relation": "0fbbcca7138fd1ff8277c69bf9f03938",
+            "name": "sub-026_task-rest_run-1_echo-1_bold.json"
+          },
+          {
+            "relation": "fc12d511864f590534b7649311359b6e",
+            "name": "sub-026_task-rest_run-1_echo-1_bold.nii"
+          },
+          {
+            "relation": "bf8044e98020ad358d35b4f684a2df61",
+            "name": "sub-026_task-rest_run-1_echo-2_bold.json"
+          },
+          {
+            "relation": "d432804d113ad3d24db7c09eb0e4a928",
+            "name": "sub-026_task-rest_run-1_echo-2_bold.nii"
+          },
+          {
+            "relation": "873faf19266364b522c1d6ff010a23f4",
+            "name": "sub-026_task-rest_run-1_echo-3_bold.json"
+          },
+          {
+            "relation": "ca995fcfd80b219b2a474a351aa6256b",
+            "name": "sub-026_task-rest_run-1_echo-3_bold.nii"
+          },
+          {
+            "relation": "b1d969444e3b2cf6a637e0e401af8ed2",
+            "name": "sub-026_task-rest_run-1_physio.json"
+          },
+          {
+            "relation": "c7322b9e688232d8591496c9bacdd07f",
+            "name": "sub-026_task-rest_run-1_physio.tsv.gz"
+          },
+          {
+            "relation": "b027df5bf2692e25e4389b3c1d61121f",
+            "name": "sub-026_task-rest_run-2_echo-1_bold.json"
+          },
+          {
+            "relation": "cfea757fd830246c0e200499328caa6f",
+            "name": "sub-026_task-rest_run-2_echo-1_bold.nii"
+          },
+          {
+            "relation": "807807cadb2a53b8ab053c87c28dba77",
+            "name": "sub-026_task-rest_run-2_echo-2_bold.json"
+          },
+          {
+            "relation": "bf5a83754588b04028a3b542c683c680",
+            "name": "sub-026_task-rest_run-2_echo-2_bold.nii"
+          },
+          {
+            "relation": "e2bbb35ec65a1da6ac637993aed9555f",
+            "name": "sub-026_task-rest_run-2_echo-3_bold.json"
+          },
+          {
+            "relation": "d4f0ac826307f186692d28d962a4cb33",
+            "name": "sub-026_task-rest_run-2_echo-3_bold.nii"
+          },
+          {
+            "relation": "f2ed61b872263d38fa3b3f5c35d46451",
+            "name": "sub-026_task-rest_run-2_physio.json"
+          },
+          {
+            "relation": "08050fddf8b54edcf6e8dd20ed418b49",
+            "name": "sub-026_task-rest_run-2_physio.tsv.gz"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "770c0aab148ac49b357464c9b08789c1",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "770c0aab148ac49b357464c9b08789c1"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45720"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "22ff64eb37754e5c041c65e50d73e027",
+        "byte_size": 1041,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "22ff64eb37754e5c041c65e50d73e027"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45124"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e0745a6a4926df590506751ab2f87f2f",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e0745a6a4926df590506751ab2f87f2f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46126"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "61bcc9bddf6122c8bf7713df4eeca7ae",
+        "byte_size": 1041,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "61bcc9bddf6122c8bf7713df4eeca7ae"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45191"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "02180f5df7a7e039eb6be0af5fd144b9",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "02180f5df7a7e039eb6be0af5fd144b9"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45717"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ad78412b62e046c2d7f46e70c84f0a35",
+        "byte_size": 1902,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ad78412b62e046c2d7f46e70c84f0a35"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46627"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5b9a67934af122a9f8a7046d14aac605",
+        "byte_size": 1049,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5b9a67934af122a9f8a7046d14aac605"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45316"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8604e9da34c047ae16fdeaa56782c720",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8604e9da34c047ae16fdeaa56782c720"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45407"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "636b783ce7993c116e8df06a0868f804",
+        "byte_size": 1049,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "636b783ce7993c116e8df06a0868f804"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45443"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1d0165578e7797307cf5b82d6b546298",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1d0165578e7797307cf5b82d6b546298"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45736"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "51c9f9c4f068f84d0d6fc62daae340dd",
+        "byte_size": 1049,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "51c9f9c4f068f84d0d6fc62daae340dd"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46207"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "40e7a5baf0522ff99a61028781f06564",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "40e7a5baf0522ff99a61028781f06564"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45784"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "66f9c2461d4904750d29717f18771847",
+        "byte_size": 178,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "66f9c2461d4904750d29717f18771847"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46572"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "cf612fd13dec932183d848f4b1c211a5",
+        "byte_size": 142,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "cf612fd13dec932183d848f4b1c211a5"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45802"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "60bca3447bb980e7b21b9d5d84ac16d0",
+        "byte_size": 464619,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "60bca3447bb980e7b21b9d5d84ac16d0"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45361"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a47ab5b3cf57e4d1dc9923f36acfb62b",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a47ab5b3cf57e4d1dc9923f36acfb62b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45748"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "bd2ef171a4203d82411f72eddb69bb55",
+        "byte_size": 476434,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "bd2ef171a4203d82411f72eddb69bb55"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45752"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "16cd0167b36edbc8355d6eddf70652a0",
+        "byte_size": 1037,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "16cd0167b36edbc8355d6eddf70652a0"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45356"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4e8e0e382d40a67f712be2ddf6978c68",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4e8e0e382d40a67f712be2ddf6978c68"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45358"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1f7fbd1bd9df0d59e61c5a951a193129",
+        "byte_size": 1037,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1f7fbd1bd9df0d59e61c5a951a193129"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45706"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "584623c4e56b1e15ba62c79455eb934c",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "584623c4e56b1e15ba62c79455eb934c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46203"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "380c897d6ec1474bc749b4f529ac5648",
+        "byte_size": 1037,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "380c897d6ec1474bc749b4f529ac5648"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46197"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "54414da1d6c300555e243927fd85fa04",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "54414da1d6c300555e243927fd85fa04"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46500"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b758cca6a704f1302b8830893618918b",
+        "byte_size": 166,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b758cca6a704f1302b8830893618918b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46657"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4d3fdda5ac93b7abaded38f5dcb36a1a",
+        "byte_size": 1045,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4d3fdda5ac93b7abaded38f5dcb36a1a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45863"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a2d337bf912bd286970e48b179d1eb67",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a2d337bf912bd286970e48b179d1eb67"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46003"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "61aaeafeb068f2e4474db1ddc062709f",
+        "byte_size": 1045,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "61aaeafeb068f2e4474db1ddc062709f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45207"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "43469f452f999528b527ddbb5781ca8c",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "43469f452f999528b527ddbb5781ca8c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45593"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ec8247219a8d162e6b41a79edb16b048",
+        "byte_size": 1045,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ec8247219a8d162e6b41a79edb16b048"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45967"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "97553d139ca593353f3a0137b66678e3",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "97553d139ca593353f3a0137b66678e3"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45303"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4a4be477b2f82edd56c569aef703b1ea",
+        "byte_size": 179,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4a4be477b2f82edd56c569aef703b1ea"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46633"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8ebb24c7fcc1281d2306572f11ab4a82",
+        "byte_size": 142,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8ebb24c7fcc1281d2306572f11ab4a82"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45470"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6950b366743ab0a636aaa9caf8acf961",
+        "byte_size": 460022,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6950b366743ab0a636aaa9caf8acf961"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46144"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5020aca0469a7eda04d8cf6e4ef3d87d",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5020aca0469a7eda04d8cf6e4ef3d87d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45442"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "878f685f595fa9dc696feef4789bb331",
+        "byte_size": 497401,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "878f685f595fa9dc696feef4789bb331"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45266"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "0fbbcca7138fd1ff8277c69bf9f03938",
+        "byte_size": 1028,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "0fbbcca7138fd1ff8277c69bf9f03938"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46218"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "fc12d511864f590534b7649311359b6e",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "fc12d511864f590534b7649311359b6e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45210"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "bf8044e98020ad358d35b4f684a2df61",
+        "byte_size": 1028,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "bf8044e98020ad358d35b4f684a2df61"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45201"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d432804d113ad3d24db7c09eb0e4a928",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d432804d113ad3d24db7c09eb0e4a928"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46430"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "873faf19266364b522c1d6ff010a23f4",
+        "byte_size": 1028,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "873faf19266364b522c1d6ff010a23f4"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45730"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ca995fcfd80b219b2a474a351aa6256b",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ca995fcfd80b219b2a474a351aa6256b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45899"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b1d969444e3b2cf6a637e0e401af8ed2",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b1d969444e3b2cf6a637e0e401af8ed2"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45915"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c7322b9e688232d8591496c9bacdd07f",
+        "byte_size": 465084,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c7322b9e688232d8591496c9bacdd07f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45221"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b027df5bf2692e25e4389b3c1d61121f",
+        "byte_size": 1028,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b027df5bf2692e25e4389b3c1d61121f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46115"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "cfea757fd830246c0e200499328caa6f",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "cfea757fd830246c0e200499328caa6f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46346"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "807807cadb2a53b8ab053c87c28dba77",
+        "byte_size": 1028,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "807807cadb2a53b8ab053c87c28dba77"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46495"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "bf5a83754588b04028a3b542c683c680",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "bf5a83754588b04028a3b542c683c680"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46255"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e2bbb35ec65a1da6ac637993aed9555f",
+        "byte_size": 1028,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e2bbb35ec65a1da6ac637993aed9555f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46091"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d4f0ac826307f186692d28d962a4cb33",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d4f0ac826307f186692d28d962a4cb33"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45446"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f2ed61b872263d38fa3b3f5c35d46451",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f2ed61b872263d38fa3b3f5c35d46451"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46504"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "08050fddf8b54edcf6e8dd20ed418b49",
+        "byte_size": 449037,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "08050fddf8b54edcf6e8dd20ed418b49"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46502"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "391360fed2f0ad9f464d4300b04fe8f4",
+        "byte_size": 20736352,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "391360fed2f0ad9f464d4300b04fe8f4"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46196"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-027/",
+        "qualified_part": [
+          {
+            "relation": "sub-027/anat/",
+            "name": "anat"
+          },
+          {
+            "relation": "sub-027/func/",
+            "name": "func"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-027/anat/",
+        "qualified_part": [
+          {
+            "relation": "391360fed2f0ad9f464d4300b04fe8f4",
+            "name": "sub-027_T1w.nii"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "9160e7408a54f19cd6943c271a0643bc",
+        "byte_size": 1040,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "9160e7408a54f19cd6943c271a0643bc"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45240"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-027/func/",
+        "qualified_part": [
+          {
+            "relation": "9160e7408a54f19cd6943c271a0643bc",
+            "name": "sub-027_task-emotionProcessing_echo-1_bold.json"
+          },
+          {
+            "relation": "d741e2a020dc97ad80e6205bdcc1953c",
+            "name": "sub-027_task-emotionProcessing_echo-1_bold.nii"
+          },
+          {
+            "relation": "c8397b637fc28c1468f26a8e6fca9854",
+            "name": "sub-027_task-emotionProcessing_echo-2_bold.json"
+          },
+          {
+            "relation": "d3d77d1e8d03a761c3d9c1e29113cd46",
+            "name": "sub-027_task-emotionProcessing_echo-2_bold.nii"
+          },
+          {
+            "relation": "2b703cf362406375d6b528f6f8eff65b",
+            "name": "sub-027_task-emotionProcessing_echo-3_bold.json"
+          },
+          {
+            "relation": "b27fcc2c413af187edddb0a4d94fae78",
+            "name": "sub-027_task-emotionProcessing_echo-3_bold.nii"
+          },
+          {
+            "relation": "64a1e3bbdc41d6cca658ff58ac0703ce",
+            "name": "sub-027_task-emotionProcessing_events.tsv.gz"
+          },
+          {
+            "relation": "b340ada6fbcebfc0999e079125cde231",
+            "name": "sub-027_task-emotionProcessingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "3a8b601a8da50c346c16721f01f843f3",
+            "name": "sub-027_task-emotionProcessingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "10940b21e34c03e91d4f0e3b70388ab7",
+            "name": "sub-027_task-emotionProcessingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "94e31e6ff6ad8b9212a23835abc46588",
+            "name": "sub-027_task-emotionProcessingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "1337be6106cbe1368eb2384d1e0614af",
+            "name": "sub-027_task-emotionProcessingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "45b90f82c23548d7c07299a03c5a219d",
+            "name": "sub-027_task-emotionProcessingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "6edd4c82ceac6be3e069f15c3613ee2e",
+            "name": "sub-027_task-emotionProcessingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "7da3a6096bb9532815b05563ec61bf57",
+            "name": "sub-027_task-emotionProcessingImagined_physio.json"
+          },
+          {
+            "relation": "57b540b40cb1493e98612110fa28c93c",
+            "name": "sub-027_task-emotionProcessingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "ff828f0cbc209f4601b5acb666ec2e61",
+            "name": "sub-027_task-emotionProcessing_physio.json"
+          },
+          {
+            "relation": "5e2a55382b9d1cab3a0d8cee81c57b16",
+            "name": "sub-027_task-emotionProcessing_physio.tsv.gz"
+          },
+          {
+            "relation": "e891f95434005225ed9747717d7b5606",
+            "name": "sub-027_task-fingerTapping_echo-1_bold.json"
+          },
+          {
+            "relation": "3608b349357d99e9c57f0bebefdb5dba",
+            "name": "sub-027_task-fingerTapping_echo-1_bold.nii"
+          },
+          {
+            "relation": "88ca6bae797eeef31ab85c72c8f1b83d",
+            "name": "sub-027_task-fingerTapping_echo-2_bold.json"
+          },
+          {
+            "relation": "3e3c6c87080b1b228d590288ed93bf88",
+            "name": "sub-027_task-fingerTapping_echo-2_bold.nii"
+          },
+          {
+            "relation": "e674d6920f9c458f9afbb3ce20416156",
+            "name": "sub-027_task-fingerTapping_echo-3_bold.json"
+          },
+          {
+            "relation": "ceca9bc881d3d8c2dce5a93323a9bab8",
+            "name": "sub-027_task-fingerTapping_echo-3_bold.nii"
+          },
+          {
+            "relation": "0c8eb59418ffe7b04c69942e22d446fb",
+            "name": "sub-027_task-fingerTapping_events.tsv.gz"
+          },
+          {
+            "relation": "a093f58299db4d28fbda66cbc6182c22",
+            "name": "sub-027_task-fingerTappingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "cb6ba5d1cbb04710d9c08597388e22ec",
+            "name": "sub-027_task-fingerTappingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "4aff660c764a99132d29bedb2eeaf39c",
+            "name": "sub-027_task-fingerTappingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "7d1773442a1c6e9a171350de28e8df0d",
+            "name": "sub-027_task-fingerTappingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "4722a3d37ecee2451946a7f7897fec2c",
+            "name": "sub-027_task-fingerTappingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "d1ba9ec1cca3971aa85232714599548c",
+            "name": "sub-027_task-fingerTappingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "4b8a49c8748a47a811bf90760466590c",
+            "name": "sub-027_task-fingerTappingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "201ea354a8c6c2f9090f93a83c70533f",
+            "name": "sub-027_task-fingerTappingImagined_physio.json"
+          },
+          {
+            "relation": "7ba98152b934f6d16a8e5f3350fe483e",
+            "name": "sub-027_task-fingerTappingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "c0c17e9c4c91d0d05d553dc841d298ed",
+            "name": "sub-027_task-fingerTapping_physio.json"
+          },
+          {
+            "relation": "009b85384195d8104c10f0df6726bb8b",
+            "name": "sub-027_task-fingerTapping_physio.tsv.gz"
+          },
+          {
+            "relation": "253882b38043b647b0541a58a3f82db4",
+            "name": "sub-027_task-rest_run-1_echo-1_bold.json"
+          },
+          {
+            "relation": "8ffcf3f54f89836cae1c0bbc17020b3e",
+            "name": "sub-027_task-rest_run-1_echo-1_bold.nii"
+          },
+          {
+            "relation": "686d54fb051d3f88ea343fcc3c95275b",
+            "name": "sub-027_task-rest_run-1_echo-2_bold.json"
+          },
+          {
+            "relation": "25adaf8e38e816070776d127d853c399",
+            "name": "sub-027_task-rest_run-1_echo-2_bold.nii"
+          },
+          {
+            "relation": "e5f7167edc3dfaf10919d8371c6239ed",
+            "name": "sub-027_task-rest_run-1_echo-3_bold.json"
+          },
+          {
+            "relation": "0d67d81e894e7de8301c486e78e91650",
+            "name": "sub-027_task-rest_run-1_echo-3_bold.nii"
+          },
+          {
+            "relation": "ad035f41a9d628c3a43837a17ffc50f7",
+            "name": "sub-027_task-rest_run-1_physio.json"
+          },
+          {
+            "relation": "cedec6211e60ce688cdb00403a795c16",
+            "name": "sub-027_task-rest_run-1_physio.tsv.gz"
+          },
+          {
+            "relation": "9634dc297777a27ef17e67ff2f31b423",
+            "name": "sub-027_task-rest_run-2_echo-1_bold.json"
+          },
+          {
+            "relation": "839e798f0209fb7dd87cc483ee4f3b78",
+            "name": "sub-027_task-rest_run-2_echo-1_bold.nii"
+          },
+          {
+            "relation": "9f79bf08427dd6445dcc5198eadead64",
+            "name": "sub-027_task-rest_run-2_echo-2_bold.json"
+          },
+          {
+            "relation": "935489062a230bd4231076feba9393cd",
+            "name": "sub-027_task-rest_run-2_echo-2_bold.nii"
+          },
+          {
+            "relation": "ce58fa531efd9f62eb4b75982de83e5a",
+            "name": "sub-027_task-rest_run-2_echo-3_bold.json"
+          },
+          {
+            "relation": "7f3c62626662b3d21664314518af4ddc",
+            "name": "sub-027_task-rest_run-2_echo-3_bold.nii"
+          },
+          {
+            "relation": "3a52de0bfc90eef9cd273d188e194ff5",
+            "name": "sub-027_task-rest_run-2_physio.json"
+          },
+          {
+            "relation": "e6481ed05c3fa687ffa6f9d8388cde2e",
+            "name": "sub-027_task-rest_run-2_physio.tsv.gz"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d741e2a020dc97ad80e6205bdcc1953c",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d741e2a020dc97ad80e6205bdcc1953c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46467"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c8397b637fc28c1468f26a8e6fca9854",
+        "byte_size": 1040,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c8397b637fc28c1468f26a8e6fca9854"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46490"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d3d77d1e8d03a761c3d9c1e29113cd46",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d3d77d1e8d03a761c3d9c1e29113cd46"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45728"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2b703cf362406375d6b528f6f8eff65b",
+        "byte_size": 1040,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2b703cf362406375d6b528f6f8eff65b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46099"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b27fcc2c413af187edddb0a4d94fae78",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b27fcc2c413af187edddb0a4d94fae78"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46270"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "64a1e3bbdc41d6cca658ff58ac0703ce",
+        "byte_size": 1886,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "64a1e3bbdc41d6cca658ff58ac0703ce"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46643"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b340ada6fbcebfc0999e079125cde231",
+        "byte_size": 1047,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b340ada6fbcebfc0999e079125cde231"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46382"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "3a8b601a8da50c346c16721f01f843f3",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "3a8b601a8da50c346c16721f01f843f3"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46132"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "10940b21e34c03e91d4f0e3b70388ab7",
+        "byte_size": 1047,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "10940b21e34c03e91d4f0e3b70388ab7"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46420"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "94e31e6ff6ad8b9212a23835abc46588",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "94e31e6ff6ad8b9212a23835abc46588"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46025"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1337be6106cbe1368eb2384d1e0614af",
+        "byte_size": 1047,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1337be6106cbe1368eb2384d1e0614af"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45551"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "45b90f82c23548d7c07299a03c5a219d",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "45b90f82c23548d7c07299a03c5a219d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45301"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6edd4c82ceac6be3e069f15c3613ee2e",
+        "byte_size": 178,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6edd4c82ceac6be3e069f15c3613ee2e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46613"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "7da3a6096bb9532815b05563ec61bf57",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "7da3a6096bb9532815b05563ec61bf57"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46179"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "57b540b40cb1493e98612110fa28c93c",
+        "byte_size": 488218,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "57b540b40cb1493e98612110fa28c93c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46242"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ff828f0cbc209f4601b5acb666ec2e61",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ff828f0cbc209f4601b5acb666ec2e61"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45510"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5e2a55382b9d1cab3a0d8cee81c57b16",
+        "byte_size": 516529,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5e2a55382b9d1cab3a0d8cee81c57b16"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46489"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e891f95434005225ed9747717d7b5606",
+        "byte_size": 1036,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e891f95434005225ed9747717d7b5606"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45803"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "3608b349357d99e9c57f0bebefdb5dba",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "3608b349357d99e9c57f0bebefdb5dba"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45503"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "88ca6bae797eeef31ab85c72c8f1b83d",
+        "byte_size": 1036,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "88ca6bae797eeef31ab85c72c8f1b83d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46219"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "3e3c6c87080b1b228d590288ed93bf88",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "3e3c6c87080b1b228d590288ed93bf88"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45951"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e674d6920f9c458f9afbb3ce20416156",
+        "byte_size": 1036,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e674d6920f9c458f9afbb3ce20416156"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45848"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ceca9bc881d3d8c2dce5a93323a9bab8",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ceca9bc881d3d8c2dce5a93323a9bab8"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46492"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "0c8eb59418ffe7b04c69942e22d446fb",
+        "byte_size": 167,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "0c8eb59418ffe7b04c69942e22d446fb"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46573"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a093f58299db4d28fbda66cbc6182c22",
+        "byte_size": 1043,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a093f58299db4d28fbda66cbc6182c22"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46029"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "cb6ba5d1cbb04710d9c08597388e22ec",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "cb6ba5d1cbb04710d9c08597388e22ec"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46480"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4aff660c764a99132d29bedb2eeaf39c",
+        "byte_size": 1043,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4aff660c764a99132d29bedb2eeaf39c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46439"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "7d1773442a1c6e9a171350de28e8df0d",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "7d1773442a1c6e9a171350de28e8df0d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46328"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4722a3d37ecee2451946a7f7897fec2c",
+        "byte_size": 1043,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4722a3d37ecee2451946a7f7897fec2c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45896"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d1ba9ec1cca3971aa85232714599548c",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d1ba9ec1cca3971aa85232714599548c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45174"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4b8a49c8748a47a811bf90760466590c",
+        "byte_size": 179,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4b8a49c8748a47a811bf90760466590c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46565"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "201ea354a8c6c2f9090f93a83c70533f",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "201ea354a8c6c2f9090f93a83c70533f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45531"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "7ba98152b934f6d16a8e5f3350fe483e",
+        "byte_size": 493219,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "7ba98152b934f6d16a8e5f3350fe483e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45699"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c0c17e9c4c91d0d05d553dc841d298ed",
+        "byte_size": 142,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c0c17e9c4c91d0d05d553dc841d298ed"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45345"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "009b85384195d8104c10f0df6726bb8b",
+        "byte_size": 499845,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "009b85384195d8104c10f0df6726bb8b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45659"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "253882b38043b647b0541a58a3f82db4",
+        "byte_size": 1026,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "253882b38043b647b0541a58a3f82db4"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45839"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8ffcf3f54f89836cae1c0bbc17020b3e",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8ffcf3f54f89836cae1c0bbc17020b3e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46239"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "686d54fb051d3f88ea343fcc3c95275b",
+        "byte_size": 1026,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "686d54fb051d3f88ea343fcc3c95275b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45876"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "25adaf8e38e816070776d127d853c399",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "25adaf8e38e816070776d127d853c399"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45762"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e5f7167edc3dfaf10919d8371c6239ed",
+        "byte_size": 1026,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e5f7167edc3dfaf10919d8371c6239ed"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45856"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "0d67d81e894e7de8301c486e78e91650",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "0d67d81e894e7de8301c486e78e91650"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46340"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ad035f41a9d628c3a43837a17ffc50f7",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ad035f41a9d628c3a43837a17ffc50f7"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46462"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "cedec6211e60ce688cdb00403a795c16",
+        "byte_size": 473633,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "cedec6211e60ce688cdb00403a795c16"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45296"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "9634dc297777a27ef17e67ff2f31b423",
+        "byte_size": 1027,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "9634dc297777a27ef17e67ff2f31b423"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45555"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "839e798f0209fb7dd87cc483ee4f3b78",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "839e798f0209fb7dd87cc483ee4f3b78"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46536"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "9f79bf08427dd6445dcc5198eadead64",
+        "byte_size": 1027,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "9f79bf08427dd6445dcc5198eadead64"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46009"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "935489062a230bd4231076feba9393cd",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "935489062a230bd4231076feba9393cd"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46460"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ce58fa531efd9f62eb4b75982de83e5a",
+        "byte_size": 1027,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ce58fa531efd9f62eb4b75982de83e5a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46526"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "7f3c62626662b3d21664314518af4ddc",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "7f3c62626662b3d21664314518af4ddc"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45789"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "3a52de0bfc90eef9cd273d188e194ff5",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "3a52de0bfc90eef9cd273d188e194ff5"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45150"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e6481ed05c3fa687ffa6f9d8388cde2e",
+        "byte_size": 487715,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e6481ed05c3fa687ffa6f9d8388cde2e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46046"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "06483989167b850081d0eab5e4e9d75f",
+        "byte_size": 20736352,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "06483989167b850081d0eab5e4e9d75f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45117"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-029/",
+        "qualified_part": [
+          {
+            "relation": "sub-029/anat/",
+            "name": "anat"
+          },
+          {
+            "relation": "sub-029/func/",
+            "name": "func"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-029/anat/",
+        "qualified_part": [
+          {
+            "relation": "06483989167b850081d0eab5e4e9d75f",
+            "name": "sub-029_T1w.nii"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8ca710b33f86c36e67dab5765f551546",
+        "byte_size": 1041,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8ca710b33f86c36e67dab5765f551546"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46096"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-029/func/",
+        "qualified_part": [
+          {
+            "relation": "8ca710b33f86c36e67dab5765f551546",
+            "name": "sub-029_task-emotionProcessing_echo-1_bold.json"
+          },
+          {
+            "relation": "2ea82caf66be69b706e8da251f3db1d0",
+            "name": "sub-029_task-emotionProcessing_echo-1_bold.nii"
+          },
+          {
+            "relation": "c642a1f2033af0aa25af0f8106ea516e",
+            "name": "sub-029_task-emotionProcessing_echo-2_bold.json"
+          },
+          {
+            "relation": "98f88deb44a64198f93800a8c567fe7c",
+            "name": "sub-029_task-emotionProcessing_echo-2_bold.nii"
+          },
+          {
+            "relation": "aef317b5b3098ea2d40de1ce8b9cfc53",
+            "name": "sub-029_task-emotionProcessing_echo-3_bold.json"
+          },
+          {
+            "relation": "86949512bb0e3dc1ccb8f6881b62c9e9",
+            "name": "sub-029_task-emotionProcessing_echo-3_bold.nii"
+          },
+          {
+            "relation": "d363bda5a57ca4e2a170fb7db38fb98a",
+            "name": "sub-029_task-emotionProcessing_events.tsv.gz"
+          },
+          {
+            "relation": "4b5ebeecc9bfc412bbb6e6207e2ed6d5",
+            "name": "sub-029_task-emotionProcessingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "dc9b6f33e0ae0b074310728fdd5fe572",
+            "name": "sub-029_task-emotionProcessingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "0e9ef021458d12f51f4e91f110661ff9",
+            "name": "sub-029_task-emotionProcessingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "6f3194817a8e84239182251ad1fd57c8",
+            "name": "sub-029_task-emotionProcessingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "c1fca06fbd4937b40f45ab3c82e20e69",
+            "name": "sub-029_task-emotionProcessingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "6a8b3989f7b59fb6989d366b27e6ec00",
+            "name": "sub-029_task-emotionProcessingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "3dd04e9279353a82d5fc7e98460a239f",
+            "name": "sub-029_task-emotionProcessingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "72c92178962a931773723d1358fca1bc",
+            "name": "sub-029_task-emotionProcessingImagined_physio.json"
+          },
+          {
+            "relation": "ab3c13026db0130f0f23bcdbf62a9e6f",
+            "name": "sub-029_task-emotionProcessingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "f3bb13d436264f3d9b208761a7af1463",
+            "name": "sub-029_task-emotionProcessing_physio.json"
+          },
+          {
+            "relation": "6cdf0fecde4d7226e248dc44fcb1836c",
+            "name": "sub-029_task-emotionProcessing_physio.tsv.gz"
+          },
+          {
+            "relation": "cc0ff9e49a4e54f8654e4ccfd3aaa3f1",
+            "name": "sub-029_task-fingerTapping_echo-1_bold.json"
+          },
+          {
+            "relation": "daa2747d5a5ab3547278063606409baf",
+            "name": "sub-029_task-fingerTapping_echo-1_bold.nii"
+          },
+          {
+            "relation": "9a52040f6152d9f9b714816a1a601a9e",
+            "name": "sub-029_task-fingerTapping_echo-2_bold.json"
+          },
+          {
+            "relation": "d77cb3cddfca2a2523a46553d9d6fb2c",
+            "name": "sub-029_task-fingerTapping_echo-2_bold.nii"
+          },
+          {
+            "relation": "e9b328f4103fc80bbb330d963750caa2",
+            "name": "sub-029_task-fingerTapping_echo-3_bold.json"
+          },
+          {
+            "relation": "5da88cf257ba32d596e009edb8574ef8",
+            "name": "sub-029_task-fingerTapping_echo-3_bold.nii"
+          },
+          {
+            "relation": "fd56c77f281c86a9ffb0ddfb09edad97",
+            "name": "sub-029_task-fingerTapping_events.tsv.gz"
+          },
+          {
+            "relation": "dc98a0fa52e322063b98f2f45fd9fba6",
+            "name": "sub-029_task-fingerTappingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "a40d4b6f350974a9298ac88ddaa3d84b",
+            "name": "sub-029_task-fingerTappingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "759d73ec6bb1a2c407609dc8dddbb704",
+            "name": "sub-029_task-fingerTappingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "abe0243354e2355bdf1786b8e6bcae36",
+            "name": "sub-029_task-fingerTappingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "d6934052b107e29a3db3e7fc8fba735a",
+            "name": "sub-029_task-fingerTappingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "e056ceee63a8590f083810062f4c34a6",
+            "name": "sub-029_task-fingerTappingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "85c94ae6f5fc3b8115d2d419476970cf",
+            "name": "sub-029_task-fingerTappingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "672a4fffbdb16d51499b7930064e1859",
+            "name": "sub-029_task-fingerTappingImagined_physio.json"
+          },
+          {
+            "relation": "f71826f74749fe71b7800028c9db1673",
+            "name": "sub-029_task-fingerTappingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "8be2efff90b216f6acd2809951cf8be6",
+            "name": "sub-029_task-fingerTapping_physio.json"
+          },
+          {
+            "relation": "a54c4190dc3c0ecc5beb2b8c9e14735d",
+            "name": "sub-029_task-fingerTapping_physio.tsv.gz"
+          },
+          {
+            "relation": "2872c86e9bacbf82a565dd634ea72386",
+            "name": "sub-029_task-rest_run-1_echo-1_bold.json"
+          },
+          {
+            "relation": "0402d0c1b534383c18c909cc1ad31274",
+            "name": "sub-029_task-rest_run-1_echo-1_bold.nii"
+          },
+          {
+            "relation": "ebde01f4f6faf37078c2ff7590b5d256",
+            "name": "sub-029_task-rest_run-1_echo-2_bold.json"
+          },
+          {
+            "relation": "666119314daf509245b75a6254078361",
+            "name": "sub-029_task-rest_run-1_echo-2_bold.nii"
+          },
+          {
+            "relation": "638328d8f9a7083428279da196b3e8c4",
+            "name": "sub-029_task-rest_run-1_echo-3_bold.json"
+          },
+          {
+            "relation": "55aa6d4913b1d6be0e2fcf1c9bbb4333",
+            "name": "sub-029_task-rest_run-1_echo-3_bold.nii"
+          },
+          {
+            "relation": "605ad92271ca46ea0eb86d118616eea9",
+            "name": "sub-029_task-rest_run-1_physio.json"
+          },
+          {
+            "relation": "0dd5ef126996587d16cbce6bd84c2171",
+            "name": "sub-029_task-rest_run-1_physio.tsv.gz"
+          },
+          {
+            "relation": "e5533ef3787593680c32ca4c1f6c846a",
+            "name": "sub-029_task-rest_run-2_echo-1_bold.json"
+          },
+          {
+            "relation": "a1803f1a402f76f74b955542462d8955",
+            "name": "sub-029_task-rest_run-2_echo-1_bold.nii"
+          },
+          {
+            "relation": "f66d20f3812cf38f3e58aec4c2920f9b",
+            "name": "sub-029_task-rest_run-2_echo-2_bold.json"
+          },
+          {
+            "relation": "287aff701204899813a052aae55231e3",
+            "name": "sub-029_task-rest_run-2_echo-2_bold.nii"
+          },
+          {
+            "relation": "31c3bd8364753cc3a49b352afb2a040a",
+            "name": "sub-029_task-rest_run-2_echo-3_bold.json"
+          },
+          {
+            "relation": "d274d9901dba8b51a96692e93beef094",
+            "name": "sub-029_task-rest_run-2_echo-3_bold.nii"
+          },
+          {
+            "relation": "dcf2960a303745514d4365f102d11dca",
+            "name": "sub-029_task-rest_run-2_physio.json"
+          },
+          {
+            "relation": "b9e8a26a359147c508c9aacaad33c4b4",
+            "name": "sub-029_task-rest_run-2_physio.tsv.gz"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2ea82caf66be69b706e8da251f3db1d0",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2ea82caf66be69b706e8da251f3db1d0"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46345"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c642a1f2033af0aa25af0f8106ea516e",
+        "byte_size": 1041,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c642a1f2033af0aa25af0f8106ea516e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45707"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "98f88deb44a64198f93800a8c567fe7c",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "98f88deb44a64198f93800a8c567fe7c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45348"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "aef317b5b3098ea2d40de1ce8b9cfc53",
+        "byte_size": 1041,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "aef317b5b3098ea2d40de1ce8b9cfc53"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46391"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "86949512bb0e3dc1ccb8f6881b62c9e9",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "86949512bb0e3dc1ccb8f6881b62c9e9"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46488"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d363bda5a57ca4e2a170fb7db38fb98a",
+        "byte_size": 1947,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d363bda5a57ca4e2a170fb7db38fb98a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46611"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4b5ebeecc9bfc412bbb6e6207e2ed6d5",
+        "byte_size": 1049,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4b5ebeecc9bfc412bbb6e6207e2ed6d5"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45357"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "dc9b6f33e0ae0b074310728fdd5fe572",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "dc9b6f33e0ae0b074310728fdd5fe572"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45972"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "0e9ef021458d12f51f4e91f110661ff9",
+        "byte_size": 1049,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "0e9ef021458d12f51f4e91f110661ff9"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45760"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6f3194817a8e84239182251ad1fd57c8",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6f3194817a8e84239182251ad1fd57c8"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46102"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c1fca06fbd4937b40f45ab3c82e20e69",
+        "byte_size": 1049,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c1fca06fbd4937b40f45ab3c82e20e69"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46330"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6a8b3989f7b59fb6989d366b27e6ec00",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6a8b3989f7b59fb6989d366b27e6ec00"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45886"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "3dd04e9279353a82d5fc7e98460a239f",
+        "byte_size": 178,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "3dd04e9279353a82d5fc7e98460a239f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46630"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "72c92178962a931773723d1358fca1bc",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "72c92178962a931773723d1358fca1bc"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45563"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ab3c13026db0130f0f23bcdbf62a9e6f",
+        "byte_size": 509090,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ab3c13026db0130f0f23bcdbf62a9e6f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45919"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f3bb13d436264f3d9b208761a7af1463",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f3bb13d436264f3d9b208761a7af1463"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46198"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6cdf0fecde4d7226e248dc44fcb1836c",
+        "byte_size": 614680,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6cdf0fecde4d7226e248dc44fcb1836c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45976"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "cc0ff9e49a4e54f8654e4ccfd3aaa3f1",
+        "byte_size": 1037,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "cc0ff9e49a4e54f8654e4ccfd3aaa3f1"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46484"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "daa2747d5a5ab3547278063606409baf",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "daa2747d5a5ab3547278063606409baf"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46123"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "9a52040f6152d9f9b714816a1a601a9e",
+        "byte_size": 1037,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "9a52040f6152d9f9b714816a1a601a9e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46381"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d77cb3cddfca2a2523a46553d9d6fb2c",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d77cb3cddfca2a2523a46553d9d6fb2c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45759"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e9b328f4103fc80bbb330d963750caa2",
+        "byte_size": 1037,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e9b328f4103fc80bbb330d963750caa2"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45651"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5da88cf257ba32d596e009edb8574ef8",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5da88cf257ba32d596e009edb8574ef8"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45220"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "fd56c77f281c86a9ffb0ddfb09edad97",
+        "byte_size": 168,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "fd56c77f281c86a9ffb0ddfb09edad97"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46566"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "dc98a0fa52e322063b98f2f45fd9fba6",
+        "byte_size": 1044,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "dc98a0fa52e322063b98f2f45fd9fba6"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45974"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a40d4b6f350974a9298ac88ddaa3d84b",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a40d4b6f350974a9298ac88ddaa3d84b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45477"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "759d73ec6bb1a2c407609dc8dddbb704",
+        "byte_size": 1044,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "759d73ec6bb1a2c407609dc8dddbb704"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46077"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "abe0243354e2355bdf1786b8e6bcae36",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "abe0243354e2355bdf1786b8e6bcae36"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45973"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d6934052b107e29a3db3e7fc8fba735a",
+        "byte_size": 1044,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d6934052b107e29a3db3e7fc8fba735a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46173"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e056ceee63a8590f083810062f4c34a6",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e056ceee63a8590f083810062f4c34a6"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46260"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "85c94ae6f5fc3b8115d2d419476970cf",
+        "byte_size": 179,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "85c94ae6f5fc3b8115d2d419476970cf"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46642"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "672a4fffbdb16d51499b7930064e1859",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "672a4fffbdb16d51499b7930064e1859"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45801"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f71826f74749fe71b7800028c9db1673",
+        "byte_size": 526633,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f71826f74749fe71b7800028c9db1673"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45434"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8be2efff90b216f6acd2809951cf8be6",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8be2efff90b216f6acd2809951cf8be6"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45128"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a54c4190dc3c0ecc5beb2b8c9e14735d",
+        "byte_size": 602444,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a54c4190dc3c0ecc5beb2b8c9e14735d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46271"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2872c86e9bacbf82a565dd634ea72386",
+        "byte_size": 1028,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2872c86e9bacbf82a565dd634ea72386"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45838"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "0402d0c1b534383c18c909cc1ad31274",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "0402d0c1b534383c18c909cc1ad31274"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45854"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ebde01f4f6faf37078c2ff7590b5d256",
+        "byte_size": 1028,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ebde01f4f6faf37078c2ff7590b5d256"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46175"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "666119314daf509245b75a6254078361",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "666119314daf509245b75a6254078361"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45329"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "638328d8f9a7083428279da196b3e8c4",
+        "byte_size": 1028,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "638328d8f9a7083428279da196b3e8c4"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45864"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "55aa6d4913b1d6be0e2fcf1c9bbb4333",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "55aa6d4913b1d6be0e2fcf1c9bbb4333"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46055"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "605ad92271ca46ea0eb86d118616eea9",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "605ad92271ca46ea0eb86d118616eea9"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45263"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "0dd5ef126996587d16cbce6bd84c2171",
+        "byte_size": 453530,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "0dd5ef126996587d16cbce6bd84c2171"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45671"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e5533ef3787593680c32ca4c1f6c846a",
+        "byte_size": 1028,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e5533ef3787593680c32ca4c1f6c846a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46040"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a1803f1a402f76f74b955542462d8955",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a1803f1a402f76f74b955542462d8955"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45749"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f66d20f3812cf38f3e58aec4c2920f9b",
+        "byte_size": 1028,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f66d20f3812cf38f3e58aec4c2920f9b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45829"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "287aff701204899813a052aae55231e3",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "287aff701204899813a052aae55231e3"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46335"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "31c3bd8364753cc3a49b352afb2a040a",
+        "byte_size": 1028,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "31c3bd8364753cc3a49b352afb2a040a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45613"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d274d9901dba8b51a96692e93beef094",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d274d9901dba8b51a96692e93beef094"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46059"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "dcf2960a303745514d4365f102d11dca",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "dcf2960a303745514d4365f102d11dca"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46013"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b9e8a26a359147c508c9aacaad33c4b4",
+        "byte_size": 493637,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b9e8a26a359147c508c9aacaad33c4b4"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45135"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "7d49af0678a253f050888f0d5c5b9a7c",
+        "byte_size": 20736352,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "7d49af0678a253f050888f0d5c5b9a7c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45964"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-030/",
+        "qualified_part": [
+          {
+            "relation": "sub-030/anat/",
+            "name": "anat"
+          },
+          {
+            "relation": "sub-030/func/",
+            "name": "func"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-030/anat/",
+        "qualified_part": [
+          {
+            "relation": "7d49af0678a253f050888f0d5c5b9a7c",
+            "name": "sub-030_T1w.nii"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6284fd8caa795a3542e92047539225bb",
+        "byte_size": 1042,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6284fd8caa795a3542e92047539225bb"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45716"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-030/func/",
+        "qualified_part": [
+          {
+            "relation": "6284fd8caa795a3542e92047539225bb",
+            "name": "sub-030_task-emotionProcessing_echo-1_bold.json"
+          },
+          {
+            "relation": "5153f6c8dda335e5e4afdd07b49d3d16",
+            "name": "sub-030_task-emotionProcessing_echo-1_bold.nii"
+          },
+          {
+            "relation": "5f346e95cfacb71285559c08ffa801e0",
+            "name": "sub-030_task-emotionProcessing_echo-2_bold.json"
+          },
+          {
+            "relation": "27e5d2456721906e1515d9da26871f8e",
+            "name": "sub-030_task-emotionProcessing_echo-2_bold.nii"
+          },
+          {
+            "relation": "5c0a009bb87d5dee80253bcccc3ba026",
+            "name": "sub-030_task-emotionProcessing_echo-3_bold.json"
+          },
+          {
+            "relation": "61294fe08c7d78a6cb629dc8786deb4c",
+            "name": "sub-030_task-emotionProcessing_echo-3_bold.nii"
+          },
+          {
+            "relation": "cdf3ae06fc8eb4745cf011b0817fbc32",
+            "name": "sub-030_task-emotionProcessing_events.tsv.gz"
+          },
+          {
+            "relation": "a947de9eba6d81991eed24943542c2c7",
+            "name": "sub-030_task-emotionProcessingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "249dd14e1e023cf98361813e8fe2c8ce",
+            "name": "sub-030_task-emotionProcessingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "3bf5e0d06f4c0b44684708016ead2384",
+            "name": "sub-030_task-emotionProcessingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "1545d6a2710463db6f31a9b18522b4f2",
+            "name": "sub-030_task-emotionProcessingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "dde2c167088d531a025f0a0e94388f5a",
+            "name": "sub-030_task-emotionProcessingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "5a8bb9ec0d6adb579068cab4e90878c2",
+            "name": "sub-030_task-emotionProcessingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "16fb8a49a30a04a40eb1d884275bff57",
+            "name": "sub-030_task-emotionProcessingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "33dc5896a50bc63493bab3f0743b3465",
+            "name": "sub-030_task-emotionProcessingImagined_physio.json"
+          },
+          {
+            "relation": "fd5ee5ea81e0249b03683f0d656d4c70",
+            "name": "sub-030_task-emotionProcessingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "ad740656f44d82f4bd7b9cd85cfa75b6",
+            "name": "sub-030_task-emotionProcessing_physio.json"
+          },
+          {
+            "relation": "e0560ed1d249cadf942ed068312f4074",
+            "name": "sub-030_task-emotionProcessing_physio.tsv.gz"
+          },
+          {
+            "relation": "87b01272f0d3aec042a70c89cb64c610",
+            "name": "sub-030_task-fingerTapping_echo-1_bold.json"
+          },
+          {
+            "relation": "70c2c565c57410becebcb81c2743b366",
+            "name": "sub-030_task-fingerTapping_echo-1_bold.nii"
+          },
+          {
+            "relation": "d2ad0551f289c82c784c0311cbda5868",
+            "name": "sub-030_task-fingerTapping_echo-2_bold.json"
+          },
+          {
+            "relation": "0a985477a760a6866461a8503d29841f",
+            "name": "sub-030_task-fingerTapping_echo-2_bold.nii"
+          },
+          {
+            "relation": "5d7912fb3c00c49ab445f37d023fabde",
+            "name": "sub-030_task-fingerTapping_echo-3_bold.json"
+          },
+          {
+            "relation": "8d8f176db5374b8f5312c07b3868f190",
+            "name": "sub-030_task-fingerTapping_echo-3_bold.nii"
+          },
+          {
+            "relation": "10274748238e4edb1cacbc5ff8c4efb4",
+            "name": "sub-030_task-fingerTapping_events.tsv.gz"
+          },
+          {
+            "relation": "6deb98259db82a9bb337c44e78e221fe",
+            "name": "sub-030_task-fingerTappingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "9206830373a50d76fa9be72699a45be2",
+            "name": "sub-030_task-fingerTappingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "1e119f9dea2d0f2266fdba2f09099eba",
+            "name": "sub-030_task-fingerTappingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "3b8d8099ff221a24e6f8c2c6e4b5570c",
+            "name": "sub-030_task-fingerTappingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "ca1f88e3755c369289b2c59316feabd1",
+            "name": "sub-030_task-fingerTappingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "54ab340987d511300097fd979ba2500a",
+            "name": "sub-030_task-fingerTappingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "aed4fce2a1c6cef0f89684bbf389f48a",
+            "name": "sub-030_task-fingerTappingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "ed88005c127d5f5aef4342a0dee22e4a",
+            "name": "sub-030_task-fingerTappingImagined_physio.json"
+          },
+          {
+            "relation": "803e662ede5ba87711a0e764a4dc5e00",
+            "name": "sub-030_task-fingerTappingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "bcd7d4cca00199ced81ffacc4c34ec31",
+            "name": "sub-030_task-fingerTapping_physio.json"
+          },
+          {
+            "relation": "50fbda51cbb53ef16f3fb3597d76d674",
+            "name": "sub-030_task-fingerTapping_physio.tsv.gz"
+          },
+          {
+            "relation": "0e9ab4d23523465646ff1a1fff65dc25",
+            "name": "sub-030_task-rest_run-1_echo-1_bold.json"
+          },
+          {
+            "relation": "7b7d78156f700cae33926db5aa2f0d04",
+            "name": "sub-030_task-rest_run-1_echo-1_bold.nii"
+          },
+          {
+            "relation": "7e85df7221171f6b2372643486c02bcb",
+            "name": "sub-030_task-rest_run-1_echo-2_bold.json"
+          },
+          {
+            "relation": "122692ec73aa0497ec013677ce2cb7e0",
+            "name": "sub-030_task-rest_run-1_echo-2_bold.nii"
+          },
+          {
+            "relation": "43e86c28283bc8009c9d97276c233295",
+            "name": "sub-030_task-rest_run-1_echo-3_bold.json"
+          },
+          {
+            "relation": "d91741896d318dc2ed2b04cb0d9278c5",
+            "name": "sub-030_task-rest_run-1_echo-3_bold.nii"
+          },
+          {
+            "relation": "51211fa4e8939015647398b0c8c7e679",
+            "name": "sub-030_task-rest_run-1_physio.json"
+          },
+          {
+            "relation": "e68ffa789f92076c93d66148afd5cd89",
+            "name": "sub-030_task-rest_run-1_physio.tsv.gz"
+          },
+          {
+            "relation": "956ae391decb81c3c0b4696c2f95ac4b",
+            "name": "sub-030_task-rest_run-2_echo-1_bold.json"
+          },
+          {
+            "relation": "747a22e06891ce5b95226b442fead6f6",
+            "name": "sub-030_task-rest_run-2_echo-1_bold.nii"
+          },
+          {
+            "relation": "04d3584fb830f7a8ef784728c17e630e",
+            "name": "sub-030_task-rest_run-2_echo-2_bold.json"
+          },
+          {
+            "relation": "1597ff009b5f28a228d4dfd9ebc0e93e",
+            "name": "sub-030_task-rest_run-2_echo-2_bold.nii"
+          },
+          {
+            "relation": "7c4457b85550d91fae95d072a4cc570b",
+            "name": "sub-030_task-rest_run-2_echo-3_bold.json"
+          },
+          {
+            "relation": "62d1d1ee187bcf3bb58bf391bf188b32",
+            "name": "sub-030_task-rest_run-2_echo-3_bold.nii"
+          },
+          {
+            "relation": "a652f7b56ad758609c5310ef0fab2937",
+            "name": "sub-030_task-rest_run-2_physio.json"
+          },
+          {
+            "relation": "4cf99739f118bfd9a0997fe0ae604bcc",
+            "name": "sub-030_task-rest_run-2_physio.tsv.gz"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5153f6c8dda335e5e4afdd07b49d3d16",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5153f6c8dda335e5e4afdd07b49d3d16"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45675"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5f346e95cfacb71285559c08ffa801e0",
+        "byte_size": 1042,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5f346e95cfacb71285559c08ffa801e0"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46140"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "27e5d2456721906e1515d9da26871f8e",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "27e5d2456721906e1515d9da26871f8e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45997"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5c0a009bb87d5dee80253bcccc3ba026",
+        "byte_size": 1042,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5c0a009bb87d5dee80253bcccc3ba026"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45514"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "61294fe08c7d78a6cb629dc8786deb4c",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "61294fe08c7d78a6cb629dc8786deb4c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45648"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "cdf3ae06fc8eb4745cf011b0817fbc32",
+        "byte_size": 1887,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "cdf3ae06fc8eb4745cf011b0817fbc32"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46648"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a947de9eba6d81991eed24943542c2c7",
+        "byte_size": 1052,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a947de9eba6d81991eed24943542c2c7"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46410"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "249dd14e1e023cf98361813e8fe2c8ce",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "249dd14e1e023cf98361813e8fe2c8ce"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45682"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "3bf5e0d06f4c0b44684708016ead2384",
+        "byte_size": 1052,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "3bf5e0d06f4c0b44684708016ead2384"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45957"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1545d6a2710463db6f31a9b18522b4f2",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1545d6a2710463db6f31a9b18522b4f2"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45196"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "dde2c167088d531a025f0a0e94388f5a",
+        "byte_size": 1052,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "dde2c167088d531a025f0a0e94388f5a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45772"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5a8bb9ec0d6adb579068cab4e90878c2",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5a8bb9ec0d6adb579068cab4e90878c2"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45129"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "16fb8a49a30a04a40eb1d884275bff57",
+        "byte_size": 180,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "16fb8a49a30a04a40eb1d884275bff57"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46588"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "33dc5896a50bc63493bab3f0743b3465",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "33dc5896a50bc63493bab3f0743b3465"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45620"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "fd5ee5ea81e0249b03683f0d656d4c70",
+        "byte_size": 495292,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "fd5ee5ea81e0249b03683f0d656d4c70"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45121"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ad740656f44d82f4bd7b9cd85cfa75b6",
+        "byte_size": 142,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ad740656f44d82f4bd7b9cd85cfa75b6"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45771"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e0560ed1d249cadf942ed068312f4074",
+        "byte_size": 491529,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e0560ed1d249cadf942ed068312f4074"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45718"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "87b01272f0d3aec042a70c89cb64c610",
+        "byte_size": 1040,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "87b01272f0d3aec042a70c89cb64c610"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46349"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "70c2c565c57410becebcb81c2743b366",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "70c2c565c57410becebcb81c2743b366"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45483"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d2ad0551f289c82c784c0311cbda5868",
+        "byte_size": 1040,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d2ad0551f289c82c784c0311cbda5868"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45429"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "0a985477a760a6866461a8503d29841f",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "0a985477a760a6866461a8503d29841f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45395"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5d7912fb3c00c49ab445f37d023fabde",
+        "byte_size": 1040,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5d7912fb3c00c49ab445f37d023fabde"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45733"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8d8f176db5374b8f5312c07b3868f190",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8d8f176db5374b8f5312c07b3868f190"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45466"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "10274748238e4edb1cacbc5ff8c4efb4",
+        "byte_size": 167,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "10274748238e4edb1cacbc5ff8c4efb4"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46581"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6deb98259db82a9bb337c44e78e221fe",
+        "byte_size": 1046,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6deb98259db82a9bb337c44e78e221fe"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46463"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "9206830373a50d76fa9be72699a45be2",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "9206830373a50d76fa9be72699a45be2"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45985"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1e119f9dea2d0f2266fdba2f09099eba",
+        "byte_size": 1046,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1e119f9dea2d0f2266fdba2f09099eba"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46334"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "3b8d8099ff221a24e6f8c2c6e4b5570c",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "3b8d8099ff221a24e6f8c2c6e4b5570c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45532"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ca1f88e3755c369289b2c59316feabd1",
+        "byte_size": 1046,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ca1f88e3755c369289b2c59316feabd1"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45545"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "54ab340987d511300097fd979ba2500a",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "54ab340987d511300097fd979ba2500a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45934"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "aed4fce2a1c6cef0f89684bbf389f48a",
+        "byte_size": 179,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "aed4fce2a1c6cef0f89684bbf389f48a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46600"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ed88005c127d5f5aef4342a0dee22e4a",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ed88005c127d5f5aef4342a0dee22e4a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46468"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "803e662ede5ba87711a0e764a4dc5e00",
+        "byte_size": 476319,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "803e662ede5ba87711a0e764a4dc5e00"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45108"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "bcd7d4cca00199ced81ffacc4c34ec31",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "bcd7d4cca00199ced81ffacc4c34ec31"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45489"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "50fbda51cbb53ef16f3fb3597d76d674",
+        "byte_size": 476107,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "50fbda51cbb53ef16f3fb3597d76d674"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46465"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "0e9ab4d23523465646ff1a1fff65dc25",
+        "byte_size": 1030,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "0e9ab4d23523465646ff1a1fff65dc25"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46403"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "7b7d78156f700cae33926db5aa2f0d04",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "7b7d78156f700cae33926db5aa2f0d04"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46414"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "7e85df7221171f6b2372643486c02bcb",
+        "byte_size": 1030,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "7e85df7221171f6b2372643486c02bcb"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45541"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "122692ec73aa0497ec013677ce2cb7e0",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "122692ec73aa0497ec013677ce2cb7e0"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45377"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "43e86c28283bc8009c9d97276c233295",
+        "byte_size": 1030,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "43e86c28283bc8009c9d97276c233295"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45564"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d91741896d318dc2ed2b04cb0d9278c5",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d91741896d318dc2ed2b04cb0d9278c5"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46280"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "51211fa4e8939015647398b0c8c7e679",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "51211fa4e8939015647398b0c8c7e679"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45408"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e68ffa789f92076c93d66148afd5cd89",
+        "byte_size": 462755,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e68ffa789f92076c93d66148afd5cd89"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45321"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "956ae391decb81c3c0b4696c2f95ac4b",
+        "byte_size": 1031,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "956ae391decb81c3c0b4696c2f95ac4b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45596"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "747a22e06891ce5b95226b442fead6f6",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "747a22e06891ce5b95226b442fead6f6"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46211"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "04d3584fb830f7a8ef784728c17e630e",
+        "byte_size": 1031,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "04d3584fb830f7a8ef784728c17e630e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45133"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1597ff009b5f28a228d4dfd9ebc0e93e",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1597ff009b5f28a228d4dfd9ebc0e93e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45715"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "7c4457b85550d91fae95d072a4cc570b",
+        "byte_size": 1031,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "7c4457b85550d91fae95d072a4cc570b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45131"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "62d1d1ee187bcf3bb58bf391bf188b32",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "62d1d1ee187bcf3bb58bf391bf188b32"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46137"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a652f7b56ad758609c5310ef0fab2937",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a652f7b56ad758609c5310ef0fab2937"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46122"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4cf99739f118bfd9a0997fe0ae604bcc",
+        "byte_size": 476195,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4cf99739f118bfd9a0997fe0ae604bcc"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46286"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "eb385669721030b98836830b7000b0b5",
+        "byte_size": 20736352,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "eb385669721030b98836830b7000b0b5"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45544"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-031/",
+        "qualified_part": [
+          {
+            "relation": "sub-031/anat/",
+            "name": "anat"
+          },
+          {
+            "relation": "sub-031/func/",
+            "name": "func"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-031/anat/",
+        "qualified_part": [
+          {
+            "relation": "eb385669721030b98836830b7000b0b5",
+            "name": "sub-031_T1w.nii"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "42a0650f24e5e4d1ceef8d63789c07e0",
+        "byte_size": 1037,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "42a0650f24e5e4d1ceef8d63789c07e0"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45851"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-031/func/",
+        "qualified_part": [
+          {
+            "relation": "42a0650f24e5e4d1ceef8d63789c07e0",
+            "name": "sub-031_task-emotionProcessing_echo-1_bold.json"
+          },
+          {
+            "relation": "a2d2a978cab262ecef9ec66c647675ab",
+            "name": "sub-031_task-emotionProcessing_echo-1_bold.nii"
+          },
+          {
+            "relation": "4e1fca6683a7845b0eabcf07a9a7fc73",
+            "name": "sub-031_task-emotionProcessing_echo-2_bold.json"
+          },
+          {
+            "relation": "0fec398f1ec3542a99bf6970f7926670",
+            "name": "sub-031_task-emotionProcessing_echo-2_bold.nii"
+          },
+          {
+            "relation": "2fae64eda1ad8304bc639b6399a6ac21",
+            "name": "sub-031_task-emotionProcessing_echo-3_bold.json"
+          },
+          {
+            "relation": "edd04104a9525374da16af5ac8444a6e",
+            "name": "sub-031_task-emotionProcessing_echo-3_bold.nii"
+          },
+          {
+            "relation": "5277d970321107e4ff62110a5efa36b2",
+            "name": "sub-031_task-emotionProcessing_events.tsv.gz"
+          },
+          {
+            "relation": "8217cc3d23c0c41e5e906b5425eef056",
+            "name": "sub-031_task-emotionProcessingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "ec54f11a2ea08dcb739e1882ed99ff43",
+            "name": "sub-031_task-emotionProcessingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "08a4ef57345695af6df33685c7d16c1f",
+            "name": "sub-031_task-emotionProcessingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "6b3e0bc231406bf13779757fd84ea449",
+            "name": "sub-031_task-emotionProcessingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "d12cf12c33775533eddb629c61308042",
+            "name": "sub-031_task-emotionProcessingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "b886908aeaa472357d3c9b59bcf37a34",
+            "name": "sub-031_task-emotionProcessingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "880d5e26a7c1025b0f921cf8c4ee76d2",
+            "name": "sub-031_task-emotionProcessingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "99890ebb90e3ff583aaae8a7c96dd4c6",
+            "name": "sub-031_task-emotionProcessingImagined_physio.json"
+          },
+          {
+            "relation": "80331e9333eae550dbfac06eecaff7f7",
+            "name": "sub-031_task-emotionProcessingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "a9ec1300d617c185be53ecc4378dd2a9",
+            "name": "sub-031_task-emotionProcessing_physio.json"
+          },
+          {
+            "relation": "b76ec0da0d71f3fcc24208db6c777034",
+            "name": "sub-031_task-emotionProcessing_physio.tsv.gz"
+          },
+          {
+            "relation": "3719f2d5fb9e27010773993f60836e39",
+            "name": "sub-031_task-fingerTapping_echo-1_bold.json"
+          },
+          {
+            "relation": "16236c6dd29c2d773c5fe63d9b5733fa",
+            "name": "sub-031_task-fingerTapping_echo-1_bold.nii"
+          },
+          {
+            "relation": "0db5e7ae1cb6627feeb54be3ba822b84",
+            "name": "sub-031_task-fingerTapping_echo-2_bold.json"
+          },
+          {
+            "relation": "bd54aedb7810b5b36460e00d483aedbe",
+            "name": "sub-031_task-fingerTapping_echo-2_bold.nii"
+          },
+          {
+            "relation": "d4c69055b292ca4302ca0f04c7169c8b",
+            "name": "sub-031_task-fingerTapping_echo-3_bold.json"
+          },
+          {
+            "relation": "e72425e7c2aee7afe5d96859729f9fb7",
+            "name": "sub-031_task-fingerTapping_echo-3_bold.nii"
+          },
+          {
+            "relation": "fc88d5449bdfef5f0eb7a528f33b27bb",
+            "name": "sub-031_task-fingerTapping_events.tsv.gz"
+          },
+          {
+            "relation": "5e7da551bf765343ced4a55abc97db70",
+            "name": "sub-031_task-fingerTappingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "ee7c5e607a7a996daf5935a1234fdb37",
+            "name": "sub-031_task-fingerTappingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "17ac41ef430199c10cae34b9edfca197",
+            "name": "sub-031_task-fingerTappingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "a501d0464c22f726e6f5f1faad45ed5d",
+            "name": "sub-031_task-fingerTappingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "4cb2a766010ebf0ca6721331b9529591",
+            "name": "sub-031_task-fingerTappingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "5df5194d728d639ebd1029b09f1f0411",
+            "name": "sub-031_task-fingerTappingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "6691789fd6206ed061aa23750b11b927",
+            "name": "sub-031_task-fingerTappingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "c623115320f634efcaefb2b0a5d75288",
+            "name": "sub-031_task-fingerTappingImagined_physio.json"
+          },
+          {
+            "relation": "4a16ec80d015060631add147e0a6fd74",
+            "name": "sub-031_task-fingerTappingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "31b4170baec18b2be5621e9f2d3bf577",
+            "name": "sub-031_task-fingerTapping_physio.json"
+          },
+          {
+            "relation": "66a719fb58313de8f23285c9e364d41b",
+            "name": "sub-031_task-fingerTapping_physio.tsv.gz"
+          },
+          {
+            "relation": "881dda2fa595fb1e83732f6baa916c6d",
+            "name": "sub-031_task-rest_run-1_echo-1_bold.json"
+          },
+          {
+            "relation": "586bfe19d96be1d7ffb8235acee74d5c",
+            "name": "sub-031_task-rest_run-1_echo-1_bold.nii"
+          },
+          {
+            "relation": "fa4292ec53aa27a9950dd945ad649149",
+            "name": "sub-031_task-rest_run-1_echo-2_bold.json"
+          },
+          {
+            "relation": "afba70a659537be0515ef3c082820c98",
+            "name": "sub-031_task-rest_run-1_echo-2_bold.nii"
+          },
+          {
+            "relation": "c284b2a35f671ff7526c69854c2bb564",
+            "name": "sub-031_task-rest_run-1_echo-3_bold.json"
+          },
+          {
+            "relation": "3f3c28f7447a7cd0f183073bbe401b13",
+            "name": "sub-031_task-rest_run-1_echo-3_bold.nii"
+          },
+          {
+            "relation": "b676a72f00b1dc65fc19563863766991",
+            "name": "sub-031_task-rest_run-1_physio.json"
+          },
+          {
+            "relation": "e50bd35a460c3654ea0d49fe55028b06",
+            "name": "sub-031_task-rest_run-1_physio.tsv.gz"
+          },
+          {
+            "relation": "bc778928ec86b0b101244f24aaa164bd",
+            "name": "sub-031_task-rest_run-2_echo-1_bold.json"
+          },
+          {
+            "relation": "1d1746b3ff6e6a7a056c7649e7a440a7",
+            "name": "sub-031_task-rest_run-2_echo-1_bold.nii"
+          },
+          {
+            "relation": "1ea98acf6dc9275f88d7f22b4c723adc",
+            "name": "sub-031_task-rest_run-2_echo-2_bold.json"
+          },
+          {
+            "relation": "706ff57f1edd078131e4ce97ad5bb0cd",
+            "name": "sub-031_task-rest_run-2_echo-2_bold.nii"
+          },
+          {
+            "relation": "5d4b834cc7ba0ac83167972984bed1f6",
+            "name": "sub-031_task-rest_run-2_echo-3_bold.json"
+          },
+          {
+            "relation": "bea921c5cb404c38ee939c51b8c586a8",
+            "name": "sub-031_task-rest_run-2_echo-3_bold.nii"
+          },
+          {
+            "relation": "a5d69e35f3340276d6be92b975f206d9",
+            "name": "sub-031_task-rest_run-2_physio.json"
+          },
+          {
+            "relation": "184f7866445f619c0c067be193c1e215",
+            "name": "sub-031_task-rest_run-2_physio.tsv.gz"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a2d2a978cab262ecef9ec66c647675ab",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a2d2a978cab262ecef9ec66c647675ab"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46256"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4e1fca6683a7845b0eabcf07a9a7fc73",
+        "byte_size": 1037,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4e1fca6683a7845b0eabcf07a9a7fc73"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45639"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "0fec398f1ec3542a99bf6970f7926670",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "0fec398f1ec3542a99bf6970f7926670"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45812"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2fae64eda1ad8304bc639b6399a6ac21",
+        "byte_size": 1037,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2fae64eda1ad8304bc639b6399a6ac21"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46538"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "edd04104a9525374da16af5ac8444a6e",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "edd04104a9525374da16af5ac8444a6e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45486"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5277d970321107e4ff62110a5efa36b2",
+        "byte_size": 1854,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5277d970321107e4ff62110a5efa36b2"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46628"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8217cc3d23c0c41e5e906b5425eef056",
+        "byte_size": 1045,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8217cc3d23c0c41e5e906b5425eef056"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45355"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ec54f11a2ea08dcb739e1882ed99ff43",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ec54f11a2ea08dcb739e1882ed99ff43"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46380"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "08a4ef57345695af6df33685c7d16c1f",
+        "byte_size": 1045,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "08a4ef57345695af6df33685c7d16c1f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45918"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6b3e0bc231406bf13779757fd84ea449",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6b3e0bc231406bf13779757fd84ea449"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45373"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d12cf12c33775533eddb629c61308042",
+        "byte_size": 1045,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d12cf12c33775533eddb629c61308042"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46363"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b886908aeaa472357d3c9b59bcf37a34",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b886908aeaa472357d3c9b59bcf37a34"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45194"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "880d5e26a7c1025b0f921cf8c4ee76d2",
+        "byte_size": 178,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "880d5e26a7c1025b0f921cf8c4ee76d2"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46614"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "99890ebb90e3ff583aaae8a7c96dd4c6",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "99890ebb90e3ff583aaae8a7c96dd4c6"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46092"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "80331e9333eae550dbfac06eecaff7f7",
+        "byte_size": 474191,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "80331e9333eae550dbfac06eecaff7f7"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45397"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a9ec1300d617c185be53ecc4378dd2a9",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a9ec1300d617c185be53ecc4378dd2a9"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45831"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b76ec0da0d71f3fcc24208db6c777034",
+        "byte_size": 486789,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b76ec0da0d71f3fcc24208db6c777034"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45874"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "3719f2d5fb9e27010773993f60836e39",
+        "byte_size": 1033,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "3719f2d5fb9e27010773993f60836e39"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46449"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "16236c6dd29c2d773c5fe63d9b5733fa",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "16236c6dd29c2d773c5fe63d9b5733fa"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46236"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "0db5e7ae1cb6627feeb54be3ba822b84",
+        "byte_size": 1033,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "0db5e7ae1cb6627feeb54be3ba822b84"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45259"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "bd54aedb7810b5b36460e00d483aedbe",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "bd54aedb7810b5b36460e00d483aedbe"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45452"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d4c69055b292ca4302ca0f04c7169c8b",
+        "byte_size": 1033,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d4c69055b292ca4302ca0f04c7169c8b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45908"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e72425e7c2aee7afe5d96859729f9fb7",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e72425e7c2aee7afe5d96859729f9fb7"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45721"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "fc88d5449bdfef5f0eb7a528f33b27bb",
+        "byte_size": 167,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "fc88d5449bdfef5f0eb7a528f33b27bb"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46618"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5e7da551bf765343ced4a55abc97db70",
+        "byte_size": 1041,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5e7da551bf765343ced4a55abc97db70"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45506"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ee7c5e607a7a996daf5935a1234fdb37",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ee7c5e607a7a996daf5935a1234fdb37"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45279"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "17ac41ef430199c10cae34b9edfca197",
+        "byte_size": 1041,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "17ac41ef430199c10cae34b9edfca197"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46103"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a501d0464c22f726e6f5f1faad45ed5d",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a501d0464c22f726e6f5f1faad45ed5d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45542"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4cb2a766010ebf0ca6721331b9529591",
+        "byte_size": 1041,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4cb2a766010ebf0ca6721331b9529591"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45130"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5df5194d728d639ebd1029b09f1f0411",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5df5194d728d639ebd1029b09f1f0411"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45152"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6691789fd6206ed061aa23750b11b927",
+        "byte_size": 179,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6691789fd6206ed061aa23750b11b927"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46598"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c623115320f634efcaefb2b0a5d75288",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c623115320f634efcaefb2b0a5d75288"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45821"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4a16ec80d015060631add147e0a6fd74",
+        "byte_size": 468033,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4a16ec80d015060631add147e0a6fd74"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46024"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "31b4170baec18b2be5621e9f2d3bf577",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "31b4170baec18b2be5621e9f2d3bf577"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45770"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "66a719fb58313de8f23285c9e364d41b",
+        "byte_size": 499366,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "66a719fb58313de8f23285c9e364d41b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45176"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "881dda2fa595fb1e83732f6baa916c6d",
+        "byte_size": 1024,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "881dda2fa595fb1e83732f6baa916c6d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45871"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "586bfe19d96be1d7ffb8235acee74d5c",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "586bfe19d96be1d7ffb8235acee74d5c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45833"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "fa4292ec53aa27a9950dd945ad649149",
+        "byte_size": 1024,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "fa4292ec53aa27a9950dd945ad649149"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45328"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "afba70a659537be0515ef3c082820c98",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "afba70a659537be0515ef3c082820c98"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45178"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c284b2a35f671ff7526c69854c2bb564",
+        "byte_size": 1024,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c284b2a35f671ff7526c69854c2bb564"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46433"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "3f3c28f7447a7cd0f183073bbe401b13",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "3f3c28f7447a7cd0f183073bbe401b13"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45751"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b676a72f00b1dc65fc19563863766991",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b676a72f00b1dc65fc19563863766991"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45806"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "e50bd35a460c3654ea0d49fe55028b06",
+        "byte_size": 466931,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "e50bd35a460c3654ea0d49fe55028b06"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45912"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "bc778928ec86b0b101244f24aaa164bd",
+        "byte_size": 1024,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "bc778928ec86b0b101244f24aaa164bd"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45635"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1d1746b3ff6e6a7a056c7649e7a440a7",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1d1746b3ff6e6a7a056c7649e7a440a7"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46364"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1ea98acf6dc9275f88d7f22b4c723adc",
+        "byte_size": 1024,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1ea98acf6dc9275f88d7f22b4c723adc"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46291"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "706ff57f1edd078131e4ce97ad5bb0cd",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "706ff57f1edd078131e4ce97ad5bb0cd"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45144"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5d4b834cc7ba0ac83167972984bed1f6",
+        "byte_size": 1024,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5d4b834cc7ba0ac83167972984bed1f6"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45998"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "bea921c5cb404c38ee939c51b8c586a8",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "bea921c5cb404c38ee939c51b8c586a8"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45186"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a5d69e35f3340276d6be92b975f206d9",
+        "byte_size": 142,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a5d69e35f3340276d6be92b975f206d9"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46319"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "184f7866445f619c0c067be193c1e215",
+        "byte_size": 464210,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "184f7866445f619c0c067be193c1e215"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46204"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "48e60100ea298d4d4c8c8d3cbfd04b0e",
+        "byte_size": 20736352,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "48e60100ea298d4d4c8c8d3cbfd04b0e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46200"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-032/",
+        "qualified_part": [
+          {
+            "relation": "sub-032/anat/",
+            "name": "anat"
+          },
+          {
+            "relation": "sub-032/func/",
+            "name": "func"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-032/anat/",
+        "qualified_part": [
+          {
+            "relation": "48e60100ea298d4d4c8c8d3cbfd04b0e",
+            "name": "sub-032_T1w.nii"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "06416007e86d197a6940d678e8136bca",
+        "byte_size": 1041,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "06416007e86d197a6940d678e8136bca"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45609"
+      },
+      {
+        "meta_type": "dlco:FileContainerObject",
+        "meta_code": "sub-032/func/",
+        "qualified_part": [
+          {
+            "relation": "06416007e86d197a6940d678e8136bca",
+            "name": "sub-032_task-emotionProcessing_echo-1_bold.json"
+          },
+          {
+            "relation": "1b89791e8c1aee44164213034f192b63",
+            "name": "sub-032_task-emotionProcessing_echo-1_bold.nii"
+          },
+          {
+            "relation": "2b3b3996277ade762410715cfd47431a",
+            "name": "sub-032_task-emotionProcessing_echo-2_bold.json"
+          },
+          {
+            "relation": "65365545508eabb82cc566e36be4ac34",
+            "name": "sub-032_task-emotionProcessing_echo-2_bold.nii"
+          },
+          {
+            "relation": "ed07bf52a32bd33053c0bb04e686972a",
+            "name": "sub-032_task-emotionProcessing_echo-3_bold.json"
+          },
+          {
+            "relation": "b1e6f7903c2a3150438d9a23616504af",
+            "name": "sub-032_task-emotionProcessing_echo-3_bold.nii"
+          },
+          {
+            "relation": "8e174c8a66696c7906ba1dcf98d2cc68",
+            "name": "sub-032_task-emotionProcessing_events.tsv.gz"
+          },
+          {
+            "relation": "61c5e521e58b82e36d53844980c06b63",
+            "name": "sub-032_task-emotionProcessingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "1bf02155e4fcab9c3684175c291dcb3f",
+            "name": "sub-032_task-emotionProcessingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "0eefb1536ee550ab938735426c2eef11",
+            "name": "sub-032_task-emotionProcessingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "4c609570fd448c9b71abec081fa6d7b4",
+            "name": "sub-032_task-emotionProcessingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "02b818204856fea23ce0f54e4dc1dd19",
+            "name": "sub-032_task-emotionProcessingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "80eba72ec6b10e3cf388f9ca45f341f3",
+            "name": "sub-032_task-emotionProcessingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "ecf9cf82ebb51b7bf4b02c480273f2a4",
+            "name": "sub-032_task-emotionProcessingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "a608105dd96eab86ce9ec6496e59f96b",
+            "name": "sub-032_task-emotionProcessingImagined_physio.json"
+          },
+          {
+            "relation": "fdf331a186d1c0bcf29afe86797af8aa",
+            "name": "sub-032_task-emotionProcessingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "a980a7103affd6f65d96e06212a0a3b0",
+            "name": "sub-032_task-emotionProcessing_physio.json"
+          },
+          {
+            "relation": "679f51d4a7e2989403d6b807fad9e7d2",
+            "name": "sub-032_task-emotionProcessing_physio.tsv.gz"
+          },
+          {
+            "relation": "ce389476e87c994f77aaa2158f41ea8d",
+            "name": "sub-032_task-fingerTapping_echo-1_bold.json"
+          },
+          {
+            "relation": "aa3c6b2b266c7d0f9231892fb30c232c",
+            "name": "sub-032_task-fingerTapping_echo-1_bold.nii"
+          },
+          {
+            "relation": "b49a4da3a7f7bd6888b4ff407e5833b2",
+            "name": "sub-032_task-fingerTapping_echo-2_bold.json"
+          },
+          {
+            "relation": "75bba51d82aee031e427861b16236775",
+            "name": "sub-032_task-fingerTapping_echo-2_bold.nii"
+          },
+          {
+            "relation": "da255b4cbc9064e4d00bdd80bfef8e94",
+            "name": "sub-032_task-fingerTapping_echo-3_bold.json"
+          },
+          {
+            "relation": "04aabb3917920bbea046ca597b0c3614",
+            "name": "sub-032_task-fingerTapping_echo-3_bold.nii"
+          },
+          {
+            "relation": "01dd8f6f5e013c54c0627beb86752f57",
+            "name": "sub-032_task-fingerTapping_events.tsv.gz"
+          },
+          {
+            "relation": "a3ecabae2ffc13e0a501f7f66763f221",
+            "name": "sub-032_task-fingerTappingImagined_echo-1_bold.json"
+          },
+          {
+            "relation": "ee6dae06d74b9429018c5e223ba18e1b",
+            "name": "sub-032_task-fingerTappingImagined_echo-1_bold.nii"
+          },
+          {
+            "relation": "feb865a25268a697bba12a00e056e9e8",
+            "name": "sub-032_task-fingerTappingImagined_echo-2_bold.json"
+          },
+          {
+            "relation": "bf036104b3012772a84b6beef452198e",
+            "name": "sub-032_task-fingerTappingImagined_echo-2_bold.nii"
+          },
+          {
+            "relation": "5a6937a8c9385dd4b229505d0e0eb9b3",
+            "name": "sub-032_task-fingerTappingImagined_echo-3_bold.json"
+          },
+          {
+            "relation": "422b513db148567d68380c9cc0a07a96",
+            "name": "sub-032_task-fingerTappingImagined_echo-3_bold.nii"
+          },
+          {
+            "relation": "70c2dff6db9c2aa45696781343789c5e",
+            "name": "sub-032_task-fingerTappingImagined_events.tsv.gz"
+          },
+          {
+            "relation": "ba316c86b3fd667eefdebfd6b430e537",
+            "name": "sub-032_task-fingerTappingImagined_physio.json"
+          },
+          {
+            "relation": "86bb10881e3538db6a45adf4d62f2de9",
+            "name": "sub-032_task-fingerTappingImagined_physio.tsv.gz"
+          },
+          {
+            "relation": "47c7b8a95b772ed4e9ab4579964acd98",
+            "name": "sub-032_task-fingerTapping_physio.json"
+          },
+          {
+            "relation": "60e6c6803435ca34b8285788e22f12b6",
+            "name": "sub-032_task-fingerTapping_physio.tsv.gz"
+          },
+          {
+            "relation": "19f46f4e86b559bcff24b380d5602814",
+            "name": "sub-032_task-rest_run-1_echo-1_bold.json"
+          },
+          {
+            "relation": "f35d8a4022fa2399322f299689275089",
+            "name": "sub-032_task-rest_run-1_echo-1_bold.nii"
+          },
+          {
+            "relation": "7390ff359ffb6e5e7218be387777ddb5",
+            "name": "sub-032_task-rest_run-1_echo-2_bold.json"
+          },
+          {
+            "relation": "af3cf6a31f6988965a963fa03adb82e4",
+            "name": "sub-032_task-rest_run-1_echo-2_bold.nii"
+          },
+          {
+            "relation": "9f4b1c3710f156c61b00783ef6e254fd",
+            "name": "sub-032_task-rest_run-1_echo-3_bold.json"
+          },
+          {
+            "relation": "94572c16591270cc44701ad2af98d235",
+            "name": "sub-032_task-rest_run-1_echo-3_bold.nii"
+          },
+          {
+            "relation": "601450400ed297074b76412ce41f391a",
+            "name": "sub-032_task-rest_run-1_physio.json"
+          },
+          {
+            "relation": "a29a480738f5ed9341c3a8cb2c35b0ce",
+            "name": "sub-032_task-rest_run-1_physio.tsv.gz"
+          },
+          {
+            "relation": "634a31cb6dddc913d0b5b2f36b7d7f55",
+            "name": "sub-032_task-rest_run-2_echo-1_bold.json"
+          },
+          {
+            "relation": "00e335fb2c52c789ddbbd47fa8577494",
+            "name": "sub-032_task-rest_run-2_echo-1_bold.nii"
+          },
+          {
+            "relation": "961828cb3e667183d08bc8c50b44841e",
+            "name": "sub-032_task-rest_run-2_echo-2_bold.json"
+          },
+          {
+            "relation": "53fa854d499812d7cd2e0c4c0bce4268",
+            "name": "sub-032_task-rest_run-2_echo-2_bold.nii"
+          },
+          {
+            "relation": "f78b6a8c5bfccaefccdb712c53398c85",
+            "name": "sub-032_task-rest_run-2_echo-3_bold.json"
+          },
+          {
+            "relation": "95d20042772759ef8f1eae8342912238",
+            "name": "sub-032_task-rest_run-2_echo-3_bold.nii"
+          },
+          {
+            "relation": "c2bc90d9766475106f49a8e071e31794",
+            "name": "sub-032_task-rest_run-2_physio.json"
+          },
+          {
+            "relation": "6e52d0eed2038d116afc2504ea53551c",
+            "name": "sub-032_task-rest_run-2_physio.tsv.gz"
+          }
+        ]
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1b89791e8c1aee44164213034f192b63",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1b89791e8c1aee44164213034f192b63"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46352"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "2b3b3996277ade762410715cfd47431a",
+        "byte_size": 1041,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "2b3b3996277ade762410715cfd47431a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45817"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "65365545508eabb82cc566e36be4ac34",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "65365545508eabb82cc566e36be4ac34"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46478"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ed07bf52a32bd33053c0bb04e686972a",
+        "byte_size": 1041,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ed07bf52a32bd33053c0bb04e686972a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45529"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b1e6f7903c2a3150438d9a23616504af",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b1e6f7903c2a3150438d9a23616504af"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45522"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "8e174c8a66696c7906ba1dcf98d2cc68",
+        "byte_size": 1873,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "8e174c8a66696c7906ba1dcf98d2cc68"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46638"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "61c5e521e58b82e36d53844980c06b63",
+        "byte_size": 1049,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "61c5e521e58b82e36d53844980c06b63"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46238"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "1bf02155e4fcab9c3684175c291dcb3f",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "1bf02155e4fcab9c3684175c291dcb3f"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45335"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "0eefb1536ee550ab938735426c2eef11",
+        "byte_size": 1049,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "0eefb1536ee550ab938735426c2eef11"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45203"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "4c609570fd448c9b71abec081fa6d7b4",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "4c609570fd448c9b71abec081fa6d7b4"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46106"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "02b818204856fea23ce0f54e4dc1dd19",
+        "byte_size": 1049,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "02b818204856fea23ce0f54e4dc1dd19"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45223"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "80eba72ec6b10e3cf388f9ca45f341f3",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "80eba72ec6b10e3cf388f9ca45f341f3"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45526"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ecf9cf82ebb51b7bf4b02c480273f2a4",
+        "byte_size": 178,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ecf9cf82ebb51b7bf4b02c480273f2a4"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46634"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a608105dd96eab86ce9ec6496e59f96b",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a608105dd96eab86ce9ec6496e59f96b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46401"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "fdf331a186d1c0bcf29afe86797af8aa",
+        "byte_size": 466464,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "fdf331a186d1c0bcf29afe86797af8aa"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45291"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a980a7103affd6f65d96e06212a0a3b0",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a980a7103affd6f65d96e06212a0a3b0"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45756"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "679f51d4a7e2989403d6b807fad9e7d2",
+        "byte_size": 493060,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "679f51d4a7e2989403d6b807fad9e7d2"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46248"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ce389476e87c994f77aaa2158f41ea8d",
+        "byte_size": 1037,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ce389476e87c994f77aaa2158f41ea8d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46405"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "aa3c6b2b266c7d0f9231892fb30c232c",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "aa3c6b2b266c7d0f9231892fb30c232c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46318"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "b49a4da3a7f7bd6888b4ff407e5833b2",
+        "byte_size": 1037,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "b49a4da3a7f7bd6888b4ff407e5833b2"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46446"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "75bba51d82aee031e427861b16236775",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "75bba51d82aee031e427861b16236775"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45773"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "da255b4cbc9064e4d00bdd80bfef8e94",
+        "byte_size": 1037,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "da255b4cbc9064e4d00bdd80bfef8e94"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45576"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "04aabb3917920bbea046ca597b0c3614",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "04aabb3917920bbea046ca597b0c3614"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46273"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "01dd8f6f5e013c54c0627beb86752f57",
+        "byte_size": 167,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "01dd8f6f5e013c54c0627beb86752f57"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46605"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a3ecabae2ffc13e0a501f7f66763f221",
+        "byte_size": 1045,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a3ecabae2ffc13e0a501f7f66763f221"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45944"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ee6dae06d74b9429018c5e223ba18e1b",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ee6dae06d74b9429018c5e223ba18e1b"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45399"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "feb865a25268a697bba12a00e056e9e8",
+        "byte_size": 1045,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "feb865a25268a697bba12a00e056e9e8"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46258"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "bf036104b3012772a84b6beef452198e",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "bf036104b3012772a84b6beef452198e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45458"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "5a6937a8c9385dd4b229505d0e0eb9b3",
+        "byte_size": 1045,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "5a6937a8c9385dd4b229505d0e0eb9b3"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46353"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "422b513db148567d68380c9cc0a07a96",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "422b513db148567d68380c9cc0a07a96"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45401"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "70c2dff6db9c2aa45696781343789c5e",
+        "byte_size": 179,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "70c2dff6db9c2aa45696781343789c5e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46610"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ba316c86b3fd667eefdebfd6b430e537",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ba316c86b3fd667eefdebfd6b430e537"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45630"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "86bb10881e3538db6a45adf4d62f2de9",
+        "byte_size": 467483,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "86bb10881e3538db6a45adf4d62f2de9"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45724"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "47c7b8a95b772ed4e9ab4579964acd98",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "47c7b8a95b772ed4e9ab4579964acd98"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45464"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "60e6c6803435ca34b8285788e22f12b6",
+        "byte_size": 471716,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "60e6c6803435ca34b8285788e22f12b6"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46193"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "19f46f4e86b559bcff24b380d5602814",
+        "byte_size": 1028,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "19f46f4e86b559bcff24b380d5602814"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46520"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f35d8a4022fa2399322f299689275089",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f35d8a4022fa2399322f299689275089"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46065"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "7390ff359ffb6e5e7218be387777ddb5",
+        "byte_size": 1028,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "7390ff359ffb6e5e7218be387777ddb5"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46408"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "af3cf6a31f6988965a963fa03adb82e4",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "af3cf6a31f6988965a963fa03adb82e4"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45652"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "9f4b1c3710f156c61b00783ef6e254fd",
+        "byte_size": 1028,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "9f4b1c3710f156c61b00783ef6e254fd"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45315"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "94572c16591270cc44701ad2af98d235",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "94572c16591270cc44701ad2af98d235"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46171"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "601450400ed297074b76412ce41f391a",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "601450400ed297074b76412ce41f391a"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46240"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "a29a480738f5ed9341c3a8cb2c35b0ce",
+        "byte_size": 462207,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "a29a480738f5ed9341c3a8cb2c35b0ce"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46529"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "634a31cb6dddc913d0b5b2f36b7d7f55",
+        "byte_size": 1028,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "634a31cb6dddc913d0b5b2f36b7d7f55"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46111"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "00e335fb2c52c789ddbbd47fa8577494",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "00e335fb2c52c789ddbbd47fa8577494"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45606"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "961828cb3e667183d08bc8c50b44841e",
+        "byte_size": 1028,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "961828cb3e667183d08bc8c50b44841e"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46290"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "53fa854d499812d7cd2e0c4c0bce4268",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "53fa854d499812d7cd2e0c4c0bce4268"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45917"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "f78b6a8c5bfccaefccdb712c53398c85",
+        "byte_size": 1028,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "f78b6a8c5bfccaefccdb712c53398c85"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46369"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "95d20042772759ef8f1eae8342912238",
+        "byte_size": 58491232,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "95d20042772759ef8f1eae8342912238"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/45217"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "c2bc90d9766475106f49a8e071e31794",
+        "byte_size": 143,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "c2bc90d9766475106f49a8e071e31794"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46336"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "6e52d0eed2038d116afc2504ea53551c",
+        "byte_size": 456867,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "6e52d0eed2038d116afc2504ea53551c"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46434"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "eac027a2545fd2b8ee12e495d2ee6499",
+        "byte_size": 1893,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "eac027a2545fd2b8ee12e495d2ee6499"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46665"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "d80166992bd6e82f2ccc13aea8537542",
+        "byte_size": 821,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "d80166992bd6e82f2ccc13aea8537542"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46667"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "ab572625ab03f4175842af1c3d52370d",
+        "byte_size": 872,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "ab572625ab03f4175842af1c3d52370d"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46666"
+      },
+      {
+        "meta_type": "dlco:DigitalDocumentObject",
+        "meta_code": "3b708d003000956e0562d0c8f39b1786",
+        "byte_size": 808,
+        "checksum": {
+          "algorithm": "md5",
+          "digest": "3b708d003000956e0562d0c8f39b1786"
+        },
+        "download_url": "https://dataverse.nl/api/access/datafile/46668"
+      }
+    ],
+    "license": "customlicenses:humanhealthdata",
+    "qualified_part": [
+      {
+        "relation": "7d63a6dd379b3b81574e31240433e008",
+        "name": "dataset_description.json"
+      },
+      {
+        "relation": "derivatives/",
+        "name": "derivatives"
+      },
+      {
+        "relation": "0a25e5c0225e9bd18c62a560df470980",
+        "name": "participants.tsv"
+      },
+      {
+        "relation": "1abb42c68887b4c075e710f0ae8ce855",
+        "name": "README.md"
+      },
+      {
+        "relation": "sub-001/",
+        "name": "sub-001"
+      },
+      {
+        "relation": "sub-002/",
+        "name": "sub-002"
+      },
+      {
+        "relation": "sub-003/",
+        "name": "sub-003"
+      },
+      {
+        "relation": "sub-004/",
+        "name": "sub-004"
+      },
+      {
+        "relation": "sub-005/",
+        "name": "sub-005"
+      },
+      {
+        "relation": "sub-006/",
+        "name": "sub-006"
+      },
+      {
+        "relation": "sub-007/",
+        "name": "sub-007"
+      },
+      {
+        "relation": "sub-010/",
+        "name": "sub-010"
+      },
+      {
+        "relation": "sub-011/",
+        "name": "sub-011"
+      },
+      {
+        "relation": "sub-012/",
+        "name": "sub-012"
+      },
+      {
+        "relation": "sub-013/",
+        "name": "sub-013"
+      },
+      {
+        "relation": "sub-015/",
+        "name": "sub-015"
+      },
+      {
+        "relation": "sub-016/",
+        "name": "sub-016"
+      },
+      {
+        "relation": "sub-017/",
+        "name": "sub-017"
+      },
+      {
+        "relation": "sub-018/",
+        "name": "sub-018"
+      },
+      {
+        "relation": "sub-019/",
+        "name": "sub-019"
+      },
+      {
+        "relation": "sub-020/",
+        "name": "sub-020"
+      },
+      {
+        "relation": "sub-021/",
+        "name": "sub-021"
+      },
+      {
+        "relation": "sub-022/",
+        "name": "sub-022"
+      },
+      {
+        "relation": "sub-023/",
+        "name": "sub-023"
+      },
+      {
+        "relation": "sub-024/",
+        "name": "sub-024"
+      },
+      {
+        "relation": "sub-025/",
+        "name": "sub-025"
+      },
+      {
+        "relation": "sub-026/",
+        "name": "sub-026"
+      },
+      {
+        "relation": "sub-027/",
+        "name": "sub-027"
+      },
+      {
+        "relation": "sub-029/",
+        "name": "sub-029"
+      },
+      {
+        "relation": "sub-030/",
+        "name": "sub-030"
+      },
+      {
+        "relation": "sub-031/",
+        "name": "sub-031"
+      },
+      {
+        "relation": "sub-032/",
+        "name": "sub-032"
+      },
+      {
+        "relation": "eac027a2545fd2b8ee12e495d2ee6499",
+        "name": "task-emotionProcessing_events.json"
+      },
+      {
+        "relation": "d80166992bd6e82f2ccc13aea8537542",
+        "name": "task-emotionProcessingImagined_events.json"
+      },
+      {
+        "relation": "ab572625ab03f4175842af1c3d52370d",
+        "name": "task-fingerTapping_events.json"
+      },
+      {
+        "relation": "3b708d003000956e0562d0c8f39b1786",
+        "name": "task-fingerTappingImagined_events.json"
+      }
+    ]
+  },
+  "identifier": [
+    "https://doi.org/10.34894/R1TNL8"
+  ],
+  "license": "customlicenses:humanhealthdata",
+  "was_attributed_to": [
+    {
+      "meta_code": "StephanHeunis",
+      "meta_type": "dlco:ResearchContributorObject",
+      "name": "Stephan Heunis",
+      "affiliation": "Eindhoven University of Technology",
+      "orcid": "0000-0003-3503-9872"
+    },
+    {
+      "meta_code": "TUE",
+      "meta_type": "dlco:OrganizationObject",
+      "name": "Eindhoven University of Technology"
+    }
+  ],
+  "qualified_attribution": [
+    {
+      "agent": "StephanHeunis",
+      "had_role": [
+        "marcrel:aut",
+        "marcrel:col",
+        "marcrel:cre"
+      ]
+    },
+    {
+      "agent": "TUE",
+      "had_role": [
+        "marcrel:sht"
+      ]
+    }
+  ],
+  "qualified_relation": [
+    {
+      "entity": "data_paper",
+      "had_role": [
+        "CiTO:isDocumentedBy",
+        "CiTO:citesAsAuthority"
+      ]
+    },
+    {
+      "entity": "methods_paper",
+      "had_role": [
+        "CiTO:isCitedAsDataSourceBy"
+      ]
+    }
+  ],
+  "relation": [
+    {
+      "meta_code": "data_paper",
+      "meta_type": "dlco:PublicationObject",
+      "citation": "Heunis S, Breeuwer M, Caballero-Gaudes C et al. rt-me-fMRI: a task and resting state dataset for real-time, multi-echo fMRI methods development and validation [version 1; peer review: 1 approved, 1 approved with reservations]. F1000Research 2021, 10:70 (https://doi.org/10.12688/f1000research.29988.1)",
+      "doi": "https://doi.org/10.12688/f1000research.29988.1"
+    },
+    {
+      "meta_code": "methods_paper",
+      "meta_type": "dlco:PublicationObject",
+      "citation": "S. Heunis, M. Breeuwer, C. Caballero-Gaudes, L. Hellrung, W. Huijbers, J.F. Jansen, R. Lamerichs, S. Zinger, A.P. Aldenkamp. The effects of multi-echo fMRI combination and rapid T*-mapping on offline and real-time BOLD sensitivity. NeuroImage, 238 (2021), Article 118244, 10.1016/j.neuroimage.2021.118244",
+      "doi": "https://doi.org/10.1016/j.neuroimage.2021.118244"
+    }
+  ],
+  "description": "rt-me-fMRI is a multi-echo functional magnetic resonance imaging dataset (N=28 healthy volunteers) with four task-based and two resting state runs. Its main purpose is to advance the development of methods for real-time multi-echo fMRI analysis with applications in neurofeedback, real-time quality control, and adaptive paradigms, although the variety of experimental task paradigms can support multiple use cases. Tasks include finger tapping, emotional face and shape matching, imagined finger tapping and imagined emotion processing. Further information is available at https://github.com/jsheunis/rt-me-fMRI",
+  "keyword": [
+    "Engineering",
+    "Medicine, Health and Life Sciences",
+    "Physics"
+  ],
+  "landing_page": "https://doi.org/10.34894/R1TNL8",
+  "modified": "2023-11-13",
+  "name": "dataverse-rtmefmri",
+  "title": "rt-me-fMRI: A task and resting state dataset for real-time, multi-echo fMRI methods development and validation",
+  "version": "1.4",
+  "@type": "DatasetVersionObject"
+}

--- a/src/examples/dataset-version/DatasetVersionObject-dataverse-rtmefmri.yaml
+++ b/src/examples/dataset-version/DatasetVersionObject-dataverse-rtmefmri.yaml
@@ -1,0 +1,13988 @@
+name: dataverse-rtmefmri
+title: 'rt-me-fMRI: A task and resting state dataset for real-time, multi-echo fMRI
+  methods development and validation'
+description: rt-me-fMRI is a multi-echo functional magnetic resonance imaging dataset
+  (N=28 healthy volunteers) with four task-based and two resting state runs. Its main
+  purpose is to advance the development of methods for real-time multi-echo fMRI analysis
+  with applications in neurofeedback, real-time quality control, and adaptive paradigms,
+  although the variety of experimental task paradigms can support multiple use cases.
+  Tasks include finger tapping, emotional face and shape matching, imagined finger
+  tapping and imagined emotion processing. Further information is available at https://github.com/jsheunis/rt-me-fMRI
+landing_page: https://doi.org/10.34894/R1TNL8
+version: '1.4'
+modified: '2023-11-13'
+keyword:
+  - Engineering
+  - Medicine, Health and Life Sciences
+  - Physics
+identifier:
+  - https://doi.org/10.34894/R1TNL8
+custom_licenses:
+  customlicenses:humanhealthdata:
+    identifier: 
+      https://dataverse.nl/api/datasets/:persistentId/versions/1.4/customlicense?persistentId=doi:10.34894/R1TNL8
+    license_text: "<h2>Data user agreement for accessing limited human health data</h2>\n
+      <br>\n<i><b>By clicking \"Accept\", I agree to the terms presented below.</b></i>\n
+      <br><br>\n<p>I request access to the <i><b>rt-me-fMRI</b></i> dataset collected
+      in the DataverseNL digital repository as deposited by researchers at\n    (1)
+      the Electrical Engineering department, Eindhoven University of Technology, (2)
+      Kempenhaeghe, and (3) Philips\n    Research, co-located at Eindhoven, The Netherlands,
+      and hereinafter referred to as the \"research institution\".\n<p>\n\n<p>By accepting
+      this agreement, I become the <a\n        href=\"https://ec.europa.eu/info/law/law-topic/data-protection/reform/rules-business-and-organisations/obligations/controller-processor/what-data-controller-or-data-processor_en\"\
+      >data\n        controller</a> (as defined under the European General Data Protection
+      Regulation, i.e. the GDPR) of the data\n    that I process for my own purposes
+      and means, and am responsible that I process these data under the following\n\
+      \    terms:</p>\n<ol>\n    <li>I will comply with all relevant rules and regulations
+      imposed by my institution and my government. This\n        agreement never has
+      prevalence over existing general data protection regulations that are applicable
+      in my\n        country.</li>\n    <li>I will not attempt to establish or retrieve
+      the identity of the study participants. I will not link these data\n       \
+      \ to any other database in a way that could provide identifying information.
+      I shall not request the\n        pseudonymisation key that would link these
+      data to an individual's personal information, nor will I accept any\n      \
+      \  additional information about individual participants under this Data Use
+      Agreement.</li>\n    <li>I will not redistribute these data or share access
+      to these data with others, unless they have independently\n        applied and
+      been granted access to these data, i.e., signed this Data Use Agreement. This
+      includes individuals\n        in my institution.</li>\n    <li>I will reference
+      the specific source of the accessed data when publicly presenting any results
+      or algorithms\n        that benefited from their use:\n        <ul>\n      \
+      \      <li>Papers, book chapters, books, posters, oral presentations, and all
+      other presentations of results\n                derived from the data should
+      acknowledge the origin of the data as follows: \"Data were provided (in\n  \
+      \              part) by the Electrical Engineering Department, Eindhoven University
+      of Technology, The Netherlands and\n                Kempenhaeghe Epilepsy Center,
+      Heeze, The Netherlands”.</li>\n            <li>Authors of publications or presentations
+      using the data should cite relevant publications describing the\n          \
+      \      methods developed and used by the research institution to acquire and
+      process the data. The specific\n                publications that are appropriate
+      to cite in any given study will depend on what the data were used and\n    \
+      \            for what purposes. When applicable, a list of publications will
+      be included in the collection.</li>\n            <li>Neither the entities that
+      constitute the research institution, nor the researchers that provide this\n\
+      \                data will be liable for any results and/or derived data. They
+      shall not be included as an author of\n                publications or presentations
+      without consent.</li>\n        </ul>\n    </li>\n    <li>Failure to comply with
+      this agreement will result in, but not limited to, termination of my privileges
+      to access\n        these data.</li>\n    <li>This agreement is governed by Dutch
+      law.</li>\n</ol>"
+license: customlicenses:humanhealthdata
+was_attributed_to:
+  - meta_type: dlco:ResearchContributorObject
+    meta_code: StephanHeunis
+    name: Stephan Heunis
+    orcid: 0000-0003-3503-9872
+    affiliation: Eindhoven University of Technology
+  - meta_type: dlco:OrganizationObject
+    meta_code: TUE
+    name: Eindhoven University of Technology
+qualified_attribution:
+  - agent: StephanHeunis
+    had_role:
+      - marcrel:aut
+      - marcrel:col
+      - marcrel:cre
+  - agent: TUE
+    had_role:
+      - marcrel:sht
+relation:
+  - meta_type: dlco:PublicationObject
+    meta_code: data_paper
+    citation: 'Heunis S, Breeuwer M, Caballero-Gaudes C et al. rt-me-fMRI: a task
+      and resting state dataset for real-time, multi-echo fMRI methods development
+      and validation [version 1; peer review: 1 approved, 1 approved with reservations].
+      F1000Research 2021, 10:70 (https://doi.org/10.12688/f1000research.29988.1)'
+    doi: https://doi.org/10.12688/f1000research.29988.1
+  - meta_type: dlco:PublicationObject
+    meta_code: methods_paper
+    citation: S. Heunis, M. Breeuwer, C. Caballero-Gaudes, L. Hellrung, W. Huijbers,
+      J.F. Jansen, R. Lamerichs, S. Zinger, A.P. Aldenkamp. The effects of multi-echo
+      fMRI combination and rapid T*-mapping on offline and real-time BOLD sensitivity.
+      NeuroImage, 238 (2021), Article 118244, 10.1016/j.neuroimage.2021.118244
+    doi: https://doi.org/10.1016/j.neuroimage.2021.118244
+qualified_relation:
+  - had_role:
+      - CiTO:isDocumentedBy
+      - CiTO:citesAsAuthority
+    entity: data_paper
+  - had_role:
+      - CiTO:isCitedAsDataSourceBy
+    entity: methods_paper
+distribution:
+  meta_type: dlco:FileContainerObject
+  meta_code: ./
+  license: customlicenses:humanhealthdata
+  has_part:
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 7d63a6dd379b3b81574e31240433e008
+      byte_size: 1455
+      checksum:
+        algorithm: md5
+        digest: 7d63a6dd379b3b81574e31240433e008
+      download_url: https://dataverse.nl/api/access/datafile/46664
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a88a2b8ad2cdf158c3b1ee84ecdbbbf9
+      byte_size: 39
+      checksum:
+        algorithm: md5
+        digest: a88a2b8ad2cdf158c3b1ee84ecdbbbf9
+      download_url: https://dataverse.nl/api/access/datafile/46709
+    - meta_type: dlco:FileContainerObject
+      meta_code: derivatives/
+      qualified_part:
+        - relation: derivatives/fmrwhy-dash/
+          name: fmrwhy-dash
+        - relation: derivatives/fmrwhy-qc/
+          name: fmrwhy-qc
+    - meta_type: dlco:FileContainerObject
+      meta_code: derivatives/fmrwhy-dash/
+      qualified_part:
+        - relation: a88a2b8ad2cdf158c3b1ee84ecdbbbf9
+          name: fmrwhy-dash.txt
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 738eead953d79c5f494795ef91b453ee
+      byte_size: 37
+      checksum:
+        algorithm: md5
+        digest: 738eead953d79c5f494795ef91b453ee
+      download_url: https://dataverse.nl/api/access/datafile/46710
+    - meta_type: dlco:FileContainerObject
+      meta_code: derivatives/fmrwhy-qc/
+      qualified_part:
+        - relation: 738eead953d79c5f494795ef91b453ee
+          name: fmrwhy-qc.txt
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 0a25e5c0225e9bd18c62a560df470980
+      byte_size: 238
+      checksum:
+        algorithm: md5
+        digest: 0a25e5c0225e9bd18c62a560df470980
+      download_url: https://dataverse.nl/api/access/datafile/46663
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1abb42c68887b4c075e710f0ae8ce855
+      byte_size: 1429
+      checksum:
+        algorithm: md5
+        digest: 1abb42c68887b4c075e710f0ae8ce855
+      download_url: https://dataverse.nl/api/access/datafile/46708
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 678f2832b684bbc90d501dc603868bff
+      byte_size: 20736352
+      checksum:
+        algorithm: md5
+        digest: 678f2832b684bbc90d501dc603868bff
+      download_url: https://dataverse.nl/api/access/datafile/45615
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-001/
+      qualified_part:
+        - relation: sub-001/anat/
+          name: anat
+        - relation: sub-001/func/
+          name: func
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-001/anat/
+      qualified_part:
+        - relation: 678f2832b684bbc90d501dc603868bff
+          name: sub-001_T1w.nii
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 89c161237e848b41add3ac5d2b500c75
+      byte_size: 1041
+      checksum:
+        algorithm: md5
+        digest: 89c161237e848b41add3ac5d2b500c75
+      download_url: https://dataverse.nl/api/access/datafile/45363
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-001/func/
+      qualified_part:
+        - relation: 89c161237e848b41add3ac5d2b500c75
+          name: sub-001_task-emotionProcessing_echo-1_bold.json
+        - relation: 78fb2c0f46963569767ae895ff76f8d4
+          name: sub-001_task-emotionProcessing_echo-1_bold.nii
+        - relation: 56a5078e8d1434e4da6f19b995263b63
+          name: sub-001_task-emotionProcessing_echo-2_bold.json
+        - relation: 5760b7656006d37965ae3125490c1eaf
+          name: sub-001_task-emotionProcessing_echo-2_bold.nii
+        - relation: f30db156c93de5390c73c9b9272c58f0
+          name: sub-001_task-emotionProcessing_echo-3_bold.json
+        - relation: 797986659433a9da8ec3f7b6e46aeb54
+          name: sub-001_task-emotionProcessing_echo-3_bold.nii
+        - relation: a2736a06b0d65a9a7d8a8405c38bfd5d
+          name: sub-001_task-emotionProcessing_events.tsv.gz
+        - relation: daf928b2860acd3705f08a1d44c986d7
+          name: sub-001_task-emotionProcessingImagined_echo-1_bold.json
+        - relation: 8e5e4295a677afbe4fff1e88a44edf40
+          name: sub-001_task-emotionProcessingImagined_echo-1_bold.nii
+        - relation: 718e2607b88161aa7da96441811bb668
+          name: sub-001_task-emotionProcessingImagined_echo-2_bold.json
+        - relation: 6a42e577d5b33591d34706aed5dab54b
+          name: sub-001_task-emotionProcessingImagined_echo-2_bold.nii
+        - relation: 7a667113b3daa985b748a6f8eacfb15c
+          name: sub-001_task-emotionProcessingImagined_echo-3_bold.json
+        - relation: a345b63a7f2164c7b2304c466cbab8df
+          name: sub-001_task-emotionProcessingImagined_echo-3_bold.nii
+        - relation: 80bbaaffae6ffa4103c5142fb17d7c2a
+          name: sub-001_task-emotionProcessingImagined_events.tsv.gz
+        - relation: c004321667c23b1902e25b22b27ae012
+          name: sub-001_task-emotionProcessingImagined_physio.json
+        - relation: cf755584ecd4e3c1f6e48fccbb30463e
+          name: sub-001_task-emotionProcessingImagined_physio.tsv.gz
+        - relation: f6d422020cde7f1acc387ba8aa45f319
+          name: sub-001_task-emotionProcessing_physio.json
+        - relation: 3e39a50cff3dae3e85b58288d9867e12
+          name: sub-001_task-emotionProcessing_physio.tsv.gz
+        - relation: 07322a7494441559e5cdd20a57a4d8cf
+          name: sub-001_task-fingerTapping_echo-1_bold.json
+        - relation: 8c5ded113bbccd377cefd38edd154d5b
+          name: sub-001_task-fingerTapping_echo-1_bold.nii
+        - relation: da5ab166644f570d8fa956457a9bbf47
+          name: sub-001_task-fingerTapping_echo-2_bold.json
+        - relation: b82b687193271c8151bcbacfbe3e7626
+          name: sub-001_task-fingerTapping_echo-2_bold.nii
+        - relation: 425e116b054dd72925d970f0fb2c3176
+          name: sub-001_task-fingerTapping_echo-3_bold.json
+        - relation: addf94f0e75a499d1736cc63387b394d
+          name: sub-001_task-fingerTapping_echo-3_bold.nii
+        - relation: 43a708b1b704c30226923f2b6ab380b6
+          name: sub-001_task-fingerTapping_events.tsv.gz
+        - relation: 920db66c4c9552efbec84fb65ae9c363
+          name: sub-001_task-fingerTappingImagined_echo-1_bold.json
+        - relation: 82f169c348b851b4ad009442086d6acd
+          name: sub-001_task-fingerTappingImagined_echo-1_bold.nii
+        - relation: 02724a22a11885cdf51dacd30b870456
+          name: sub-001_task-fingerTappingImagined_echo-2_bold.json
+        - relation: 58655ea820a6fb46d19d0666b767439c
+          name: sub-001_task-fingerTappingImagined_echo-2_bold.nii
+        - relation: bec034b87f61d4e21c24209c75b25897
+          name: sub-001_task-fingerTappingImagined_echo-3_bold.json
+        - relation: 12d17d0ec3dc7e9d90e75516ea6a26e1
+          name: sub-001_task-fingerTappingImagined_echo-3_bold.nii
+        - relation: 933088364ebb3346e825dd3f929bed11
+          name: sub-001_task-fingerTappingImagined_events.tsv.gz
+        - relation: b1842207924fca982fb1fc24d76bc312
+          name: sub-001_task-fingerTappingImagined_physio.json
+        - relation: 30cbe40f3eff986588253335007b44b1
+          name: sub-001_task-fingerTappingImagined_physio.tsv.gz
+        - relation: 2a064003e1080fb234c6a87d301677eb
+          name: sub-001_task-fingerTapping_physio.json
+        - relation: fd983bb7f0aacfd1c82a4cc66291ece7
+          name: sub-001_task-fingerTapping_physio.tsv.gz
+        - relation: 8afd88b03a88b24ecf64f84ae52e8846
+          name: sub-001_task-rest_run-1_echo-1_bold.json
+        - relation: 44e4f216d13068469c80e71f8527a2e6
+          name: sub-001_task-rest_run-1_echo-1_bold.nii
+        - relation: b72be0db59010c4ec993396099b3482c
+          name: sub-001_task-rest_run-1_echo-2_bold.json
+        - relation: 0eaaf587c1ec3e2c62727bb1c990b46a
+          name: sub-001_task-rest_run-1_echo-2_bold.nii
+        - relation: 0c304cbaed62715915e922fa8bb5ec2a
+          name: sub-001_task-rest_run-1_echo-3_bold.json
+        - relation: 9b6b87f2d7b292fb432b8b0f55c1d1a8
+          name: sub-001_task-rest_run-1_echo-3_bold.nii
+        - relation: 8b1fe1885567392c664bd283bcff1d2e
+          name: sub-001_task-rest_run-1_physio.json
+        - relation: e5f5aae66346cc2b6eab06147ea076a6
+          name: sub-001_task-rest_run-1_physio.tsv.gz
+        - relation: 9b028ce4d5801195fefff15bc1b5768e
+          name: sub-001_task-rest_run-2_echo-1_bold.json
+        - relation: 31c95eed2391907357fde714b47e54d0
+          name: sub-001_task-rest_run-2_echo-1_bold.nii
+        - relation: 4a0d83ee1a3782f528eca56303895eca
+          name: sub-001_task-rest_run-2_echo-2_bold.json
+        - relation: 0058bec35f3a53a169011571dc4a8a01
+          name: sub-001_task-rest_run-2_echo-2_bold.nii
+        - relation: 739448e73206d3da7cd20bd564457af6
+          name: sub-001_task-rest_run-2_echo-3_bold.json
+        - relation: 354671b079f219299fee7457c9d673e8
+          name: sub-001_task-rest_run-2_echo-3_bold.nii
+        - relation: 0ffd5218f0f1686afa4dc8143dbc7a3b
+          name: sub-001_task-rest_run-2_physio.json
+        - relation: 498f80810fc869ca053aa3ee4f27d538
+          name: sub-001_task-rest_run-2_physio.tsv.gz
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 78fb2c0f46963569767ae895ff76f8d4
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 78fb2c0f46963569767ae895ff76f8d4
+      download_url: https://dataverse.nl/api/access/datafile/45312
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 56a5078e8d1434e4da6f19b995263b63
+      byte_size: 1041
+      checksum:
+        algorithm: md5
+        digest: 56a5078e8d1434e4da6f19b995263b63
+      download_url: https://dataverse.nl/api/access/datafile/46262
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5760b7656006d37965ae3125490c1eaf
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 5760b7656006d37965ae3125490c1eaf
+      download_url: https://dataverse.nl/api/access/datafile/45604
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f30db156c93de5390c73c9b9272c58f0
+      byte_size: 1041
+      checksum:
+        algorithm: md5
+        digest: f30db156c93de5390c73c9b9272c58f0
+      download_url: https://dataverse.nl/api/access/datafile/46333
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 797986659433a9da8ec3f7b6e46aeb54
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 797986659433a9da8ec3f7b6e46aeb54
+      download_url: https://dataverse.nl/api/access/datafile/45650
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a2736a06b0d65a9a7d8a8405c38bfd5d
+      byte_size: 1880
+      checksum:
+        algorithm: md5
+        digest: a2736a06b0d65a9a7d8a8405c38bfd5d
+      download_url: https://dataverse.nl/api/access/datafile/46584
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: daf928b2860acd3705f08a1d44c986d7
+      byte_size: 1049
+      checksum:
+        algorithm: md5
+        digest: daf928b2860acd3705f08a1d44c986d7
+      download_url: https://dataverse.nl/api/access/datafile/46265
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8e5e4295a677afbe4fff1e88a44edf40
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 8e5e4295a677afbe4fff1e88a44edf40
+      download_url: https://dataverse.nl/api/access/datafile/45505
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 718e2607b88161aa7da96441811bb668
+      byte_size: 1049
+      checksum:
+        algorithm: md5
+        digest: 718e2607b88161aa7da96441811bb668
+      download_url: https://dataverse.nl/api/access/datafile/45334
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6a42e577d5b33591d34706aed5dab54b
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 6a42e577d5b33591d34706aed5dab54b
+      download_url: https://dataverse.nl/api/access/datafile/45456
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 7a667113b3daa985b748a6f8eacfb15c
+      byte_size: 1049
+      checksum:
+        algorithm: md5
+        digest: 7a667113b3daa985b748a6f8eacfb15c
+      download_url: https://dataverse.nl/api/access/datafile/45704
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a345b63a7f2164c7b2304c466cbab8df
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: a345b63a7f2164c7b2304c466cbab8df
+      download_url: https://dataverse.nl/api/access/datafile/45487
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 80bbaaffae6ffa4103c5142fb17d7c2a
+      byte_size: 142
+      checksum:
+        algorithm: md5
+        digest: 80bbaaffae6ffa4103c5142fb17d7c2a
+      download_url: https://dataverse.nl/api/access/datafile/46660
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c004321667c23b1902e25b22b27ae012
+      byte_size: 142
+      checksum:
+        algorithm: md5
+        digest: c004321667c23b1902e25b22b27ae012
+      download_url: https://dataverse.nl/api/access/datafile/45381
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: cf755584ecd4e3c1f6e48fccbb30463e
+      byte_size: 488347
+      checksum:
+        algorithm: md5
+        digest: cf755584ecd4e3c1f6e48fccbb30463e
+      download_url: https://dataverse.nl/api/access/datafile/45767
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f6d422020cde7f1acc387ba8aa45f319
+      byte_size: 142
+      checksum:
+        algorithm: md5
+        digest: f6d422020cde7f1acc387ba8aa45f319
+      download_url: https://dataverse.nl/api/access/datafile/45694
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 3e39a50cff3dae3e85b58288d9867e12
+      byte_size: 494035
+      checksum:
+        algorithm: md5
+        digest: 3e39a50cff3dae3e85b58288d9867e12
+      download_url: https://dataverse.nl/api/access/datafile/45996
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 07322a7494441559e5cdd20a57a4d8cf
+      byte_size: 1036
+      checksum:
+        algorithm: md5
+        digest: 07322a7494441559e5cdd20a57a4d8cf
+      download_url: https://dataverse.nl/api/access/datafile/45425
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8c5ded113bbccd377cefd38edd154d5b
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 8c5ded113bbccd377cefd38edd154d5b
+      download_url: https://dataverse.nl/api/access/datafile/46431
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: da5ab166644f570d8fa956457a9bbf47
+      byte_size: 1036
+      checksum:
+        algorithm: md5
+        digest: da5ab166644f570d8fa956457a9bbf47
+      download_url: https://dataverse.nl/api/access/datafile/45999
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b82b687193271c8151bcbacfbe3e7626
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: b82b687193271c8151bcbacfbe3e7626
+      download_url: https://dataverse.nl/api/access/datafile/45897
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 425e116b054dd72925d970f0fb2c3176
+      byte_size: 1036
+      checksum:
+        algorithm: md5
+        digest: 425e116b054dd72925d970f0fb2c3176
+      download_url: https://dataverse.nl/api/access/datafile/46441
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: addf94f0e75a499d1736cc63387b394d
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: addf94f0e75a499d1736cc63387b394d
+      download_url: https://dataverse.nl/api/access/datafile/46514
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 43a708b1b704c30226923f2b6ab380b6
+      byte_size: 131
+      checksum:
+        algorithm: md5
+        digest: 43a708b1b704c30226923f2b6ab380b6
+      download_url: https://dataverse.nl/api/access/datafile/46590
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 920db66c4c9552efbec84fb65ae9c363
+      byte_size: 1041
+      checksum:
+        algorithm: md5
+        digest: 920db66c4c9552efbec84fb65ae9c363
+      download_url: https://dataverse.nl/api/access/datafile/45681
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 82f169c348b851b4ad009442086d6acd
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 82f169c348b851b4ad009442086d6acd
+      download_url: https://dataverse.nl/api/access/datafile/45115
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 02724a22a11885cdf51dacd30b870456
+      byte_size: 1041
+      checksum:
+        algorithm: md5
+        digest: 02724a22a11885cdf51dacd30b870456
+      download_url: https://dataverse.nl/api/access/datafile/45991
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 58655ea820a6fb46d19d0666b767439c
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 58655ea820a6fb46d19d0666b767439c
+      download_url: https://dataverse.nl/api/access/datafile/45672
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: bec034b87f61d4e21c24209c75b25897
+      byte_size: 1041
+      checksum:
+        algorithm: md5
+        digest: bec034b87f61d4e21c24209c75b25897
+      download_url: https://dataverse.nl/api/access/datafile/46223
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 12d17d0ec3dc7e9d90e75516ea6a26e1
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 12d17d0ec3dc7e9d90e75516ea6a26e1
+      download_url: https://dataverse.nl/api/access/datafile/45860
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 933088364ebb3346e825dd3f929bed11
+      byte_size: 146
+      checksum:
+        algorithm: md5
+        digest: 933088364ebb3346e825dd3f929bed11
+      download_url: https://dataverse.nl/api/access/datafile/46646
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b1842207924fca982fb1fc24d76bc312
+      byte_size: 142
+      checksum:
+        algorithm: md5
+        digest: b1842207924fca982fb1fc24d76bc312
+      download_url: https://dataverse.nl/api/access/datafile/46303
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 30cbe40f3eff986588253335007b44b1
+      byte_size: 495447
+      checksum:
+        algorithm: md5
+        digest: 30cbe40f3eff986588253335007b44b1
+      download_url: https://dataverse.nl/api/access/datafile/46166
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2a064003e1080fb234c6a87d301677eb
+      byte_size: 142
+      checksum:
+        algorithm: md5
+        digest: 2a064003e1080fb234c6a87d301677eb
+      download_url: https://dataverse.nl/api/access/datafile/45577
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: fd983bb7f0aacfd1c82a4cc66291ece7
+      byte_size: 488065
+      checksum:
+        algorithm: md5
+        digest: fd983bb7f0aacfd1c82a4cc66291ece7
+      download_url: https://dataverse.nl/api/access/datafile/45746
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8afd88b03a88b24ecf64f84ae52e8846
+      byte_size: 1028
+      checksum:
+        algorithm: md5
+        digest: 8afd88b03a88b24ecf64f84ae52e8846
+      download_url: https://dataverse.nl/api/access/datafile/45610
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 44e4f216d13068469c80e71f8527a2e6
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 44e4f216d13068469c80e71f8527a2e6
+      download_url: https://dataverse.nl/api/access/datafile/45273
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b72be0db59010c4ec993396099b3482c
+      byte_size: 1028
+      checksum:
+        algorithm: md5
+        digest: b72be0db59010c4ec993396099b3482c
+      download_url: https://dataverse.nl/api/access/datafile/45228
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 0eaaf587c1ec3e2c62727bb1c990b46a
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 0eaaf587c1ec3e2c62727bb1c990b46a
+      download_url: https://dataverse.nl/api/access/datafile/46020
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 0c304cbaed62715915e922fa8bb5ec2a
+      byte_size: 1028
+      checksum:
+        algorithm: md5
+        digest: 0c304cbaed62715915e922fa8bb5ec2a
+      download_url: https://dataverse.nl/api/access/datafile/45254
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 9b6b87f2d7b292fb432b8b0f55c1d1a8
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 9b6b87f2d7b292fb432b8b0f55c1d1a8
+      download_url: https://dataverse.nl/api/access/datafile/46098
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8b1fe1885567392c664bd283bcff1d2e
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 8b1fe1885567392c664bd283bcff1d2e
+      download_url: https://dataverse.nl/api/access/datafile/45180
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e5f5aae66346cc2b6eab06147ea076a6
+      byte_size: 447241
+      checksum:
+        algorithm: md5
+        digest: e5f5aae66346cc2b6eab06147ea076a6
+      download_url: https://dataverse.nl/api/access/datafile/45102
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 9b028ce4d5801195fefff15bc1b5768e
+      byte_size: 1028
+      checksum:
+        algorithm: md5
+        digest: 9b028ce4d5801195fefff15bc1b5768e
+      download_url: https://dataverse.nl/api/access/datafile/46015
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 31c95eed2391907357fde714b47e54d0
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 31c95eed2391907357fde714b47e54d0
+      download_url: https://dataverse.nl/api/access/datafile/46082
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4a0d83ee1a3782f528eca56303895eca
+      byte_size: 1028
+      checksum:
+        algorithm: md5
+        digest: 4a0d83ee1a3782f528eca56303895eca
+      download_url: https://dataverse.nl/api/access/datafile/46512
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 0058bec35f3a53a169011571dc4a8a01
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 0058bec35f3a53a169011571dc4a8a01
+      download_url: https://dataverse.nl/api/access/datafile/46426
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 739448e73206d3da7cd20bd564457af6
+      byte_size: 1028
+      checksum:
+        algorithm: md5
+        digest: 739448e73206d3da7cd20bd564457af6
+      download_url: https://dataverse.nl/api/access/datafile/46177
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 354671b079f219299fee7457c9d673e8
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 354671b079f219299fee7457c9d673e8
+      download_url: https://dataverse.nl/api/access/datafile/45119
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 0ffd5218f0f1686afa4dc8143dbc7a3b
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 0ffd5218f0f1686afa4dc8143dbc7a3b
+      download_url: https://dataverse.nl/api/access/datafile/45945
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 498f80810fc869ca053aa3ee4f27d538
+      byte_size: 489156
+      checksum:
+        algorithm: md5
+        digest: 498f80810fc869ca053aa3ee4f27d538
+      download_url: https://dataverse.nl/api/access/datafile/46281
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f97f4f4adcf76fb6d5d22c3ead8488a6
+      byte_size: 20736352
+      checksum:
+        algorithm: md5
+        digest: f97f4f4adcf76fb6d5d22c3ead8488a6
+      download_url: https://dataverse.nl/api/access/datafile/46216
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-002/
+      qualified_part:
+        - relation: sub-002/anat/
+          name: anat
+        - relation: sub-002/func/
+          name: func
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-002/anat/
+      qualified_part:
+        - relation: f97f4f4adcf76fb6d5d22c3ead8488a6
+          name: sub-002_T1w.nii
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: cf7d2a3f3e619ec6608d54e76f95df61
+      byte_size: 1039
+      checksum:
+        algorithm: md5
+        digest: cf7d2a3f3e619ec6608d54e76f95df61
+      download_url: https://dataverse.nl/api/access/datafile/45495
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-002/func/
+      qualified_part:
+        - relation: cf7d2a3f3e619ec6608d54e76f95df61
+          name: sub-002_task-emotionProcessing_echo-1_bold.json
+        - relation: d4242276c9dee9f7e7971bba128270ad
+          name: sub-002_task-emotionProcessing_echo-1_bold.nii
+        - relation: 9c7736a4a9e4222eec3c03a5f9aa1549
+          name: sub-002_task-emotionProcessing_echo-2_bold.json
+        - relation: 2ecebc86b99f59b0bed9377a09516955
+          name: sub-002_task-emotionProcessing_echo-2_bold.nii
+        - relation: 0a080ec8ad2f4941fd8b8104a4ea0370
+          name: sub-002_task-emotionProcessing_echo-3_bold.json
+        - relation: 647534a55fd905146ba11e854be1b527
+          name: sub-002_task-emotionProcessing_echo-3_bold.nii
+        - relation: 33e05c7294222071648be193f2c8e658
+          name: sub-002_task-emotionProcessing_events.tsv.gz
+        - relation: 35cd1eee55bbc9c48667230c83d8b415
+          name: sub-002_task-emotionProcessingImagined_echo-1_bold.json
+        - relation: 5406f3e37283de3226136a4848fb8e92
+          name: sub-002_task-emotionProcessingImagined_echo-1_bold.nii
+        - relation: e202428748d8dc5f95d1081f9a1408ab
+          name: sub-002_task-emotionProcessingImagined_echo-2_bold.json
+        - relation: 3b570804931e64328f99f1d95fec8aef
+          name: sub-002_task-emotionProcessingImagined_echo-2_bold.nii
+        - relation: 66da6541ad9ee098040d6a5cc2b8ca12
+          name: sub-002_task-emotionProcessingImagined_echo-3_bold.json
+        - relation: 3bc569cbc0a2f29c913bc9578899cc0c
+          name: sub-002_task-emotionProcessingImagined_echo-3_bold.nii
+        - relation: db82d76d3330ec3990c4af83e938d87c
+          name: sub-002_task-emotionProcessingImagined_events.tsv.gz
+        - relation: 80adcff0f946010d4b877fb4efc8caef
+          name: sub-002_task-emotionProcessingImagined_physio.json
+        - relation: e6ef5142cec6da41a411e0a89d97d824
+          name: sub-002_task-emotionProcessingImagined_physio.tsv.gz
+        - relation: d74e8747cc4889f1de5df37aab11c55f
+          name: sub-002_task-emotionProcessing_physio.json
+        - relation: 187c2fba563a2fa2b941de43f70dd61a
+          name: sub-002_task-emotionProcessing_physio.tsv.gz
+        - relation: 21709237f7b3492a22c8b7ab28f7e19b
+          name: sub-002_task-fingerTapping_echo-1_bold.json
+        - relation: fc63662a4dc71495b97f7de2dd2c8a0f
+          name: sub-002_task-fingerTapping_echo-1_bold.nii
+        - relation: 57c2423318daf74f152041ef0781b26a
+          name: sub-002_task-fingerTapping_echo-2_bold.json
+        - relation: 031af3d3b88dc94e5118bdd92363290d
+          name: sub-002_task-fingerTapping_echo-2_bold.nii
+        - relation: 83f8efcda5d35afcf51caa1bdf235f28
+          name: sub-002_task-fingerTapping_echo-3_bold.json
+        - relation: 2d1663374ca312b50e3a0c3382787c48
+          name: sub-002_task-fingerTapping_echo-3_bold.nii
+        - relation: f888ebecc08f0a7b3bfcb3fd74e59e65
+          name: sub-002_task-fingerTapping_events.tsv.gz
+        - relation: 4936ee6da36541314819583b3da319b4
+          name: sub-002_task-fingerTappingImagined_echo-1_bold.json
+        - relation: beab4fec941e693a8059141ab16ee6eb
+          name: sub-002_task-fingerTappingImagined_echo-1_bold.nii
+        - relation: 958c43a8868b916df6ad06a35d0871ef
+          name: sub-002_task-fingerTappingImagined_echo-2_bold.json
+        - relation: dcc7227a72c483e546ed72567decd240
+          name: sub-002_task-fingerTappingImagined_echo-2_bold.nii
+        - relation: ac1d6b1751abccbe064ecc2eaa72b91e
+          name: sub-002_task-fingerTappingImagined_echo-3_bold.json
+        - relation: d52160b2aca2cbd22144a3c76ab2c5a4
+          name: sub-002_task-fingerTappingImagined_echo-3_bold.nii
+        - relation: ba6099cd9c3ba2ea89c6e01e47e7a1b6
+          name: sub-002_task-fingerTappingImagined_events.tsv.gz
+        - relation: 455ab639907f79b81120e9bb5e262c51
+          name: sub-002_task-fingerTappingImagined_physio.json
+        - relation: 0e703d0254167656d9fd8319eda8631a
+          name: sub-002_task-fingerTappingImagined_physio.tsv.gz
+        - relation: 623fd32c3abaf5045866a9f257041a24
+          name: sub-002_task-fingerTapping_physio.json
+        - relation: 221ab54e3cd08b6f9036ec41b083d336
+          name: sub-002_task-fingerTapping_physio.tsv.gz
+        - relation: 3761f3d617dd7ba60e81d2601ef59947
+          name: sub-002_task-rest_run-1_echo-1_bold.json
+        - relation: ecb90665078449c064d070accf6cd7e8
+          name: sub-002_task-rest_run-1_echo-1_bold.nii
+        - relation: 3fc98b2caa94ee94cd2ad78c9aa3f78c
+          name: sub-002_task-rest_run-1_echo-2_bold.json
+        - relation: 8b8690d3f6d670bf191eadd8e01119dd
+          name: sub-002_task-rest_run-1_echo-2_bold.nii
+        - relation: 36354f68d03ea100abfa17db08d24e07
+          name: sub-002_task-rest_run-1_echo-3_bold.json
+        - relation: b690270b545ea0fdf0ff5327fa10b8b9
+          name: sub-002_task-rest_run-1_echo-3_bold.nii
+        - relation: 2cd78841361d665f5661ca7678500942
+          name: sub-002_task-rest_run-1_physio.json
+        - relation: 9ee6308ef60143c844e94849b76b811d
+          name: sub-002_task-rest_run-1_physio.tsv.gz
+        - relation: 69f53a4bedb42b1f612883b8afd7497b
+          name: sub-002_task-rest_run-2_echo-1_bold.json
+        - relation: 7138afaaa1a1d3a6d816621d832799b1
+          name: sub-002_task-rest_run-2_echo-1_bold.nii
+        - relation: 22cb9852e9c9d955d7365b1448728357
+          name: sub-002_task-rest_run-2_echo-2_bold.json
+        - relation: 79fa20148b1630ffb08992beab303b2b
+          name: sub-002_task-rest_run-2_echo-2_bold.nii
+        - relation: 27ae4e73617361c270ecc71101f3cddd
+          name: sub-002_task-rest_run-2_echo-3_bold.json
+        - relation: 005456b77cd14cd08bd60b082f35b26d
+          name: sub-002_task-rest_run-2_echo-3_bold.nii
+        - relation: 1f75cd2288e414151a8e07e2efa99a5d
+          name: sub-002_task-rest_run-2_physio.json
+        - relation: 2853087ae72d9e2dc2ac40e4c7d8231c
+          name: sub-002_task-rest_run-2_physio.tsv.gz
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d4242276c9dee9f7e7971bba128270ad
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: d4242276c9dee9f7e7971bba128270ad
+      download_url: https://dataverse.nl/api/access/datafile/45238
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 9c7736a4a9e4222eec3c03a5f9aa1549
+      byte_size: 1039
+      checksum:
+        algorithm: md5
+        digest: 9c7736a4a9e4222eec3c03a5f9aa1549
+      download_url: https://dataverse.nl/api/access/datafile/45879
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2ecebc86b99f59b0bed9377a09516955
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 2ecebc86b99f59b0bed9377a09516955
+      download_url: https://dataverse.nl/api/access/datafile/45411
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 0a080ec8ad2f4941fd8b8104a4ea0370
+      byte_size: 1039
+      checksum:
+        algorithm: md5
+        digest: 0a080ec8ad2f4941fd8b8104a4ea0370
+      download_url: https://dataverse.nl/api/access/datafile/46342
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 647534a55fd905146ba11e854be1b527
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 647534a55fd905146ba11e854be1b527
+      download_url: https://dataverse.nl/api/access/datafile/45836
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 33e05c7294222071648be193f2c8e658
+      byte_size: 1896
+      checksum:
+        algorithm: md5
+        digest: 33e05c7294222071648be193f2c8e658
+      download_url: https://dataverse.nl/api/access/datafile/46552
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 35cd1eee55bbc9c48667230c83d8b415
+      byte_size: 1048
+      checksum:
+        algorithm: md5
+        digest: 35cd1eee55bbc9c48667230c83d8b415
+      download_url: https://dataverse.nl/api/access/datafile/46021
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5406f3e37283de3226136a4848fb8e92
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 5406f3e37283de3226136a4848fb8e92
+      download_url: https://dataverse.nl/api/access/datafile/46121
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e202428748d8dc5f95d1081f9a1408ab
+      byte_size: 1048
+      checksum:
+        algorithm: md5
+        digest: e202428748d8dc5f95d1081f9a1408ab
+      download_url: https://dataverse.nl/api/access/datafile/45741
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 3b570804931e64328f99f1d95fec8aef
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 3b570804931e64328f99f1d95fec8aef
+      download_url: https://dataverse.nl/api/access/datafile/45437
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 66da6541ad9ee098040d6a5cc2b8ca12
+      byte_size: 1048
+      checksum:
+        algorithm: md5
+        digest: 66da6541ad9ee098040d6a5cc2b8ca12
+      download_url: https://dataverse.nl/api/access/datafile/46314
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 3bc569cbc0a2f29c913bc9578899cc0c
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 3bc569cbc0a2f29c913bc9578899cc0c
+      download_url: https://dataverse.nl/api/access/datafile/45094
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: db82d76d3330ec3990c4af83e938d87c
+      byte_size: 176
+      checksum:
+        algorithm: md5
+        digest: db82d76d3330ec3990c4af83e938d87c
+      download_url: https://dataverse.nl/api/access/datafile/46595
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 80adcff0f946010d4b877fb4efc8caef
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 80adcff0f946010d4b877fb4efc8caef
+      download_url: https://dataverse.nl/api/access/datafile/45889
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e6ef5142cec6da41a411e0a89d97d824
+      byte_size: 485217
+      checksum:
+        algorithm: md5
+        digest: e6ef5142cec6da41a411e0a89d97d824
+      download_url: https://dataverse.nl/api/access/datafile/45485
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d74e8747cc4889f1de5df37aab11c55f
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: d74e8747cc4889f1de5df37aab11c55f
+      download_url: https://dataverse.nl/api/access/datafile/45420
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 187c2fba563a2fa2b941de43f70dd61a
+      byte_size: 498781
+      checksum:
+        algorithm: md5
+        digest: 187c2fba563a2fa2b941de43f70dd61a
+      download_url: https://dataverse.nl/api/access/datafile/46124
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 21709237f7b3492a22c8b7ab28f7e19b
+      byte_size: 1035
+      checksum:
+        algorithm: md5
+        digest: 21709237f7b3492a22c8b7ab28f7e19b
+      download_url: https://dataverse.nl/api/access/datafile/45415
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: fc63662a4dc71495b97f7de2dd2c8a0f
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: fc63662a4dc71495b97f7de2dd2c8a0f
+      download_url: https://dataverse.nl/api/access/datafile/45660
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 57c2423318daf74f152041ef0781b26a
+      byte_size: 1035
+      checksum:
+        algorithm: md5
+        digest: 57c2423318daf74f152041ef0781b26a
+      download_url: https://dataverse.nl/api/access/datafile/45975
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 031af3d3b88dc94e5118bdd92363290d
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 031af3d3b88dc94e5118bdd92363290d
+      download_url: https://dataverse.nl/api/access/datafile/46503
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 83f8efcda5d35afcf51caa1bdf235f28
+      byte_size: 1035
+      checksum:
+        algorithm: md5
+        digest: 83f8efcda5d35afcf51caa1bdf235f28
+      download_url: https://dataverse.nl/api/access/datafile/45339
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2d1663374ca312b50e3a0c3382787c48
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 2d1663374ca312b50e3a0c3382787c48
+      download_url: https://dataverse.nl/api/access/datafile/45380
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f888ebecc08f0a7b3bfcb3fd74e59e65
+      byte_size: 165
+      checksum:
+        algorithm: md5
+        digest: f888ebecc08f0a7b3bfcb3fd74e59e65
+      download_url: https://dataverse.nl/api/access/datafile/46617
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4936ee6da36541314819583b3da319b4
+      byte_size: 1044
+      checksum:
+        algorithm: md5
+        digest: 4936ee6da36541314819583b3da319b4
+      download_url: https://dataverse.nl/api/access/datafile/45253
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: beab4fec941e693a8059141ab16ee6eb
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: beab4fec941e693a8059141ab16ee6eb
+      download_url: https://dataverse.nl/api/access/datafile/45622
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 958c43a8868b916df6ad06a35d0871ef
+      byte_size: 1044
+      checksum:
+        algorithm: md5
+        digest: 958c43a8868b916df6ad06a35d0871ef
+      download_url: https://dataverse.nl/api/access/datafile/45605
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: dcc7227a72c483e546ed72567decd240
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: dcc7227a72c483e546ed72567decd240
+      download_url: https://dataverse.nl/api/access/datafile/46293
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ac1d6b1751abccbe064ecc2eaa72b91e
+      byte_size: 1044
+      checksum:
+        algorithm: md5
+        digest: ac1d6b1751abccbe064ecc2eaa72b91e
+      download_url: https://dataverse.nl/api/access/datafile/45107
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d52160b2aca2cbd22144a3c76ab2c5a4
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: d52160b2aca2cbd22144a3c76ab2c5a4
+      download_url: https://dataverse.nl/api/access/datafile/46154
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ba6099cd9c3ba2ea89c6e01e47e7a1b6
+      byte_size: 178
+      checksum:
+        algorithm: md5
+        digest: ba6099cd9c3ba2ea89c6e01e47e7a1b6
+      download_url: https://dataverse.nl/api/access/datafile/46607
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 455ab639907f79b81120e9bb5e262c51
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 455ab639907f79b81120e9bb5e262c51
+      download_url: https://dataverse.nl/api/access/datafile/45705
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 0e703d0254167656d9fd8319eda8631a
+      byte_size: 507693
+      checksum:
+        algorithm: md5
+        digest: 0e703d0254167656d9fd8319eda8631a
+      download_url: https://dataverse.nl/api/access/datafile/45330
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 623fd32c3abaf5045866a9f257041a24
+      byte_size: 142
+      checksum:
+        algorithm: md5
+        digest: 623fd32c3abaf5045866a9f257041a24
+      download_url: https://dataverse.nl/api/access/datafile/45159
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 221ab54e3cd08b6f9036ec41b083d336
+      byte_size: 506416
+      checksum:
+        algorithm: md5
+        digest: 221ab54e3cd08b6f9036ec41b083d336
+      download_url: https://dataverse.nl/api/access/datafile/45496
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 3761f3d617dd7ba60e81d2601ef59947
+      byte_size: 1027
+      checksum:
+        algorithm: md5
+        digest: 3761f3d617dd7ba60e81d2601ef59947
+      download_url: https://dataverse.nl/api/access/datafile/46470
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ecb90665078449c064d070accf6cd7e8
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: ecb90665078449c064d070accf6cd7e8
+      download_url: https://dataverse.nl/api/access/datafile/45757
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 3fc98b2caa94ee94cd2ad78c9aa3f78c
+      byte_size: 1027
+      checksum:
+        algorithm: md5
+        digest: 3fc98b2caa94ee94cd2ad78c9aa3f78c
+      download_url: https://dataverse.nl/api/access/datafile/45327
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8b8690d3f6d670bf191eadd8e01119dd
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 8b8690d3f6d670bf191eadd8e01119dd
+      download_url: https://dataverse.nl/api/access/datafile/46288
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 36354f68d03ea100abfa17db08d24e07
+      byte_size: 1027
+      checksum:
+        algorithm: md5
+        digest: 36354f68d03ea100abfa17db08d24e07
+      download_url: https://dataverse.nl/api/access/datafile/45708
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b690270b545ea0fdf0ff5327fa10b8b9
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: b690270b545ea0fdf0ff5327fa10b8b9
+      download_url: https://dataverse.nl/api/access/datafile/46159
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2cd78841361d665f5661ca7678500942
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 2cd78841361d665f5661ca7678500942
+      download_url: https://dataverse.nl/api/access/datafile/45160
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 9ee6308ef60143c844e94849b76b811d
+      byte_size: 450745
+      checksum:
+        algorithm: md5
+        digest: 9ee6308ef60143c844e94849b76b811d
+      download_url: https://dataverse.nl/api/access/datafile/45256
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 69f53a4bedb42b1f612883b8afd7497b
+      byte_size: 1027
+      checksum:
+        algorithm: md5
+        digest: 69f53a4bedb42b1f612883b8afd7497b
+      download_url: https://dataverse.nl/api/access/datafile/45661
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 7138afaaa1a1d3a6d816621d832799b1
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 7138afaaa1a1d3a6d816621d832799b1
+      download_url: https://dataverse.nl/api/access/datafile/45110
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 22cb9852e9c9d955d7365b1448728357
+      byte_size: 1027
+      checksum:
+        algorithm: md5
+        digest: 22cb9852e9c9d955d7365b1448728357
+      download_url: https://dataverse.nl/api/access/datafile/46277
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 79fa20148b1630ffb08992beab303b2b
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 79fa20148b1630ffb08992beab303b2b
+      download_url: https://dataverse.nl/api/access/datafile/46128
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 27ae4e73617361c270ecc71101f3cddd
+      byte_size: 1027
+      checksum:
+        algorithm: md5
+        digest: 27ae4e73617361c270ecc71101f3cddd
+      download_url: https://dataverse.nl/api/access/datafile/45164
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 005456b77cd14cd08bd60b082f35b26d
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 005456b77cd14cd08bd60b082f35b26d
+      download_url: https://dataverse.nl/api/access/datafile/45981
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1f75cd2288e414151a8e07e2efa99a5d
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 1f75cd2288e414151a8e07e2efa99a5d
+      download_url: https://dataverse.nl/api/access/datafile/45553
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2853087ae72d9e2dc2ac40e4c7d8231c
+      byte_size: 467796
+      checksum:
+        algorithm: md5
+        digest: 2853087ae72d9e2dc2ac40e4c7d8231c
+      download_url: https://dataverse.nl/api/access/datafile/45992
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a525adfda11e7a413d064b83351014f7
+      byte_size: 20736352
+      checksum:
+        algorithm: md5
+        digest: a525adfda11e7a413d064b83351014f7
+      download_url: https://dataverse.nl/api/access/datafile/45171
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-003/
+      qualified_part:
+        - relation: sub-003/anat/
+          name: anat
+        - relation: sub-003/func/
+          name: func
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-003/anat/
+      qualified_part:
+        - relation: a525adfda11e7a413d064b83351014f7
+          name: sub-003_T1w.nii
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4518a04d528ff9af69b75633417073c4
+      byte_size: 1039
+      checksum:
+        algorithm: md5
+        digest: 4518a04d528ff9af69b75633417073c4
+      download_url: https://dataverse.nl/api/access/datafile/46311
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-003/func/
+      qualified_part:
+        - relation: 4518a04d528ff9af69b75633417073c4
+          name: sub-003_task-emotionProcessing_echo-1_bold.json
+        - relation: f41afd8250988c7601d688addb9b7102
+          name: sub-003_task-emotionProcessing_echo-1_bold.nii
+        - relation: 2050d7c945bee0a6caad609e7b74dac9
+          name: sub-003_task-emotionProcessing_echo-2_bold.json
+        - relation: 75efa8502c5c44e3912929c0b57565d7
+          name: sub-003_task-emotionProcessing_echo-2_bold.nii
+        - relation: 0608ebbb657942ffc976be8dbbb931fc
+          name: sub-003_task-emotionProcessing_echo-3_bold.json
+        - relation: 44c62c76a20eba67bf4787d00a4531e6
+          name: sub-003_task-emotionProcessing_echo-3_bold.nii
+        - relation: 01db1c4a5194d11f29dcf290cde45ef1
+          name: sub-003_task-emotionProcessing_events.tsv.gz
+        - relation: e4dd082be4ec8c3c60c1a0baf5b61bf7
+          name: sub-003_task-emotionProcessingImagined_echo-1_bold.json
+        - relation: 4176db44d86095450d06d787ce620b2b
+          name: sub-003_task-emotionProcessingImagined_echo-1_bold.nii
+        - relation: 198f071835eb54f9a23d4ab8019c2a37
+          name: sub-003_task-emotionProcessingImagined_echo-2_bold.json
+        - relation: 4694b2571463007ae3cc175a3cc7eb17
+          name: sub-003_task-emotionProcessingImagined_echo-2_bold.nii
+        - relation: 25f2bdb1dcf0a366013718a654a3504a
+          name: sub-003_task-emotionProcessingImagined_echo-3_bold.json
+        - relation: 4d5b995c9938fbe15bdd2c49fbff6c61
+          name: sub-003_task-emotionProcessingImagined_echo-3_bold.nii
+        - relation: 46cb2364d901e50f1364f9e96d37d972
+          name: sub-003_task-emotionProcessingImagined_events.tsv.gz
+        - relation: 9d39fcc727462332da8bf2677ac02842
+          name: sub-003_task-emotionProcessingImagined_physio.json
+        - relation: 25cfd7f2e211d2182d54007c2133058d
+          name: sub-003_task-emotionProcessingImagined_physio.tsv.gz
+        - relation: 7671d986969005f3924a49b68375ffb8
+          name: sub-003_task-emotionProcessing_physio.json
+        - relation: ecb4728f450c6dded958d78386553632
+          name: sub-003_task-emotionProcessing_physio.tsv.gz
+        - relation: da47e50192f9bc1ff023b1298ab6c4c1
+          name: sub-003_task-fingerTapping_echo-1_bold.json
+        - relation: e011d174c5ef1c6a243b69866d76acbc
+          name: sub-003_task-fingerTapping_echo-1_bold.nii
+        - relation: 2f9ee78f5ed4b03f3093558524ed7977
+          name: sub-003_task-fingerTapping_echo-2_bold.json
+        - relation: c5dc421a2ce1cdf989da7c282db5ec0c
+          name: sub-003_task-fingerTapping_echo-2_bold.nii
+        - relation: a6a3e3505d46a8cdc0760ffa179fc7e4
+          name: sub-003_task-fingerTapping_echo-3_bold.json
+        - relation: b06d2d248db37901b035e19e9a560fa9
+          name: sub-003_task-fingerTapping_echo-3_bold.nii
+        - relation: 1b2fd317345b898fa22d1ab9e44c2dad
+          name: sub-003_task-fingerTapping_events.tsv.gz
+        - relation: 6dc91b045886ce1681b5dcf11d07e0f3
+          name: sub-003_task-fingerTappingImagined_echo-1_bold.json
+        - relation: c54e7e640293282594de0d16cfe2d813
+          name: sub-003_task-fingerTappingImagined_echo-1_bold.nii
+        - relation: fa1e47cf0f9b847994d20ece5d4b8c1b
+          name: sub-003_task-fingerTappingImagined_echo-2_bold.json
+        - relation: 20f42887282f4bf87fc9d76aa1578102
+          name: sub-003_task-fingerTappingImagined_echo-2_bold.nii
+        - relation: 4eaffe9798a630e7f7b35d94adc5681e
+          name: sub-003_task-fingerTappingImagined_echo-3_bold.json
+        - relation: 7408815811cc6083fcf63a2417e1bec2
+          name: sub-003_task-fingerTappingImagined_echo-3_bold.nii
+        - relation: d5a6c6f4589c8b5db4625150aec8c27e
+          name: sub-003_task-fingerTappingImagined_events.tsv.gz
+        - relation: 0e4d96ff2b8b767e68f04bc62a704b4c
+          name: sub-003_task-fingerTappingImagined_physio.json
+        - relation: 3be50c6940c311ae26c2dc7f4c7df108
+          name: sub-003_task-fingerTappingImagined_physio.tsv.gz
+        - relation: 4f920e3548a8b17edcf2c5cd02393156
+          name: sub-003_task-fingerTapping_physio.json
+        - relation: b1c827674e51653497a3a54541e36313
+          name: sub-003_task-fingerTapping_physio.tsv.gz
+        - relation: 17ae93a36f0bc5af4b6d6e0634864632
+          name: sub-003_task-rest_run-1_echo-1_bold.json
+        - relation: db701d264ea88dffe4a47a207ab850a2
+          name: sub-003_task-rest_run-1_echo-1_bold.nii
+        - relation: 36be4c278f402df7ee8f7a3724d9e010
+          name: sub-003_task-rest_run-1_echo-2_bold.json
+        - relation: 2d4f35a104e2be5af5ce8a15519e9aac
+          name: sub-003_task-rest_run-1_echo-2_bold.nii
+        - relation: 50ad11f44d3f985bfe270667b6b093b9
+          name: sub-003_task-rest_run-1_echo-3_bold.json
+        - relation: 038053e3e4ddf25cf8576219507dfaa3
+          name: sub-003_task-rest_run-1_echo-3_bold.nii
+        - relation: 10a7e7a80ed4aab38196fad3ff89c291
+          name: sub-003_task-rest_run-1_physio.json
+        - relation: c53d254a96bd5c6f8b6229ae8e5a4417
+          name: sub-003_task-rest_run-1_physio.tsv.gz
+        - relation: 08472211cbfcf501142274f13c8eb449
+          name: sub-003_task-rest_run-2_echo-1_bold.json
+        - relation: fab75720328ab13511b6d397b211b948
+          name: sub-003_task-rest_run-2_echo-1_bold.nii
+        - relation: 5179d897d306c52b209d691c35415f5c
+          name: sub-003_task-rest_run-2_echo-2_bold.json
+        - relation: 2c6b0d65245c1f5955ce5ccb6b5ec789
+          name: sub-003_task-rest_run-2_echo-2_bold.nii
+        - relation: 2a98a2e0a158a9af593918d54340973c
+          name: sub-003_task-rest_run-2_echo-3_bold.json
+        - relation: 51a412ffa50f35b4eddc4784d392814c
+          name: sub-003_task-rest_run-2_echo-3_bold.nii
+        - relation: 6ac1a20148d2ae8984c099e033fd0c35
+          name: sub-003_task-rest_run-2_physio.json
+        - relation: 80f50906952e9c32795e83eb0cb3abaf
+          name: sub-003_task-rest_run-2_physio.tsv.gz
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f41afd8250988c7601d688addb9b7102
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: f41afd8250988c7601d688addb9b7102
+      download_url: https://dataverse.nl/api/access/datafile/46493
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2050d7c945bee0a6caad609e7b74dac9
+      byte_size: 1039
+      checksum:
+        algorithm: md5
+        digest: 2050d7c945bee0a6caad609e7b74dac9
+      download_url: https://dataverse.nl/api/access/datafile/45149
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 75efa8502c5c44e3912929c0b57565d7
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 75efa8502c5c44e3912929c0b57565d7
+      download_url: https://dataverse.nl/api/access/datafile/45435
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 0608ebbb657942ffc976be8dbbb931fc
+      byte_size: 1039
+      checksum:
+        algorithm: md5
+        digest: 0608ebbb657942ffc976be8dbbb931fc
+      download_url: https://dataverse.nl/api/access/datafile/45566
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 44c62c76a20eba67bf4787d00a4531e6
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 44c62c76a20eba67bf4787d00a4531e6
+      download_url: https://dataverse.nl/api/access/datafile/45834
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 01db1c4a5194d11f29dcf290cde45ef1
+      byte_size: 1858
+      checksum:
+        algorithm: md5
+        digest: 01db1c4a5194d11f29dcf290cde45ef1
+      download_url: https://dataverse.nl/api/access/datafile/46626
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e4dd082be4ec8c3c60c1a0baf5b61bf7
+      byte_size: 1049
+      checksum:
+        algorithm: md5
+        digest: e4dd082be4ec8c3c60c1a0baf5b61bf7
+      download_url: https://dataverse.nl/api/access/datafile/46097
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4176db44d86095450d06d787ce620b2b
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 4176db44d86095450d06d787ce620b2b
+      download_url: https://dataverse.nl/api/access/datafile/45633
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 198f071835eb54f9a23d4ab8019c2a37
+      byte_size: 1049
+      checksum:
+        algorithm: md5
+        digest: 198f071835eb54f9a23d4ab8019c2a37
+      download_url: https://dataverse.nl/api/access/datafile/45412
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4694b2571463007ae3cc175a3cc7eb17
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 4694b2571463007ae3cc175a3cc7eb17
+      download_url: https://dataverse.nl/api/access/datafile/45646
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 25f2bdb1dcf0a366013718a654a3504a
+      byte_size: 1049
+      checksum:
+        algorithm: md5
+        digest: 25f2bdb1dcf0a366013718a654a3504a
+      download_url: https://dataverse.nl/api/access/datafile/45282
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4d5b995c9938fbe15bdd2c49fbff6c61
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 4d5b995c9938fbe15bdd2c49fbff6c61
+      download_url: https://dataverse.nl/api/access/datafile/45783
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 46cb2364d901e50f1364f9e96d37d972
+      byte_size: 176
+      checksum:
+        algorithm: md5
+        digest: 46cb2364d901e50f1364f9e96d37d972
+      download_url: https://dataverse.nl/api/access/datafile/46620
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 9d39fcc727462332da8bf2677ac02842
+      byte_size: 142
+      checksum:
+        algorithm: md5
+        digest: 9d39fcc727462332da8bf2677ac02842
+      download_url: https://dataverse.nl/api/access/datafile/46060
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 25cfd7f2e211d2182d54007c2133058d
+      byte_size: 493322
+      checksum:
+        algorithm: md5
+        digest: 25cfd7f2e211d2182d54007c2133058d
+      download_url: https://dataverse.nl/api/access/datafile/45599
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 7671d986969005f3924a49b68375ffb8
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 7671d986969005f3924a49b68375ffb8
+      download_url: https://dataverse.nl/api/access/datafile/45883
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ecb4728f450c6dded958d78386553632
+      byte_size: 512614
+      checksum:
+        algorithm: md5
+        digest: ecb4728f450c6dded958d78386553632
+      download_url: https://dataverse.nl/api/access/datafile/45872
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: da47e50192f9bc1ff023b1298ab6c4c1
+      byte_size: 1037
+      checksum:
+        algorithm: md5
+        digest: da47e50192f9bc1ff023b1298ab6c4c1
+      download_url: https://dataverse.nl/api/access/datafile/45990
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e011d174c5ef1c6a243b69866d76acbc
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: e011d174c5ef1c6a243b69866d76acbc
+      download_url: https://dataverse.nl/api/access/datafile/45432
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2f9ee78f5ed4b03f3093558524ed7977
+      byte_size: 1037
+      checksum:
+        algorithm: md5
+        digest: 2f9ee78f5ed4b03f3093558524ed7977
+      download_url: https://dataverse.nl/api/access/datafile/45732
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c5dc421a2ce1cdf989da7c282db5ec0c
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: c5dc421a2ce1cdf989da7c282db5ec0c
+      download_url: https://dataverse.nl/api/access/datafile/45423
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a6a3e3505d46a8cdc0760ffa179fc7e4
+      byte_size: 1037
+      checksum:
+        algorithm: md5
+        digest: a6a3e3505d46a8cdc0760ffa179fc7e4
+      download_url: https://dataverse.nl/api/access/datafile/46075
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b06d2d248db37901b035e19e9a560fa9
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: b06d2d248db37901b035e19e9a560fa9
+      download_url: https://dataverse.nl/api/access/datafile/45245
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1b2fd317345b898fa22d1ab9e44c2dad
+      byte_size: 164
+      checksum:
+        algorithm: md5
+        digest: 1b2fd317345b898fa22d1ab9e44c2dad
+      download_url: https://dataverse.nl/api/access/datafile/46659
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6dc91b045886ce1681b5dcf11d07e0f3
+      byte_size: 1045
+      checksum:
+        algorithm: md5
+        digest: 6dc91b045886ce1681b5dcf11d07e0f3
+      download_url: https://dataverse.nl/api/access/datafile/46385
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c54e7e640293282594de0d16cfe2d813
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: c54e7e640293282594de0d16cfe2d813
+      download_url: https://dataverse.nl/api/access/datafile/45558
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: fa1e47cf0f9b847994d20ece5d4b8c1b
+      byte_size: 1045
+      checksum:
+        algorithm: md5
+        digest: fa1e47cf0f9b847994d20ece5d4b8c1b
+      download_url: https://dataverse.nl/api/access/datafile/46412
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 20f42887282f4bf87fc9d76aa1578102
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 20f42887282f4bf87fc9d76aa1578102
+      download_url: https://dataverse.nl/api/access/datafile/46028
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4eaffe9798a630e7f7b35d94adc5681e
+      byte_size: 1045
+      checksum:
+        algorithm: md5
+        digest: 4eaffe9798a630e7f7b35d94adc5681e
+      download_url: https://dataverse.nl/api/access/datafile/45095
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 7408815811cc6083fcf63a2417e1bec2
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 7408815811cc6083fcf63a2417e1bec2
+      download_url: https://dataverse.nl/api/access/datafile/45737
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d5a6c6f4589c8b5db4625150aec8c27e
+      byte_size: 179
+      checksum:
+        algorithm: md5
+        digest: d5a6c6f4589c8b5db4625150aec8c27e
+      download_url: https://dataverse.nl/api/access/datafile/46594
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 0e4d96ff2b8b767e68f04bc62a704b4c
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 0e4d96ff2b8b767e68f04bc62a704b4c
+      download_url: https://dataverse.nl/api/access/datafile/46299
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 3be50c6940c311ae26c2dc7f4c7df108
+      byte_size: 489887
+      checksum:
+        algorithm: md5
+        digest: 3be50c6940c311ae26c2dc7f4c7df108
+      download_url: https://dataverse.nl/api/access/datafile/45104
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4f920e3548a8b17edcf2c5cd02393156
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 4f920e3548a8b17edcf2c5cd02393156
+      download_url: https://dataverse.nl/api/access/datafile/45642
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b1c827674e51653497a3a54541e36313
+      byte_size: 523737
+      checksum:
+        algorithm: md5
+        digest: b1c827674e51653497a3a54541e36313
+      download_url: https://dataverse.nl/api/access/datafile/45462
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 17ae93a36f0bc5af4b6d6e0634864632
+      byte_size: 1028
+      checksum:
+        algorithm: md5
+        digest: 17ae93a36f0bc5af4b6d6e0634864632
+      download_url: https://dataverse.nl/api/access/datafile/46531
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: db701d264ea88dffe4a47a207ab850a2
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: db701d264ea88dffe4a47a207ab850a2
+      download_url: https://dataverse.nl/api/access/datafile/45893
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 36be4c278f402df7ee8f7a3724d9e010
+      byte_size: 1028
+      checksum:
+        algorithm: md5
+        digest: 36be4c278f402df7ee8f7a3724d9e010
+      download_url: https://dataverse.nl/api/access/datafile/45824
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2d4f35a104e2be5af5ce8a15519e9aac
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 2d4f35a104e2be5af5ce8a15519e9aac
+      download_url: https://dataverse.nl/api/access/datafile/45603
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 50ad11f44d3f985bfe270667b6b093b9
+      byte_size: 1028
+      checksum:
+        algorithm: md5
+        digest: 50ad11f44d3f985bfe270667b6b093b9
+      download_url: https://dataverse.nl/api/access/datafile/45711
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 038053e3e4ddf25cf8576219507dfaa3
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 038053e3e4ddf25cf8576219507dfaa3
+      download_url: https://dataverse.nl/api/access/datafile/46394
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 10a7e7a80ed4aab38196fad3ff89c291
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 10a7e7a80ed4aab38196fad3ff89c291
+      download_url: https://dataverse.nl/api/access/datafile/45398
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c53d254a96bd5c6f8b6229ae8e5a4417
+      byte_size: 444600
+      checksum:
+        algorithm: md5
+        digest: c53d254a96bd5c6f8b6229ae8e5a4417
+      download_url: https://dataverse.nl/api/access/datafile/46379
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 08472211cbfcf501142274f13c8eb449
+      byte_size: 1028
+      checksum:
+        algorithm: md5
+        digest: 08472211cbfcf501142274f13c8eb449
+      download_url: https://dataverse.nl/api/access/datafile/46199
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: fab75720328ab13511b6d397b211b948
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: fab75720328ab13511b6d397b211b948
+      download_url: https://dataverse.nl/api/access/datafile/45949
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5179d897d306c52b209d691c35415f5c
+      byte_size: 1028
+      checksum:
+        algorithm: md5
+        digest: 5179d897d306c52b209d691c35415f5c
+      download_url: https://dataverse.nl/api/access/datafile/46440
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2c6b0d65245c1f5955ce5ccb6b5ec789
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 2c6b0d65245c1f5955ce5ccb6b5ec789
+      download_url: https://dataverse.nl/api/access/datafile/45444
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2a98a2e0a158a9af593918d54340973c
+      byte_size: 1028
+      checksum:
+        algorithm: md5
+        digest: 2a98a2e0a158a9af593918d54340973c
+      download_url: https://dataverse.nl/api/access/datafile/45158
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 51a412ffa50f35b4eddc4784d392814c
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 51a412ffa50f35b4eddc4784d392814c
+      download_url: https://dataverse.nl/api/access/datafile/45653
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6ac1a20148d2ae8984c099e033fd0c35
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 6ac1a20148d2ae8984c099e033fd0c35
+      download_url: https://dataverse.nl/api/access/datafile/45601
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 80f50906952e9c32795e83eb0cb3abaf
+      byte_size: 472280
+      checksum:
+        algorithm: md5
+        digest: 80f50906952e9c32795e83eb0cb3abaf
+      download_url: https://dataverse.nl/api/access/datafile/45155
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 58d8367944bf28848557da5fa9a42cbf
+      byte_size: 20736352
+      checksum:
+        algorithm: md5
+        digest: 58d8367944bf28848557da5fa9a42cbf
+      download_url: https://dataverse.nl/api/access/datafile/45910
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-004/
+      qualified_part:
+        - relation: sub-004/anat/
+          name: anat
+        - relation: sub-004/func/
+          name: func
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-004/anat/
+      qualified_part:
+        - relation: 58d8367944bf28848557da5fa9a42cbf
+          name: sub-004_T1w.nii
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 34a35e002060107f9d015e47e337ab30
+      byte_size: 1042
+      checksum:
+        algorithm: md5
+        digest: 34a35e002060107f9d015e47e337ab30
+      download_url: https://dataverse.nl/api/access/datafile/45136
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-004/func/
+      qualified_part:
+        - relation: 34a35e002060107f9d015e47e337ab30
+          name: sub-004_task-emotionProcessing_echo-1_bold.json
+        - relation: 1966f9963c3cce7b182cd15e5fd6b247
+          name: sub-004_task-emotionProcessing_echo-1_bold.nii
+        - relation: 5a59e89c7d19e229a2813067e8e61f71
+          name: sub-004_task-emotionProcessing_echo-2_bold.json
+        - relation: 8899bd49d48c71c57e602f5048be4ac6
+          name: sub-004_task-emotionProcessing_echo-2_bold.nii
+        - relation: 4fa63ab16201e215019dda3cac213e2a
+          name: sub-004_task-emotionProcessing_echo-3_bold.json
+        - relation: 8c6d259a6aba141794311f476d629b3e
+          name: sub-004_task-emotionProcessing_echo-3_bold.nii
+        - relation: 44479a7e0853ae4448577db9d59ad4fd
+          name: sub-004_task-emotionProcessing_events.tsv.gz
+        - relation: f36ef17a4f775994cc72f6c477617d2a
+          name: sub-004_task-emotionProcessingImagined_echo-1_bold.json
+        - relation: 43cfc6023dfa200ff0e406ba59b45c34
+          name: sub-004_task-emotionProcessingImagined_echo-1_bold.nii
+        - relation: 49f053634b6e9efc7f6c75d8a27c0203
+          name: sub-004_task-emotionProcessingImagined_echo-2_bold.json
+        - relation: 74477f9caf0a44d593a03311120868de
+          name: sub-004_task-emotionProcessingImagined_echo-2_bold.nii
+        - relation: 58394a3751a16d3489d7184a3c028a48
+          name: sub-004_task-emotionProcessingImagined_echo-3_bold.json
+        - relation: 1e6626678c8869bdf81d9c086f30f2dc
+          name: sub-004_task-emotionProcessingImagined_echo-3_bold.nii
+        - relation: 07d6079dae864f78200f7952d9c4e4c6
+          name: sub-004_task-emotionProcessingImagined_events.tsv.gz
+        - relation: 8305718c9f660f7a56ff7a1d20baf70d
+          name: sub-004_task-emotionProcessingImagined_physio.json
+        - relation: c996e6b7c02de87e8aa4557c8e1f3768
+          name: sub-004_task-emotionProcessingImagined_physio.tsv.gz
+        - relation: dab7cb3e67b101ca05a9a508215f8dd0
+          name: sub-004_task-emotionProcessing_physio.json
+        - relation: ceea28302989820975135a9c614dd540
+          name: sub-004_task-emotionProcessing_physio.tsv.gz
+        - relation: 8a5131e167a16243ea24d0be2e50d088
+          name: sub-004_task-fingerTapping_echo-1_bold.json
+        - relation: 6f08635a0f32a98a2f79a0fa8d24535e
+          name: sub-004_task-fingerTapping_echo-1_bold.nii
+        - relation: e2a4369dd2f8a003a7875e5ad0575be1
+          name: sub-004_task-fingerTapping_echo-2_bold.json
+        - relation: c63ac9ab0f47be10beeecbd6994b3011
+          name: sub-004_task-fingerTapping_echo-2_bold.nii
+        - relation: e7f2903e14bdb420ecf97e9d4c390da3
+          name: sub-004_task-fingerTapping_echo-3_bold.json
+        - relation: 40c2011540513e0feaaccf63b81b690e
+          name: sub-004_task-fingerTapping_echo-3_bold.nii
+        - relation: cc4b52c7e9b24d4c5d83ea093200d98b
+          name: sub-004_task-fingerTapping_events.tsv.gz
+        - relation: a5ca44b8a3d361b1fe1b3567be9adea6
+          name: sub-004_task-fingerTappingImagined_echo-1_bold.json
+        - relation: 683f476deac7c52b45a1246b2e1ffb35
+          name: sub-004_task-fingerTappingImagined_echo-1_bold.nii
+        - relation: d0af5398225d1082e6c1af5eed463db9
+          name: sub-004_task-fingerTappingImagined_echo-2_bold.json
+        - relation: 9cc07e3893057ca6cdfd206828d16194
+          name: sub-004_task-fingerTappingImagined_echo-2_bold.nii
+        - relation: 4a18cf99e492cf5c14e7639fb31842e7
+          name: sub-004_task-fingerTappingImagined_echo-3_bold.json
+        - relation: c80b6124c2c5b4fad41bb398416d86a4
+          name: sub-004_task-fingerTappingImagined_echo-3_bold.nii
+        - relation: ba23264ce250a919463ac1c88740217e
+          name: sub-004_task-fingerTappingImagined_events.tsv.gz
+        - relation: d2c6e3310ed7ef5d21f969b30244f520
+          name: sub-004_task-fingerTappingImagined_physio.json
+        - relation: 94966adddec90ba26e94b32be4eebc61
+          name: sub-004_task-fingerTappingImagined_physio.tsv.gz
+        - relation: ee153b04600e381b86f0543a33f91a6f
+          name: sub-004_task-fingerTapping_physio.json
+        - relation: 82b693bd13603114e1366bcd7451a2ce
+          name: sub-004_task-fingerTapping_physio.tsv.gz
+        - relation: ca28f098501f7d6279f2643df7a809ed
+          name: sub-004_task-rest_run-1_echo-1_bold.json
+        - relation: b4fc16017fc34696bad6b292e90ee274
+          name: sub-004_task-rest_run-1_echo-1_bold.nii
+        - relation: 01e1290eb404eccf4520e1dab01c24bb
+          name: sub-004_task-rest_run-1_echo-2_bold.json
+        - relation: 5e911175e9c452cca2d6f25436a9bfb8
+          name: sub-004_task-rest_run-1_echo-2_bold.nii
+        - relation: 2ca75787822c8e4f03ca5b67a60531a9
+          name: sub-004_task-rest_run-1_echo-3_bold.json
+        - relation: 561457fa892cbdd65220c6e3128e1f49
+          name: sub-004_task-rest_run-1_echo-3_bold.nii
+        - relation: 285431e80fa96a66ecb6e37f4fb414cf
+          name: sub-004_task-rest_run-1_physio.json
+        - relation: 956ca5c8a5d40a90cf1504da247c6b4c
+          name: sub-004_task-rest_run-1_physio.tsv.gz
+        - relation: 5cde587fccae4ea2bbfac89fe90762e5
+          name: sub-004_task-rest_run-2_echo-1_bold.json
+        - relation: afebe2e9412da20fabb39983ad8bf4e4
+          name: sub-004_task-rest_run-2_echo-1_bold.nii
+        - relation: 22021c29436d8dd41bdcc4d623767287
+          name: sub-004_task-rest_run-2_echo-2_bold.json
+        - relation: c8470d6102b3ae3d8cbaa5cba22c0470
+          name: sub-004_task-rest_run-2_echo-2_bold.nii
+        - relation: 8e0eb4c3371a930c04845b7eb889d1a2
+          name: sub-004_task-rest_run-2_echo-3_bold.json
+        - relation: e124551b127db0efc5489510daf2f037
+          name: sub-004_task-rest_run-2_echo-3_bold.nii
+        - relation: 4f5d46a7566d1a7bbfbd5be7ad026956
+          name: sub-004_task-rest_run-2_physio.json
+        - relation: 6c03087b2beb9db957ef5988fb253057
+          name: sub-004_task-rest_run-2_physio.tsv.gz
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1966f9963c3cce7b182cd15e5fd6b247
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 1966f9963c3cce7b182cd15e5fd6b247
+      download_url: https://dataverse.nl/api/access/datafile/45861
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5a59e89c7d19e229a2813067e8e61f71
+      byte_size: 1042
+      checksum:
+        algorithm: md5
+        digest: 5a59e89c7d19e229a2813067e8e61f71
+      download_url: https://dataverse.nl/api/access/datafile/45843
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8899bd49d48c71c57e602f5048be4ac6
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 8899bd49d48c71c57e602f5048be4ac6
+      download_url: https://dataverse.nl/api/access/datafile/46511
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4fa63ab16201e215019dda3cac213e2a
+      byte_size: 1042
+      checksum:
+        algorithm: md5
+        digest: 4fa63ab16201e215019dda3cac213e2a
+      download_url: https://dataverse.nl/api/access/datafile/46148
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8c6d259a6aba141794311f476d629b3e
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 8c6d259a6aba141794311f476d629b3e
+      download_url: https://dataverse.nl/api/access/datafile/45304
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 44479a7e0853ae4448577db9d59ad4fd
+      byte_size: 1868
+      checksum:
+        algorithm: md5
+        digest: 44479a7e0853ae4448577db9d59ad4fd
+      download_url: https://dataverse.nl/api/access/datafile/46578
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f36ef17a4f775994cc72f6c477617d2a
+      byte_size: 1050
+      checksum:
+        algorithm: md5
+        digest: f36ef17a4f775994cc72f6c477617d2a
+      download_url: https://dataverse.nl/api/access/datafile/45189
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 43cfc6023dfa200ff0e406ba59b45c34
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 43cfc6023dfa200ff0e406ba59b45c34
+      download_url: https://dataverse.nl/api/access/datafile/46089
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 49f053634b6e9efc7f6c75d8a27c0203
+      byte_size: 1050
+      checksum:
+        algorithm: md5
+        digest: 49f053634b6e9efc7f6c75d8a27c0203
+      download_url: https://dataverse.nl/api/access/datafile/45971
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 74477f9caf0a44d593a03311120868de
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 74477f9caf0a44d593a03311120868de
+      download_url: https://dataverse.nl/api/access/datafile/45846
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 58394a3751a16d3489d7184a3c028a48
+      byte_size: 1050
+      checksum:
+        algorithm: md5
+        digest: 58394a3751a16d3489d7184a3c028a48
+      download_url: https://dataverse.nl/api/access/datafile/45712
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1e6626678c8869bdf81d9c086f30f2dc
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 1e6626678c8869bdf81d9c086f30f2dc
+      download_url: https://dataverse.nl/api/access/datafile/46428
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 07d6079dae864f78200f7952d9c4e4c6
+      byte_size: 175
+      checksum:
+        algorithm: md5
+        digest: 07d6079dae864f78200f7952d9c4e4c6
+      download_url: https://dataverse.nl/api/access/datafile/46652
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8305718c9f660f7a56ff7a1d20baf70d
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 8305718c9f660f7a56ff7a1d20baf70d
+      download_url: https://dataverse.nl/api/access/datafile/46063
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c996e6b7c02de87e8aa4557c8e1f3768
+      byte_size: 485821
+      checksum:
+        algorithm: md5
+        digest: c996e6b7c02de87e8aa4557c8e1f3768
+      download_url: https://dataverse.nl/api/access/datafile/46192
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: dab7cb3e67b101ca05a9a508215f8dd0
+      byte_size: 142
+      checksum:
+        algorithm: md5
+        digest: dab7cb3e67b101ca05a9a508215f8dd0
+      download_url: https://dataverse.nl/api/access/datafile/46444
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ceea28302989820975135a9c614dd540
+      byte_size: 508552
+      checksum:
+        algorithm: md5
+        digest: ceea28302989820975135a9c614dd540
+      download_url: https://dataverse.nl/api/access/datafile/46376
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8a5131e167a16243ea24d0be2e50d088
+      byte_size: 1038
+      checksum:
+        algorithm: md5
+        digest: 8a5131e167a16243ea24d0be2e50d088
+      download_url: https://dataverse.nl/api/access/datafile/46086
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6f08635a0f32a98a2f79a0fa8d24535e
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 6f08635a0f32a98a2f79a0fa8d24535e
+      download_url: https://dataverse.nl/api/access/datafile/46326
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e2a4369dd2f8a003a7875e5ad0575be1
+      byte_size: 1038
+      checksum:
+        algorithm: md5
+        digest: e2a4369dd2f8a003a7875e5ad0575be1
+      download_url: https://dataverse.nl/api/access/datafile/46419
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c63ac9ab0f47be10beeecbd6994b3011
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: c63ac9ab0f47be10beeecbd6994b3011
+      download_url: https://dataverse.nl/api/access/datafile/45294
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e7f2903e14bdb420ecf97e9d4c390da3
+      byte_size: 1038
+      checksum:
+        algorithm: md5
+        digest: e7f2903e14bdb420ecf97e9d4c390da3
+      download_url: https://dataverse.nl/api/access/datafile/45926
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 40c2011540513e0feaaccf63b81b690e
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 40c2011540513e0feaaccf63b81b690e
+      download_url: https://dataverse.nl/api/access/datafile/45710
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: cc4b52c7e9b24d4c5d83ea093200d98b
+      byte_size: 165
+      checksum:
+        algorithm: md5
+        digest: cc4b52c7e9b24d4c5d83ea093200d98b
+      download_url: https://dataverse.nl/api/access/datafile/46629
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a5ca44b8a3d361b1fe1b3567be9adea6
+      byte_size: 1046
+      checksum:
+        algorithm: md5
+        digest: a5ca44b8a3d361b1fe1b3567be9adea6
+      download_url: https://dataverse.nl/api/access/datafile/46222
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 683f476deac7c52b45a1246b2e1ffb35
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 683f476deac7c52b45a1246b2e1ffb35
+      download_url: https://dataverse.nl/api/access/datafile/45911
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d0af5398225d1082e6c1af5eed463db9
+      byte_size: 1046
+      checksum:
+        algorithm: md5
+        digest: d0af5398225d1082e6c1af5eed463db9
+      download_url: https://dataverse.nl/api/access/datafile/45226
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 9cc07e3893057ca6cdfd206828d16194
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 9cc07e3893057ca6cdfd206828d16194
+      download_url: https://dataverse.nl/api/access/datafile/45393
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4a18cf99e492cf5c14e7639fb31842e7
+      byte_size: 1046
+      checksum:
+        algorithm: md5
+        digest: 4a18cf99e492cf5c14e7639fb31842e7
+      download_url: https://dataverse.nl/api/access/datafile/46491
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c80b6124c2c5b4fad41bb398416d86a4
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: c80b6124c2c5b4fad41bb398416d86a4
+      download_url: https://dataverse.nl/api/access/datafile/45318
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ba23264ce250a919463ac1c88740217e
+      byte_size: 179
+      checksum:
+        algorithm: md5
+        digest: ba23264ce250a919463ac1c88740217e
+      download_url: https://dataverse.nl/api/access/datafile/46615
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d2c6e3310ed7ef5d21f969b30244f520
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: d2c6e3310ed7ef5d21f969b30244f520
+      download_url: https://dataverse.nl/api/access/datafile/45402
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 94966adddec90ba26e94b32be4eebc61
+      byte_size: 487009
+      checksum:
+        algorithm: md5
+        digest: 94966adddec90ba26e94b32be4eebc61
+      download_url: https://dataverse.nl/api/access/datafile/46367
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ee153b04600e381b86f0543a33f91a6f
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: ee153b04600e381b86f0543a33f91a6f
+      download_url: https://dataverse.nl/api/access/datafile/46014
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 82b693bd13603114e1366bcd7451a2ce
+      byte_size: 489124
+      checksum:
+        algorithm: md5
+        digest: 82b693bd13603114e1366bcd7451a2ce
+      download_url: https://dataverse.nl/api/access/datafile/46533
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ca28f098501f7d6279f2643df7a809ed
+      byte_size: 1029
+      checksum:
+        algorithm: md5
+        digest: ca28f098501f7d6279f2643df7a809ed
+      download_url: https://dataverse.nl/api/access/datafile/45765
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b4fc16017fc34696bad6b292e90ee274
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: b4fc16017fc34696bad6b292e90ee274
+      download_url: https://dataverse.nl/api/access/datafile/45257
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 01e1290eb404eccf4520e1dab01c24bb
+      byte_size: 1029
+      checksum:
+        algorithm: md5
+        digest: 01e1290eb404eccf4520e1dab01c24bb
+      download_url: https://dataverse.nl/api/access/datafile/46427
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5e911175e9c452cca2d6f25436a9bfb8
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 5e911175e9c452cca2d6f25436a9bfb8
+      download_url: https://dataverse.nl/api/access/datafile/45390
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2ca75787822c8e4f03ca5b67a60531a9
+      byte_size: 1029
+      checksum:
+        algorithm: md5
+        digest: 2ca75787822c8e4f03ca5b67a60531a9
+      download_url: https://dataverse.nl/api/access/datafile/46110
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 561457fa892cbdd65220c6e3128e1f49
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 561457fa892cbdd65220c6e3128e1f49
+      download_url: https://dataverse.nl/api/access/datafile/45326
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 285431e80fa96a66ecb6e37f4fb414cf
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 285431e80fa96a66ecb6e37f4fb414cf
+      download_url: https://dataverse.nl/api/access/datafile/45959
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 956ca5c8a5d40a90cf1504da247c6b4c
+      byte_size: 452268
+      checksum:
+        algorithm: md5
+        digest: 956ca5c8a5d40a90cf1504da247c6b4c
+      download_url: https://dataverse.nl/api/access/datafile/45366
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5cde587fccae4ea2bbfac89fe90762e5
+      byte_size: 1029
+      checksum:
+        algorithm: md5
+        digest: 5cde587fccae4ea2bbfac89fe90762e5
+      download_url: https://dataverse.nl/api/access/datafile/45700
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: afebe2e9412da20fabb39983ad8bf4e4
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: afebe2e9412da20fabb39983ad8bf4e4
+      download_url: https://dataverse.nl/api/access/datafile/45543
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 22021c29436d8dd41bdcc4d623767287
+      byte_size: 1029
+      checksum:
+        algorithm: md5
+        digest: 22021c29436d8dd41bdcc4d623767287
+      download_url: https://dataverse.nl/api/access/datafile/45994
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c8470d6102b3ae3d8cbaa5cba22c0470
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: c8470d6102b3ae3d8cbaa5cba22c0470
+      download_url: https://dataverse.nl/api/access/datafile/45614
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8e0eb4c3371a930c04845b7eb889d1a2
+      byte_size: 1029
+      checksum:
+        algorithm: md5
+        digest: 8e0eb4c3371a930c04845b7eb889d1a2
+      download_url: https://dataverse.nl/api/access/datafile/46519
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e124551b127db0efc5489510daf2f037
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: e124551b127db0efc5489510daf2f037
+      download_url: https://dataverse.nl/api/access/datafile/45572
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4f5d46a7566d1a7bbfbd5be7ad026956
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 4f5d46a7566d1a7bbfbd5be7ad026956
+      download_url: https://dataverse.nl/api/access/datafile/45449
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6c03087b2beb9db957ef5988fb253057
+      byte_size: 466721
+      checksum:
+        algorithm: md5
+        digest: 6c03087b2beb9db957ef5988fb253057
+      download_url: https://dataverse.nl/api/access/datafile/45537
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ba7215ae4a975c77d06363cc23455895
+      byte_size: 20736352
+      checksum:
+        algorithm: md5
+        digest: ba7215ae4a975c77d06363cc23455895
+      download_url: https://dataverse.nl/api/access/datafile/45156
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-005/
+      qualified_part:
+        - relation: sub-005/anat/
+          name: anat
+        - relation: sub-005/func/
+          name: func
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-005/anat/
+      qualified_part:
+        - relation: ba7215ae4a975c77d06363cc23455895
+          name: sub-005_T1w.nii
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5620260863482ac69a3d880b3cc5d4d5
+      byte_size: 1036
+      checksum:
+        algorithm: md5
+        digest: 5620260863482ac69a3d880b3cc5d4d5
+      download_url: https://dataverse.nl/api/access/datafile/45239
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-005/func/
+      qualified_part:
+        - relation: 5620260863482ac69a3d880b3cc5d4d5
+          name: sub-005_task-emotionProcessing_echo-1_bold.json
+        - relation: e8597ab384391f88368f92df85528228
+          name: sub-005_task-emotionProcessing_echo-1_bold.nii
+        - relation: 06a41d823bf94b4e474e61bdb7c600f7
+          name: sub-005_task-emotionProcessing_echo-2_bold.json
+        - relation: d8886eae9e8b52724ac1b3a739f845fd
+          name: sub-005_task-emotionProcessing_echo-2_bold.nii
+        - relation: 857942be9fae2be22771e0fa3e6c0596
+          name: sub-005_task-emotionProcessing_echo-3_bold.json
+        - relation: 2463012f8847a959bcc923302e446034
+          name: sub-005_task-emotionProcessing_echo-3_bold.nii
+        - relation: 8591fb9d4b80fe2e976d8556478965eb
+          name: sub-005_task-emotionProcessing_events.tsv.gz
+        - relation: cf85da54869c203e5227cd2e678827be
+          name: sub-005_task-emotionProcessingImagined_echo-1_bold.json
+        - relation: 1827f157a2ea364d9d0d4a91b8f4e9e8
+          name: sub-005_task-emotionProcessingImagined_echo-1_bold.nii
+        - relation: a26bcd77739bb9a39b6a097a50927e9e
+          name: sub-005_task-emotionProcessingImagined_echo-2_bold.json
+        - relation: 86d61fffd5f9bfe8985687ca25db1b3d
+          name: sub-005_task-emotionProcessingImagined_echo-2_bold.nii
+        - relation: 2e6bb2a54113f9b4bfa0db68bbbd9582
+          name: sub-005_task-emotionProcessingImagined_echo-3_bold.json
+        - relation: 560c581bd2dd79e4e515a5b8fc684e16
+          name: sub-005_task-emotionProcessingImagined_echo-3_bold.nii
+        - relation: 1b2cccc690fa0fb1292b34051d0fd921
+          name: sub-005_task-emotionProcessingImagined_events.tsv.gz
+        - relation: e34ca6bef05662b16f9dcbd5ecf59898
+          name: sub-005_task-emotionProcessingImagined_physio.json
+        - relation: 4ae203ccaed175f79ff01003f8a19bb7
+          name: sub-005_task-emotionProcessingImagined_physio.tsv.gz
+        - relation: 57d9656db263d6740b1b3c842db67bd8
+          name: sub-005_task-emotionProcessing_physio.json
+        - relation: 076bdc3f561911acb07eab3dd1f5df9a
+          name: sub-005_task-emotionProcessing_physio.tsv.gz
+        - relation: 1058863a0b9ac9305ca3eaa205c8e482
+          name: sub-005_task-fingerTapping_echo-1_bold.json
+        - relation: c4c158f389337815f03dd442323170cd
+          name: sub-005_task-fingerTapping_echo-1_bold.nii
+        - relation: f7b81b0343d8bcd0037c42715e479aae
+          name: sub-005_task-fingerTapping_echo-2_bold.json
+        - relation: 61d9111af78acb7fbfc9f1c953e393d1
+          name: sub-005_task-fingerTapping_echo-2_bold.nii
+        - relation: b838da26f4982a9055838095cd42edb8
+          name: sub-005_task-fingerTapping_echo-3_bold.json
+        - relation: 559c1c151f4130bc52190576ada7a1e0
+          name: sub-005_task-fingerTapping_echo-3_bold.nii
+        - relation: 2dc9bdf268f8ee5f6660b6079d347ae6
+          name: sub-005_task-fingerTapping_events.tsv.gz
+        - relation: 0ca76203dbb3231b05d4c28cacf8deb5
+          name: sub-005_task-fingerTappingImagined_echo-1_bold.json
+        - relation: 242cef3e49f0361bcf7ee7337ad42f9e
+          name: sub-005_task-fingerTappingImagined_echo-1_bold.nii
+        - relation: acb9906cfe54b0a07753784ceebe36d1
+          name: sub-005_task-fingerTappingImagined_echo-2_bold.json
+        - relation: cf58f27bec609869d3e1223ec0928040
+          name: sub-005_task-fingerTappingImagined_echo-2_bold.nii
+        - relation: 6d3d0a49ce28df559814f25c3f56249d
+          name: sub-005_task-fingerTappingImagined_echo-3_bold.json
+        - relation: fb5d2a49b1fa43561b3893c705f20a37
+          name: sub-005_task-fingerTappingImagined_echo-3_bold.nii
+        - relation: 5511a9bdf9b4bc31847a527f09b1dc0e
+          name: sub-005_task-fingerTappingImagined_events.tsv.gz
+        - relation: 534405ecb32f76a2885211190f10fb72
+          name: sub-005_task-fingerTappingImagined_physio.json
+        - relation: 4e38eaee3bca1fe437c028cddbc84a58
+          name: sub-005_task-fingerTappingImagined_physio.tsv.gz
+        - relation: 1b95897a4ff499880e19e33c1d9063e1
+          name: sub-005_task-fingerTapping_physio.json
+        - relation: cb614443d3b1a376ff71023ef5762224
+          name: sub-005_task-fingerTapping_physio.tsv.gz
+        - relation: fd7a04bc9095b203ce07810848951508
+          name: sub-005_task-rest_run-1_echo-1_bold.json
+        - relation: f27c8fa8553a3105635841347685da9e
+          name: sub-005_task-rest_run-1_echo-1_bold.nii
+        - relation: 503939b3eacaf49259ed9f0485fbb169
+          name: sub-005_task-rest_run-1_echo-2_bold.json
+        - relation: 826254d83065c0461428cf7a1c7bcbfb
+          name: sub-005_task-rest_run-1_echo-2_bold.nii
+        - relation: efb5d489c01003958d3b3f84ef85bf49
+          name: sub-005_task-rest_run-1_echo-3_bold.json
+        - relation: 4908d85ca4e3b0a0d5e354107329c93d
+          name: sub-005_task-rest_run-1_echo-3_bold.nii
+        - relation: a13d5b27089b27005943abc68e90c2d5
+          name: sub-005_task-rest_run-1_physio.json
+        - relation: 800ebe464c7dc49deb06e557e0f29ea7
+          name: sub-005_task-rest_run-1_physio.tsv.gz
+        - relation: 8b7812f78a276e261df17d3b221a066a
+          name: sub-005_task-rest_run-2_echo-1_bold.json
+        - relation: fea0858e750b27aa46e3c8a3b411f10f
+          name: sub-005_task-rest_run-2_echo-1_bold.nii
+        - relation: e011cc059bd77e9c19a5e38584eb5628
+          name: sub-005_task-rest_run-2_echo-2_bold.json
+        - relation: 35fdfa50f2d36c0ac4d329e5012369ad
+          name: sub-005_task-rest_run-2_echo-2_bold.nii
+        - relation: 6611683433437ac176de1c263a2f4ecc
+          name: sub-005_task-rest_run-2_echo-3_bold.json
+        - relation: b3c11c643a12d6acb7dd626b963ad193
+          name: sub-005_task-rest_run-2_echo-3_bold.nii
+        - relation: d66328032fd3fbc635bd564170bc8671
+          name: sub-005_task-rest_run-2_physio.json
+        - relation: b7338170f7583bc97fbc2140052f28c2
+          name: sub-005_task-rest_run-2_physio.tsv.gz
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e8597ab384391f88368f92df85528228
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: e8597ab384391f88368f92df85528228
+      download_url: https://dataverse.nl/api/access/datafile/46232
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 06a41d823bf94b4e474e61bdb7c600f7
+      byte_size: 1036
+      checksum:
+        algorithm: md5
+        digest: 06a41d823bf94b4e474e61bdb7c600f7
+      download_url: https://dataverse.nl/api/access/datafile/46042
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d8886eae9e8b52724ac1b3a739f845fd
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: d8886eae9e8b52724ac1b3a739f845fd
+      download_url: https://dataverse.nl/api/access/datafile/46361
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 857942be9fae2be22771e0fa3e6c0596
+      byte_size: 1036
+      checksum:
+        algorithm: md5
+        digest: 857942be9fae2be22771e0fa3e6c0596
+      download_url: https://dataverse.nl/api/access/datafile/45904
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2463012f8847a959bcc923302e446034
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 2463012f8847a959bcc923302e446034
+      download_url: https://dataverse.nl/api/access/datafile/45237
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8591fb9d4b80fe2e976d8556478965eb
+      byte_size: 1906
+      checksum:
+        algorithm: md5
+        digest: 8591fb9d4b80fe2e976d8556478965eb
+      download_url: https://dataverse.nl/api/access/datafile/46647
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: cf85da54869c203e5227cd2e678827be
+      byte_size: 1043
+      checksum:
+        algorithm: md5
+        digest: cf85da54869c203e5227cd2e678827be
+      download_url: https://dataverse.nl/api/access/datafile/45588
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1827f157a2ea364d9d0d4a91b8f4e9e8
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 1827f157a2ea364d9d0d4a91b8f4e9e8
+      download_url: https://dataverse.nl/api/access/datafile/45292
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a26bcd77739bb9a39b6a097a50927e9e
+      byte_size: 1043
+      checksum:
+        algorithm: md5
+        digest: a26bcd77739bb9a39b6a097a50927e9e
+      download_url: https://dataverse.nl/api/access/datafile/45629
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 86d61fffd5f9bfe8985687ca25db1b3d
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 86d61fffd5f9bfe8985687ca25db1b3d
+      download_url: https://dataverse.nl/api/access/datafile/45323
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2e6bb2a54113f9b4bfa0db68bbbd9582
+      byte_size: 1043
+      checksum:
+        algorithm: md5
+        digest: 2e6bb2a54113f9b4bfa0db68bbbd9582
+      download_url: https://dataverse.nl/api/access/datafile/45418
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 560c581bd2dd79e4e515a5b8fc684e16
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 560c581bd2dd79e4e515a5b8fc684e16
+      download_url: https://dataverse.nl/api/access/datafile/46049
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1b2cccc690fa0fb1292b34051d0fd921
+      byte_size: 174
+      checksum:
+        algorithm: md5
+        digest: 1b2cccc690fa0fb1292b34051d0fd921
+      download_url: https://dataverse.nl/api/access/datafile/46593
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e34ca6bef05662b16f9dcbd5ecf59898
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: e34ca6bef05662b16f9dcbd5ecf59898
+      download_url: https://dataverse.nl/api/access/datafile/45436
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4ae203ccaed175f79ff01003f8a19bb7
+      byte_size: 476888
+      checksum:
+        algorithm: md5
+        digest: 4ae203ccaed175f79ff01003f8a19bb7
+      download_url: https://dataverse.nl/api/access/datafile/46164
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 57d9656db263d6740b1b3c842db67bd8
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 57d9656db263d6740b1b3c842db67bd8
+      download_url: https://dataverse.nl/api/access/datafile/45484
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 076bdc3f561911acb07eab3dd1f5df9a
+      byte_size: 488391
+      checksum:
+        algorithm: md5
+        digest: 076bdc3f561911acb07eab3dd1f5df9a
+      download_url: https://dataverse.nl/api/access/datafile/46064
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1058863a0b9ac9305ca3eaa205c8e482
+      byte_size: 1031
+      checksum:
+        algorithm: md5
+        digest: 1058863a0b9ac9305ca3eaa205c8e482
+      download_url: https://dataverse.nl/api/access/datafile/45465
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c4c158f389337815f03dd442323170cd
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: c4c158f389337815f03dd442323170cd
+      download_url: https://dataverse.nl/api/access/datafile/46119
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f7b81b0343d8bcd0037c42715e479aae
+      byte_size: 1031
+      checksum:
+        algorithm: md5
+        digest: f7b81b0343d8bcd0037c42715e479aae
+      download_url: https://dataverse.nl/api/access/datafile/45664
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 61d9111af78acb7fbfc9f1c953e393d1
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 61d9111af78acb7fbfc9f1c953e393d1
+      download_url: https://dataverse.nl/api/access/datafile/45637
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b838da26f4982a9055838095cd42edb8
+      byte_size: 1031
+      checksum:
+        algorithm: md5
+        digest: b838da26f4982a9055838095cd42edb8
+      download_url: https://dataverse.nl/api/access/datafile/45590
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 559c1c151f4130bc52190576ada7a1e0
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 559c1c151f4130bc52190576ada7a1e0
+      download_url: https://dataverse.nl/api/access/datafile/46421
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2dc9bdf268f8ee5f6660b6079d347ae6
+      byte_size: 164
+      checksum:
+        algorithm: md5
+        digest: 2dc9bdf268f8ee5f6660b6079d347ae6
+      download_url: https://dataverse.nl/api/access/datafile/46624
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 0ca76203dbb3231b05d4c28cacf8deb5
+      byte_size: 1040
+      checksum:
+        algorithm: md5
+        digest: 0ca76203dbb3231b05d4c28cacf8deb5
+      download_url: https://dataverse.nl/api/access/datafile/45091
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 242cef3e49f0361bcf7ee7337ad42f9e
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 242cef3e49f0361bcf7ee7337ad42f9e
+      download_url: https://dataverse.nl/api/access/datafile/45467
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: acb9906cfe54b0a07753784ceebe36d1
+      byte_size: 1040
+      checksum:
+        algorithm: md5
+        digest: acb9906cfe54b0a07753784ceebe36d1
+      download_url: https://dataverse.nl/api/access/datafile/46534
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: cf58f27bec609869d3e1223ec0928040
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: cf58f27bec609869d3e1223ec0928040
+      download_url: https://dataverse.nl/api/access/datafile/46451
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6d3d0a49ce28df559814f25c3f56249d
+      byte_size: 1040
+      checksum:
+        algorithm: md5
+        digest: 6d3d0a49ce28df559814f25c3f56249d
+      download_url: https://dataverse.nl/api/access/datafile/45480
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: fb5d2a49b1fa43561b3893c705f20a37
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: fb5d2a49b1fa43561b3893c705f20a37
+      download_url: https://dataverse.nl/api/access/datafile/45271
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5511a9bdf9b4bc31847a527f09b1dc0e
+      byte_size: 178
+      checksum:
+        algorithm: md5
+        digest: 5511a9bdf9b4bc31847a527f09b1dc0e
+      download_url: https://dataverse.nl/api/access/datafile/46553
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 534405ecb32f76a2885211190f10fb72
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 534405ecb32f76a2885211190f10fb72
+      download_url: https://dataverse.nl/api/access/datafile/46509
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4e38eaee3bca1fe437c028cddbc84a58
+      byte_size: 477047
+      checksum:
+        algorithm: md5
+        digest: 4e38eaee3bca1fe437c028cddbc84a58
+      download_url: https://dataverse.nl/api/access/datafile/45342
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1b95897a4ff499880e19e33c1d9063e1
+      byte_size: 142
+      checksum:
+        algorithm: md5
+        digest: 1b95897a4ff499880e19e33c1d9063e1
+      download_url: https://dataverse.nl/api/access/datafile/45293
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: cb614443d3b1a376ff71023ef5762224
+      byte_size: 494630
+      checksum:
+        algorithm: md5
+        digest: cb614443d3b1a376ff71023ef5762224
+      download_url: https://dataverse.nl/api/access/datafile/45865
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: fd7a04bc9095b203ce07810848951508
+      byte_size: 1023
+      checksum:
+        algorithm: md5
+        digest: fd7a04bc9095b203ce07810848951508
+      download_url: https://dataverse.nl/api/access/datafile/45275
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f27c8fa8553a3105635841347685da9e
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: f27c8fa8553a3105635841347685da9e
+      download_url: https://dataverse.nl/api/access/datafile/45787
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 503939b3eacaf49259ed9f0485fbb169
+      byte_size: 1023
+      checksum:
+        algorithm: md5
+        digest: 503939b3eacaf49259ed9f0485fbb169
+      download_url: https://dataverse.nl/api/access/datafile/46073
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 826254d83065c0461428cf7a1c7bcbfb
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 826254d83065c0461428cf7a1c7bcbfb
+      download_url: https://dataverse.nl/api/access/datafile/45227
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: efb5d489c01003958d3b3f84ef85bf49
+      byte_size: 1023
+      checksum:
+        algorithm: md5
+        digest: efb5d489c01003958d3b3f84ef85bf49
+      download_url: https://dataverse.nl/api/access/datafile/46474
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4908d85ca4e3b0a0d5e354107329c93d
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 4908d85ca4e3b0a0d5e354107329c93d
+      download_url: https://dataverse.nl/api/access/datafile/45396
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a13d5b27089b27005943abc68e90c2d5
+      byte_size: 142
+      checksum:
+        algorithm: md5
+        digest: a13d5b27089b27005943abc68e90c2d5
+      download_url: https://dataverse.nl/api/access/datafile/46302
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 800ebe464c7dc49deb06e557e0f29ea7
+      byte_size: 451182
+      checksum:
+        algorithm: md5
+        digest: 800ebe464c7dc49deb06e557e0f29ea7
+      download_url: https://dataverse.nl/api/access/datafile/45778
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8b7812f78a276e261df17d3b221a066a
+      byte_size: 1021
+      checksum:
+        algorithm: md5
+        digest: 8b7812f78a276e261df17d3b221a066a
+      download_url: https://dataverse.nl/api/access/datafile/45490
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: fea0858e750b27aa46e3c8a3b411f10f
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: fea0858e750b27aa46e3c8a3b411f10f
+      download_url: https://dataverse.nl/api/access/datafile/46130
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e011cc059bd77e9c19a5e38584eb5628
+      byte_size: 1021
+      checksum:
+        algorithm: md5
+        digest: e011cc059bd77e9c19a5e38584eb5628
+      download_url: https://dataverse.nl/api/access/datafile/45740
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 35fdfa50f2d36c0ac4d329e5012369ad
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 35fdfa50f2d36c0ac4d329e5012369ad
+      download_url: https://dataverse.nl/api/access/datafile/45154
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6611683433437ac176de1c263a2f4ecc
+      byte_size: 1021
+      checksum:
+        algorithm: md5
+        digest: 6611683433437ac176de1c263a2f4ecc
+      download_url: https://dataverse.nl/api/access/datafile/46541
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b3c11c643a12d6acb7dd626b963ad193
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: b3c11c643a12d6acb7dd626b963ad193
+      download_url: https://dataverse.nl/api/access/datafile/45277
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d66328032fd3fbc635bd564170bc8671
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: d66328032fd3fbc635bd564170bc8671
+      download_url: https://dataverse.nl/api/access/datafile/45451
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b7338170f7583bc97fbc2140052f28c2
+      byte_size: 455634
+      checksum:
+        algorithm: md5
+        digest: b7338170f7583bc97fbc2140052f28c2
+      download_url: https://dataverse.nl/api/access/datafile/45723
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 9d3c80f922108f4f4b0a509b48f19215
+      byte_size: 20736352
+      checksum:
+        algorithm: md5
+        digest: 9d3c80f922108f4f4b0a509b48f19215
+      download_url: https://dataverse.nl/api/access/datafile/46481
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-006/
+      qualified_part:
+        - relation: sub-006/anat/
+          name: anat
+        - relation: sub-006/func/
+          name: func
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-006/anat/
+      qualified_part:
+        - relation: 9d3c80f922108f4f4b0a509b48f19215
+          name: sub-006_T1w.nii
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 19d730e7f95456220e9a207e24aeb85c
+      byte_size: 1040
+      checksum:
+        algorithm: md5
+        digest: 19d730e7f95456220e9a207e24aeb85c
+      download_url: https://dataverse.nl/api/access/datafile/46010
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-006/func/
+      qualified_part:
+        - relation: 19d730e7f95456220e9a207e24aeb85c
+          name: sub-006_task-emotionProcessing_echo-1_bold.json
+        - relation: 790c9551fe64f5bf1505f57c08a41752
+          name: sub-006_task-emotionProcessing_echo-1_bold.nii
+        - relation: 27b0d9091824e35ec179f26bae10ac3b
+          name: sub-006_task-emotionProcessing_echo-2_bold.json
+        - relation: 133c94bb368ecdaea7f44b7516487173
+          name: sub-006_task-emotionProcessing_echo-2_bold.nii
+        - relation: 753ef08256365e77b156a2253826019b
+          name: sub-006_task-emotionProcessing_echo-3_bold.json
+        - relation: 2b0c6daf7d033cbd6aa50e33643e3a55
+          name: sub-006_task-emotionProcessing_echo-3_bold.nii
+        - relation: cc467164073fc96d80c0acffd443393e
+          name: sub-006_task-emotionProcessing_events.tsv.gz
+        - relation: 7dd90f3e0b89cecf35ee80581c470b24
+          name: sub-006_task-emotionProcessingImagined_echo-1_bold.json
+        - relation: 6ffda225a2031c373c9d20043c2bc95c
+          name: sub-006_task-emotionProcessingImagined_echo-1_bold.nii
+        - relation: 8c4c9cbdf880b4835108bcb06f12fc65
+          name: sub-006_task-emotionProcessingImagined_echo-2_bold.json
+        - relation: d951cc8d496ef3ab6de4ef5aeb781a82
+          name: sub-006_task-emotionProcessingImagined_echo-2_bold.nii
+        - relation: 00fd2c769d3635aaa5316175f80c1809
+          name: sub-006_task-emotionProcessingImagined_echo-3_bold.json
+        - relation: 11b60cd08709c18a081020f900068d20
+          name: sub-006_task-emotionProcessingImagined_echo-3_bold.nii
+        - relation: 9b728f7556d453898be3d4af32fb1547
+          name: sub-006_task-emotionProcessingImagined_events.tsv.gz
+        - relation: 75bd732c9458524aace0ea22711c60c5
+          name: sub-006_task-emotionProcessingImagined_physio.json
+        - relation: 6e10a0278d083ca6429de64a22b39171
+          name: sub-006_task-emotionProcessingImagined_physio.tsv.gz
+        - relation: 475357635c0286f20fbf29453815fb81
+          name: sub-006_task-emotionProcessing_physio.json
+        - relation: ed554922d2b3f7f717bbc8284e4ea27b
+          name: sub-006_task-emotionProcessing_physio.tsv.gz
+        - relation: dad55e717902bc97813aae0d69004b7d
+          name: sub-006_task-fingerTapping_echo-1_bold.json
+        - relation: 46a2ac4ea03adc8f2aa8139f49151177
+          name: sub-006_task-fingerTapping_echo-1_bold.nii
+        - relation: bd248b0b225157cb9faa47f231b7687b
+          name: sub-006_task-fingerTapping_echo-2_bold.json
+        - relation: e6f261aced80375d6485eb6a0591c46f
+          name: sub-006_task-fingerTapping_echo-2_bold.nii
+        - relation: ffaea300a145bb2d8f41179f24f6095c
+          name: sub-006_task-fingerTapping_echo-3_bold.json
+        - relation: 1ee36d37a637953c423827d3593a68fe
+          name: sub-006_task-fingerTapping_echo-3_bold.nii
+        - relation: 97cda8e7a0ccb7735140f207f0fac941
+          name: sub-006_task-fingerTapping_events.tsv.gz
+        - relation: 838a300357bb8c8f7b7ef7b713e77505
+          name: sub-006_task-fingerTappingImagined_echo-1_bold.json
+        - relation: 25b554d3c728a1eaee9742af3ee2f04c
+          name: sub-006_task-fingerTappingImagined_echo-1_bold.nii
+        - relation: f790dcfe4fdfbbc880afb29c4ab97e2a
+          name: sub-006_task-fingerTappingImagined_echo-2_bold.json
+        - relation: 84e86baec637e4f1056ef8b4d9c43f8c
+          name: sub-006_task-fingerTappingImagined_echo-2_bold.nii
+        - relation: 874c40b78895b1a4d0ef778e2d7e2f0e
+          name: sub-006_task-fingerTappingImagined_echo-3_bold.json
+        - relation: 0d0257625e969fdf73b3435f0b62b672
+          name: sub-006_task-fingerTappingImagined_echo-3_bold.nii
+        - relation: 34513c7eb841d2d29b30d3afb9a6fb8a
+          name: sub-006_task-fingerTappingImagined_events.tsv.gz
+        - relation: a97a5b4ee2a2ceb39548b97747c5f4ef
+          name: sub-006_task-fingerTappingImagined_physio.json
+        - relation: 489ade52cee2ab077ab53960f14e8879
+          name: sub-006_task-fingerTappingImagined_physio.tsv.gz
+        - relation: 54e018529ba4432aa63cb13717f61cde
+          name: sub-006_task-fingerTapping_physio.json
+        - relation: 189a945abfc4f3585f040ace44a19f20
+          name: sub-006_task-fingerTapping_physio.tsv.gz
+        - relation: 669a562f9541700c11b9f570cf642776
+          name: sub-006_task-rest_run-1_echo-1_bold.json
+        - relation: e34bca7c50a48aeb3bc133a4a3ad9609
+          name: sub-006_task-rest_run-1_echo-1_bold.nii
+        - relation: abea61313a4f682180a67d01e9f537b2
+          name: sub-006_task-rest_run-1_echo-2_bold.json
+        - relation: abd127f75e7f44c47c560a049d9d1859
+          name: sub-006_task-rest_run-1_echo-2_bold.nii
+        - relation: bb93a09ac4d604d2c37428e24e271f97
+          name: sub-006_task-rest_run-1_echo-3_bold.json
+        - relation: 819a2c8cc4d45feed5fc8a6d9fe19f1d
+          name: sub-006_task-rest_run-1_echo-3_bold.nii
+        - relation: 8c28268a70a2208a8596249381e2d5b0
+          name: sub-006_task-rest_run-1_physio.json
+        - relation: 6ed25207a1fd7daeb1b0d92d8b1290c2
+          name: sub-006_task-rest_run-1_physio.tsv.gz
+        - relation: a32ed609bc7ae23d5b0ea2d64e101f42
+          name: sub-006_task-rest_run-2_echo-1_bold.json
+        - relation: e251adeba1d8f17ceadc117659d5f50c
+          name: sub-006_task-rest_run-2_echo-1_bold.nii
+        - relation: 32c38c5ea5a8a4944fbb7e58c389b06c
+          name: sub-006_task-rest_run-2_echo-2_bold.json
+        - relation: a49a7475acc48e3a8c541d28de3ac89d
+          name: sub-006_task-rest_run-2_echo-2_bold.nii
+        - relation: da5c5f6183f155557598ef18cafee90d
+          name: sub-006_task-rest_run-2_echo-3_bold.json
+        - relation: ec8d899551a623c7cd5234b66578c893
+          name: sub-006_task-rest_run-2_echo-3_bold.nii
+        - relation: 8aa7cae04a66c8841494937ec2ca77ef
+          name: sub-006_task-rest_run-2_physio.json
+        - relation: bef7ae13fdf5c01e6b16c281ec653db7
+          name: sub-006_task-rest_run-2_physio.tsv.gz
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 790c9551fe64f5bf1505f57c08a41752
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 790c9551fe64f5bf1505f57c08a41752
+      download_url: https://dataverse.nl/api/access/datafile/46107
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 27b0d9091824e35ec179f26bae10ac3b
+      byte_size: 1040
+      checksum:
+        algorithm: md5
+        digest: 27b0d9091824e35ec179f26bae10ac3b
+      download_url: https://dataverse.nl/api/access/datafile/45488
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 133c94bb368ecdaea7f44b7516487173
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 133c94bb368ecdaea7f44b7516487173
+      download_url: https://dataverse.nl/api/access/datafile/45208
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 753ef08256365e77b156a2253826019b
+      byte_size: 1040
+      checksum:
+        algorithm: md5
+        digest: 753ef08256365e77b156a2253826019b
+      download_url: https://dataverse.nl/api/access/datafile/45213
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2b0c6daf7d033cbd6aa50e33643e3a55
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 2b0c6daf7d033cbd6aa50e33643e3a55
+      download_url: https://dataverse.nl/api/access/datafile/45810
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: cc467164073fc96d80c0acffd443393e
+      byte_size: 1939
+      checksum:
+        algorithm: md5
+        digest: cc467164073fc96d80c0acffd443393e
+      download_url: https://dataverse.nl/api/access/datafile/46577
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 7dd90f3e0b89cecf35ee80581c470b24
+      byte_size: 1048
+      checksum:
+        algorithm: md5
+        digest: 7dd90f3e0b89cecf35ee80581c470b24
+      download_url: https://dataverse.nl/api/access/datafile/45299
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6ffda225a2031c373c9d20043c2bc95c
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 6ffda225a2031c373c9d20043c2bc95c
+      download_url: https://dataverse.nl/api/access/datafile/46377
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8c4c9cbdf880b4835108bcb06f12fc65
+      byte_size: 1048
+      checksum:
+        algorithm: md5
+        digest: 8c4c9cbdf880b4835108bcb06f12fc65
+      download_url: https://dataverse.nl/api/access/datafile/46295
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d951cc8d496ef3ab6de4ef5aeb781a82
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: d951cc8d496ef3ab6de4ef5aeb781a82
+      download_url: https://dataverse.nl/api/access/datafile/45631
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 00fd2c769d3635aaa5316175f80c1809
+      byte_size: 1048
+      checksum:
+        algorithm: md5
+        digest: 00fd2c769d3635aaa5316175f80c1809
+      download_url: https://dataverse.nl/api/access/datafile/45139
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 11b60cd08709c18a081020f900068d20
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 11b60cd08709c18a081020f900068d20
+      download_url: https://dataverse.nl/api/access/datafile/45308
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 9b728f7556d453898be3d4af32fb1547
+      byte_size: 177
+      checksum:
+        algorithm: md5
+        digest: 9b728f7556d453898be3d4af32fb1547
+      download_url: https://dataverse.nl/api/access/datafile/46587
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 75bd732c9458524aace0ea22711c60c5
+      byte_size: 142
+      checksum:
+        algorithm: md5
+        digest: 75bd732c9458524aace0ea22711c60c5
+      download_url: https://dataverse.nl/api/access/datafile/45205
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6e10a0278d083ca6429de64a22b39171
+      byte_size: 477953
+      checksum:
+        algorithm: md5
+        digest: 6e10a0278d083ca6429de64a22b39171
+      download_url: https://dataverse.nl/api/access/datafile/46356
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 475357635c0286f20fbf29453815fb81
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 475357635c0286f20fbf29453815fb81
+      download_url: https://dataverse.nl/api/access/datafile/45520
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ed554922d2b3f7f717bbc8284e4ea27b
+      byte_size: 487297
+      checksum:
+        algorithm: md5
+        digest: ed554922d2b3f7f717bbc8284e4ea27b
+      download_url: https://dataverse.nl/api/access/datafile/45538
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: dad55e717902bc97813aae0d69004b7d
+      byte_size: 1035
+      checksum:
+        algorithm: md5
+        digest: dad55e717902bc97813aae0d69004b7d
+      download_url: https://dataverse.nl/api/access/datafile/46436
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 46a2ac4ea03adc8f2aa8139f49151177
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 46a2ac4ea03adc8f2aa8139f49151177
+      download_url: https://dataverse.nl/api/access/datafile/46347
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: bd248b0b225157cb9faa47f231b7687b
+      byte_size: 1035
+      checksum:
+        algorithm: md5
+        digest: bd248b0b225157cb9faa47f231b7687b
+      download_url: https://dataverse.nl/api/access/datafile/46178
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e6f261aced80375d6485eb6a0591c46f
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: e6f261aced80375d6485eb6a0591c46f
+      download_url: https://dataverse.nl/api/access/datafile/46006
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ffaea300a145bb2d8f41179f24f6095c
+      byte_size: 1035
+      checksum:
+        algorithm: md5
+        digest: ffaea300a145bb2d8f41179f24f6095c
+      download_url: https://dataverse.nl/api/access/datafile/46417
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1ee36d37a637953c423827d3593a68fe
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 1ee36d37a637953c423827d3593a68fe
+      download_url: https://dataverse.nl/api/access/datafile/46390
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 97cda8e7a0ccb7735140f207f0fac941
+      byte_size: 164
+      checksum:
+        algorithm: md5
+        digest: 97cda8e7a0ccb7735140f207f0fac941
+      download_url: https://dataverse.nl/api/access/datafile/46580
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 838a300357bb8c8f7b7ef7b713e77505
+      byte_size: 1043
+      checksum:
+        algorithm: md5
+        digest: 838a300357bb8c8f7b7ef7b713e77505
+      download_url: https://dataverse.nl/api/access/datafile/45738
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 25b554d3c728a1eaee9742af3ee2f04c
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 25b554d3c728a1eaee9742af3ee2f04c
+      download_url: https://dataverse.nl/api/access/datafile/45666
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f790dcfe4fdfbbc880afb29c4ab97e2a
+      byte_size: 1043
+      checksum:
+        algorithm: md5
+        digest: f790dcfe4fdfbbc880afb29c4ab97e2a
+      download_url: https://dataverse.nl/api/access/datafile/46141
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 84e86baec637e4f1056ef8b4d9c43f8c
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 84e86baec637e4f1056ef8b4d9c43f8c
+      download_url: https://dataverse.nl/api/access/datafile/45841
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 874c40b78895b1a4d0ef778e2d7e2f0e
+      byte_size: 1043
+      checksum:
+        algorithm: md5
+        digest: 874c40b78895b1a4d0ef778e2d7e2f0e
+      download_url: https://dataverse.nl/api/access/datafile/46095
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 0d0257625e969fdf73b3435f0b62b672
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 0d0257625e969fdf73b3435f0b62b672
+      download_url: https://dataverse.nl/api/access/datafile/46487
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 34513c7eb841d2d29b30d3afb9a6fb8a
+      byte_size: 178
+      checksum:
+        algorithm: md5
+        digest: 34513c7eb841d2d29b30d3afb9a6fb8a
+      download_url: https://dataverse.nl/api/access/datafile/46574
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a97a5b4ee2a2ceb39548b97747c5f4ef
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: a97a5b4ee2a2ceb39548b97747c5f4ef
+      download_url: https://dataverse.nl/api/access/datafile/45852
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 489ade52cee2ab077ab53960f14e8879
+      byte_size: 495320
+      checksum:
+        algorithm: md5
+        digest: 489ade52cee2ab077ab53960f14e8879
+      download_url: https://dataverse.nl/api/access/datafile/46002
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 54e018529ba4432aa63cb13717f61cde
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 54e018529ba4432aa63cb13717f61cde
+      download_url: https://dataverse.nl/api/access/datafile/46461
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 189a945abfc4f3585f040ace44a19f20
+      byte_size: 481816
+      checksum:
+        algorithm: md5
+        digest: 189a945abfc4f3585f040ace44a19f20
+      download_url: https://dataverse.nl/api/access/datafile/45167
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 669a562f9541700c11b9f570cf642776
+      byte_size: 1027
+      checksum:
+        algorithm: md5
+        digest: 669a562f9541700c11b9f570cf642776
+      download_url: https://dataverse.nl/api/access/datafile/45354
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e34bca7c50a48aeb3bc133a4a3ad9609
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: e34bca7c50a48aeb3bc133a4a3ad9609
+      download_url: https://dataverse.nl/api/access/datafile/46453
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: abea61313a4f682180a67d01e9f537b2
+      byte_size: 1027
+      checksum:
+        algorithm: md5
+        digest: abea61313a4f682180a67d01e9f537b2
+      download_url: https://dataverse.nl/api/access/datafile/45498
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: abd127f75e7f44c47c560a049d9d1859
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: abd127f75e7f44c47c560a049d9d1859
+      download_url: https://dataverse.nl/api/access/datafile/46051
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: bb93a09ac4d604d2c37428e24e271f97
+      byte_size: 1027
+      checksum:
+        algorithm: md5
+        digest: bb93a09ac4d604d2c37428e24e271f97
+      download_url: https://dataverse.nl/api/access/datafile/45138
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 819a2c8cc4d45feed5fc8a6d9fe19f1d
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 819a2c8cc4d45feed5fc8a6d9fe19f1d
+      download_url: https://dataverse.nl/api/access/datafile/46244
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8c28268a70a2208a8596249381e2d5b0
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 8c28268a70a2208a8596249381e2d5b0
+      download_url: https://dataverse.nl/api/access/datafile/45983
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6ed25207a1fd7daeb1b0d92d8b1290c2
+      byte_size: 470282
+      checksum:
+        algorithm: md5
+        digest: 6ed25207a1fd7daeb1b0d92d8b1290c2
+      download_url: https://dataverse.nl/api/access/datafile/45594
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a32ed609bc7ae23d5b0ea2d64e101f42
+      byte_size: 1027
+      checksum:
+        algorithm: md5
+        digest: a32ed609bc7ae23d5b0ea2d64e101f42
+      download_url: https://dataverse.nl/api/access/datafile/45430
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e251adeba1d8f17ceadc117659d5f50c
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: e251adeba1d8f17ceadc117659d5f50c
+      download_url: https://dataverse.nl/api/access/datafile/45200
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 32c38c5ea5a8a4944fbb7e58c389b06c
+      byte_size: 1027
+      checksum:
+        algorithm: md5
+        digest: 32c38c5ea5a8a4944fbb7e58c389b06c
+      download_url: https://dataverse.nl/api/access/datafile/46516
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a49a7475acc48e3a8c541d28de3ac89d
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: a49a7475acc48e3a8c541d28de3ac89d
+      download_url: https://dataverse.nl/api/access/datafile/46176
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: da5c5f6183f155557598ef18cafee90d
+      byte_size: 1027
+      checksum:
+        algorithm: md5
+        digest: da5c5f6183f155557598ef18cafee90d
+      download_url: https://dataverse.nl/api/access/datafile/46515
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ec8d899551a623c7cd5234b66578c893
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: ec8d899551a623c7cd5234b66578c893
+      download_url: https://dataverse.nl/api/access/datafile/46266
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8aa7cae04a66c8841494937ec2ca77ef
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 8aa7cae04a66c8841494937ec2ca77ef
+      download_url: https://dataverse.nl/api/access/datafile/46341
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: bef7ae13fdf5c01e6b16c281ec653db7
+      byte_size: 476201
+      checksum:
+        algorithm: md5
+        digest: bef7ae13fdf5c01e6b16c281ec653db7
+      download_url: https://dataverse.nl/api/access/datafile/45286
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: fbc1e0cadc88e77c902c3957d3697ff8
+      byte_size: 20736352
+      checksum:
+        algorithm: md5
+        digest: fbc1e0cadc88e77c902c3957d3697ff8
+      download_url: https://dataverse.nl/api/access/datafile/45827
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-007/
+      qualified_part:
+        - relation: sub-007/anat/
+          name: anat
+        - relation: sub-007/func/
+          name: func
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-007/anat/
+      qualified_part:
+        - relation: fbc1e0cadc88e77c902c3957d3697ff8
+          name: sub-007_T1w.nii
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 546bfbdc9eb9e8d4fdd72f7f2a2855bc
+      byte_size: 1043
+      checksum:
+        algorithm: md5
+        digest: 546bfbdc9eb9e8d4fdd72f7f2a2855bc
+      download_url: https://dataverse.nl/api/access/datafile/45251
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-007/func/
+      qualified_part:
+        - relation: 546bfbdc9eb9e8d4fdd72f7f2a2855bc
+          name: sub-007_task-emotionProcessing_echo-1_bold.json
+        - relation: ff85dbedbb45279bb3f3fdd7c23012e7
+          name: sub-007_task-emotionProcessing_echo-1_bold.nii
+        - relation: f6745fa00ca7d991f6a1028d7dc587bf
+          name: sub-007_task-emotionProcessing_echo-2_bold.json
+        - relation: cf7167081c0ae6e886080eea50e45e5f
+          name: sub-007_task-emotionProcessing_echo-2_bold.nii
+        - relation: 01560fd90928f842b4fece30ecccef6f
+          name: sub-007_task-emotionProcessing_echo-3_bold.json
+        - relation: 8784a8244173581831f8c154b94f8077
+          name: sub-007_task-emotionProcessing_echo-3_bold.nii
+        - relation: 9f87561b465acf40c79a9c2d3a8319b6
+          name: sub-007_task-emotionProcessing_events.tsv.gz
+        - relation: 7011c67d20cfdfe41797613299b4ad0f
+          name: sub-007_task-emotionProcessingImagined_echo-1_bold.json
+        - relation: 9c1f6a85f118a8c1b511be62b57b3789
+          name: sub-007_task-emotionProcessingImagined_echo-1_bold.nii
+        - relation: 181e1d723e5107c1bf52f314403ce2f7
+          name: sub-007_task-emotionProcessingImagined_echo-2_bold.json
+        - relation: 1d7028d89cdde68515286a63ebc47ae7
+          name: sub-007_task-emotionProcessingImagined_echo-2_bold.nii
+        - relation: f94a966d01fbb37b3804b43233b09228
+          name: sub-007_task-emotionProcessingImagined_echo-3_bold.json
+        - relation: c9af8f55d26f56477b0b42d647c75538
+          name: sub-007_task-emotionProcessingImagined_echo-3_bold.nii
+        - relation: a14595a04fa570203ff5a200bf6b4f42
+          name: sub-007_task-emotionProcessingImagined_events.tsv.gz
+        - relation: 2bd463332c59abb455e544e5b926b075
+          name: sub-007_task-emotionProcessingImagined_physio.json
+        - relation: 8d61be093569285fe4d0ccba7b8d4066
+          name: sub-007_task-emotionProcessingImagined_physio.tsv.gz
+        - relation: ebd4c5024fc2c63829cd66705135c047
+          name: sub-007_task-emotionProcessing_physio.json
+        - relation: b4e5d718da2c84444e15c191d680f756
+          name: sub-007_task-emotionProcessing_physio.tsv.gz
+        - relation: b8aa0235d1518b988e3a07f658738226
+          name: sub-007_task-fingerTapping_echo-1_bold.json
+        - relation: 19292eaa783f4d0598a87cd1ca7b0563
+          name: sub-007_task-fingerTapping_echo-1_bold.nii
+        - relation: 361961f4bc30ec4eaa1bfe9a36e270dc
+          name: sub-007_task-fingerTapping_echo-2_bold.json
+        - relation: 472188cbd9b951f8ccca6f236151395b
+          name: sub-007_task-fingerTapping_echo-2_bold.nii
+        - relation: 33a478f431f41fd183c58c138c6b57a9
+          name: sub-007_task-fingerTapping_echo-3_bold.json
+        - relation: 522e173aa201ab2270c7adb597c97105
+          name: sub-007_task-fingerTapping_echo-3_bold.nii
+        - relation: 80f803f4d5795a7ac16a0fece568730d
+          name: sub-007_task-fingerTapping_events.tsv.gz
+        - relation: 1da6abda2407618e0df5c408f656f030
+          name: sub-007_task-fingerTappingImagined_echo-1_bold.json
+        - relation: 6782618324fef13f1889ab44b53774ec
+          name: sub-007_task-fingerTappingImagined_echo-1_bold.nii
+        - relation: bef00992f80fbca5c89dec95e7e29962
+          name: sub-007_task-fingerTappingImagined_echo-2_bold.json
+        - relation: d16a3909c93e1b5fabe5fcb0d94a124b
+          name: sub-007_task-fingerTappingImagined_echo-2_bold.nii
+        - relation: 8469140ce87ef9f4060a88bbed4439be
+          name: sub-007_task-fingerTappingImagined_echo-3_bold.json
+        - relation: b08e9141daca5df31278b472b2080608
+          name: sub-007_task-fingerTappingImagined_echo-3_bold.nii
+        - relation: 9046a531aa50523795d30ead98aa3efa
+          name: sub-007_task-fingerTappingImagined_events.tsv.gz
+        - relation: f90f2c7f8d0d8658759199e1bce75aa5
+          name: sub-007_task-fingerTappingImagined_physio.json
+        - relation: df7af70a068b02d5093813ef3e034ef9
+          name: sub-007_task-fingerTappingImagined_physio.tsv.gz
+        - relation: 20a6d9fec97d01da69ff7b1063e151d8
+          name: sub-007_task-fingerTapping_physio.json
+        - relation: d74a7e3e51b82463356492dded1fd888
+          name: sub-007_task-fingerTapping_physio.tsv.gz
+        - relation: 4959a08e00f5f4648e2d61f408cc0b38
+          name: sub-007_task-rest_run-1_echo-1_bold.json
+        - relation: 7e6e883dcd5dcb54cbbc00404009989a
+          name: sub-007_task-rest_run-1_echo-1_bold.nii
+        - relation: 034b7fa7cf9975f5bf5acab99af751c5
+          name: sub-007_task-rest_run-1_echo-2_bold.json
+        - relation: 1109e59c036b13ed6f9d40aa275e650f
+          name: sub-007_task-rest_run-1_echo-2_bold.nii
+        - relation: 901312b94dcad0754bfa7c01b96ace98
+          name: sub-007_task-rest_run-1_echo-3_bold.json
+        - relation: b75defef6758d046883ac46f7fe718f6
+          name: sub-007_task-rest_run-1_echo-3_bold.nii
+        - relation: 2c05d7ffba904b20acf7f8d798e56f1a
+          name: sub-007_task-rest_run-1_physio.json
+        - relation: 26bdaee0f8531fba3f072d0de0dafdff
+          name: sub-007_task-rest_run-1_physio.tsv.gz
+        - relation: f870b8885b5f5777c880004242ada96c
+          name: sub-007_task-rest_run-2_echo-1_bold.json
+        - relation: 135abe8207577cc86e46e70c541a095e
+          name: sub-007_task-rest_run-2_echo-1_bold.nii
+        - relation: 0cea8aabf50a08cf40064469989c7a24
+          name: sub-007_task-rest_run-2_echo-2_bold.json
+        - relation: 62b37f39c8e730772e07d76cd7f883ff
+          name: sub-007_task-rest_run-2_echo-2_bold.nii
+        - relation: 2528930ba2cb1ee93762bbf4d2b6cf88
+          name: sub-007_task-rest_run-2_echo-3_bold.json
+        - relation: 92cbee685bec54eea7b58fab9cfa87be
+          name: sub-007_task-rest_run-2_echo-3_bold.nii
+        - relation: e2b861e80af7998037002ea748928567
+          name: sub-007_task-rest_run-2_physio.json
+        - relation: 55a951fd7252a67fad44cf4a2d4d2c36
+          name: sub-007_task-rest_run-2_physio.tsv.gz
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ff85dbedbb45279bb3f3fdd7c23012e7
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: ff85dbedbb45279bb3f3fdd7c23012e7
+      download_url: https://dataverse.nl/api/access/datafile/46209
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f6745fa00ca7d991f6a1028d7dc587bf
+      byte_size: 1043
+      checksum:
+        algorithm: md5
+        digest: f6745fa00ca7d991f6a1028d7dc587bf
+      download_url: https://dataverse.nl/api/access/datafile/45212
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: cf7167081c0ae6e886080eea50e45e5f
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: cf7167081c0ae6e886080eea50e45e5f
+      download_url: https://dataverse.nl/api/access/datafile/45779
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 01560fd90928f842b4fece30ecccef6f
+      byte_size: 1043
+      checksum:
+        algorithm: md5
+        digest: 01560fd90928f842b4fece30ecccef6f
+      download_url: https://dataverse.nl/api/access/datafile/45881
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8784a8244173581831f8c154b94f8077
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 8784a8244173581831f8c154b94f8077
+      download_url: https://dataverse.nl/api/access/datafile/45562
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 9f87561b465acf40c79a9c2d3a8319b6
+      byte_size: 1901
+      checksum:
+        algorithm: md5
+        digest: 9f87561b465acf40c79a9c2d3a8319b6
+      download_url: https://dataverse.nl/api/access/datafile/46554
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 7011c67d20cfdfe41797613299b4ad0f
+      byte_size: 1051
+      checksum:
+        algorithm: md5
+        digest: 7011c67d20cfdfe41797613299b4ad0f
+      download_url: https://dataverse.nl/api/access/datafile/46454
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 9c1f6a85f118a8c1b511be62b57b3789
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 9c1f6a85f118a8c1b511be62b57b3789
+      download_url: https://dataverse.nl/api/access/datafile/45274
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 181e1d723e5107c1bf52f314403ce2f7
+      byte_size: 1051
+      checksum:
+        algorithm: md5
+        digest: 181e1d723e5107c1bf52f314403ce2f7
+      download_url: https://dataverse.nl/api/access/datafile/45283
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1d7028d89cdde68515286a63ebc47ae7
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 1d7028d89cdde68515286a63ebc47ae7
+      download_url: https://dataverse.nl/api/access/datafile/45331
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f94a966d01fbb37b3804b43233b09228
+      byte_size: 1051
+      checksum:
+        algorithm: md5
+        digest: f94a966d01fbb37b3804b43233b09228
+      download_url: https://dataverse.nl/api/access/datafile/45146
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c9af8f55d26f56477b0b42d647c75538
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: c9af8f55d26f56477b0b42d647c75538
+      download_url: https://dataverse.nl/api/access/datafile/46044
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a14595a04fa570203ff5a200bf6b4f42
+      byte_size: 173
+      checksum:
+        algorithm: md5
+        digest: a14595a04fa570203ff5a200bf6b4f42
+      download_url: https://dataverse.nl/api/access/datafile/46645
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2bd463332c59abb455e544e5b926b075
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 2bd463332c59abb455e544e5b926b075
+      download_url: https://dataverse.nl/api/access/datafile/45873
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8d61be093569285fe4d0ccba7b8d4066
+      byte_size: 505783
+      checksum:
+        algorithm: md5
+        digest: 8d61be093569285fe4d0ccba7b8d4066
+      download_url: https://dataverse.nl/api/access/datafile/45284
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ebd4c5024fc2c63829cd66705135c047
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: ebd4c5024fc2c63829cd66705135c047
+      download_url: https://dataverse.nl/api/access/datafile/46005
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b4e5d718da2c84444e15c191d680f756
+      byte_size: 465952
+      checksum:
+        algorithm: md5
+        digest: b4e5d718da2c84444e15c191d680f756
+      download_url: https://dataverse.nl/api/access/datafile/46050
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b8aa0235d1518b988e3a07f658738226
+      byte_size: 1039
+      checksum:
+        algorithm: md5
+        digest: b8aa0235d1518b988e3a07f658738226
+      download_url: https://dataverse.nl/api/access/datafile/46245
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 19292eaa783f4d0598a87cd1ca7b0563
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 19292eaa783f4d0598a87cd1ca7b0563
+      download_url: https://dataverse.nl/api/access/datafile/46007
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 361961f4bc30ec4eaa1bfe9a36e270dc
+      byte_size: 1039
+      checksum:
+        algorithm: md5
+        digest: 361961f4bc30ec4eaa1bfe9a36e270dc
+      download_url: https://dataverse.nl/api/access/datafile/45116
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 472188cbd9b951f8ccca6f236151395b
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 472188cbd9b951f8ccca6f236151395b
+      download_url: https://dataverse.nl/api/access/datafile/45232
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 33a478f431f41fd183c58c138c6b57a9
+      byte_size: 1039
+      checksum:
+        algorithm: md5
+        digest: 33a478f431f41fd183c58c138c6b57a9
+      download_url: https://dataverse.nl/api/access/datafile/45585
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 522e173aa201ab2270c7adb597c97105
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 522e173aa201ab2270c7adb597c97105
+      download_url: https://dataverse.nl/api/access/datafile/45476
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 80f803f4d5795a7ac16a0fece568730d
+      byte_size: 162
+      checksum:
+        algorithm: md5
+        digest: 80f803f4d5795a7ac16a0fece568730d
+      download_url: https://dataverse.nl/api/access/datafile/46582
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1da6abda2407618e0df5c408f656f030
+      byte_size: 1047
+      checksum:
+        algorithm: md5
+        digest: 1da6abda2407618e0df5c408f656f030
+      download_url: https://dataverse.nl/api/access/datafile/45524
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6782618324fef13f1889ab44b53774ec
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 6782618324fef13f1889ab44b53774ec
+      download_url: https://dataverse.nl/api/access/datafile/46297
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: bef00992f80fbca5c89dec95e7e29962
+      byte_size: 1047
+      checksum:
+        algorithm: md5
+        digest: bef00992f80fbca5c89dec95e7e29962
+      download_url: https://dataverse.nl/api/access/datafile/45570
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d16a3909c93e1b5fabe5fcb0d94a124b
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: d16a3909c93e1b5fabe5fcb0d94a124b
+      download_url: https://dataverse.nl/api/access/datafile/45867
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8469140ce87ef9f4060a88bbed4439be
+      byte_size: 1047
+      checksum:
+        algorithm: md5
+        digest: 8469140ce87ef9f4060a88bbed4439be
+      download_url: https://dataverse.nl/api/access/datafile/45878
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b08e9141daca5df31278b472b2080608
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: b08e9141daca5df31278b472b2080608
+      download_url: https://dataverse.nl/api/access/datafile/46304
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 9046a531aa50523795d30ead98aa3efa
+      byte_size: 175
+      checksum:
+        algorithm: md5
+        digest: 9046a531aa50523795d30ead98aa3efa
+      download_url: https://dataverse.nl/api/access/datafile/46589
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f90f2c7f8d0d8658759199e1bce75aa5
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: f90f2c7f8d0d8658759199e1bce75aa5
+      download_url: https://dataverse.nl/api/access/datafile/46396
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: df7af70a068b02d5093813ef3e034ef9
+      byte_size: 460170
+      checksum:
+        algorithm: md5
+        digest: df7af70a068b02d5093813ef3e034ef9
+      download_url: https://dataverse.nl/api/access/datafile/45539
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 20a6d9fec97d01da69ff7b1063e151d8
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 20a6d9fec97d01da69ff7b1063e151d8
+      download_url: https://dataverse.nl/api/access/datafile/45627
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d74a7e3e51b82463356492dded1fd888
+      byte_size: 479042
+      checksum:
+        algorithm: md5
+        digest: d74a7e3e51b82463356492dded1fd888
+      download_url: https://dataverse.nl/api/access/datafile/45438
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4959a08e00f5f4648e2d61f408cc0b38
+      byte_size: 1030
+      checksum:
+        algorithm: md5
+        digest: 4959a08e00f5f4648e2d61f408cc0b38
+      download_url: https://dataverse.nl/api/access/datafile/45887
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 7e6e883dcd5dcb54cbbc00404009989a
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 7e6e883dcd5dcb54cbbc00404009989a
+      download_url: https://dataverse.nl/api/access/datafile/46413
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 034b7fa7cf9975f5bf5acab99af751c5
+      byte_size: 1030
+      checksum:
+        algorithm: md5
+        digest: 034b7fa7cf9975f5bf5acab99af751c5
+      download_url: https://dataverse.nl/api/access/datafile/45389
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1109e59c036b13ed6f9d40aa275e650f
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 1109e59c036b13ed6f9d40aa275e650f
+      download_url: https://dataverse.nl/api/access/datafile/45942
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 901312b94dcad0754bfa7c01b96ace98
+      byte_size: 1030
+      checksum:
+        algorithm: md5
+        digest: 901312b94dcad0754bfa7c01b96ace98
+      download_url: https://dataverse.nl/api/access/datafile/45800
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b75defef6758d046883ac46f7fe718f6
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: b75defef6758d046883ac46f7fe718f6
+      download_url: https://dataverse.nl/api/access/datafile/46497
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2c05d7ffba904b20acf7f8d798e56f1a
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 2c05d7ffba904b20acf7f8d798e56f1a
+      download_url: https://dataverse.nl/api/access/datafile/46142
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 26bdaee0f8531fba3f072d0de0dafdff
+      byte_size: 453559
+      checksum:
+        algorithm: md5
+        digest: 26bdaee0f8531fba3f072d0de0dafdff
+      download_url: https://dataverse.nl/api/access/datafile/46008
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f870b8885b5f5777c880004242ada96c
+      byte_size: 1030
+      checksum:
+        algorithm: md5
+        digest: f870b8885b5f5777c880004242ada96c
+      download_url: https://dataverse.nl/api/access/datafile/45163
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 135abe8207577cc86e46e70c541a095e
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 135abe8207577cc86e46e70c541a095e
+      download_url: https://dataverse.nl/api/access/datafile/45674
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 0cea8aabf50a08cf40064469989c7a24
+      byte_size: 1030
+      checksum:
+        algorithm: md5
+        digest: 0cea8aabf50a08cf40064469989c7a24
+      download_url: https://dataverse.nl/api/access/datafile/45832
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 62b37f39c8e730772e07d76cd7f883ff
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 62b37f39c8e730772e07d76cd7f883ff
+      download_url: https://dataverse.nl/api/access/datafile/46317
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2528930ba2cb1ee93762bbf4d2b6cf88
+      byte_size: 1030
+      checksum:
+        algorithm: md5
+        digest: 2528930ba2cb1ee93762bbf4d2b6cf88
+      download_url: https://dataverse.nl/api/access/datafile/46537
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 92cbee685bec54eea7b58fab9cfa87be
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 92cbee685bec54eea7b58fab9cfa87be
+      download_url: https://dataverse.nl/api/access/datafile/45668
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e2b861e80af7998037002ea748928567
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: e2b861e80af7998037002ea748928567
+      download_url: https://dataverse.nl/api/access/datafile/46230
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 55a951fd7252a67fad44cf4a2d4d2c36
+      byte_size: 444758
+      checksum:
+        algorithm: md5
+        digest: 55a951fd7252a67fad44cf4a2d4d2c36
+      download_url: https://dataverse.nl/api/access/datafile/46184
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b3077aed8b42c7b913990adb014c3048
+      byte_size: 20736352
+      checksum:
+        algorithm: md5
+        digest: b3077aed8b42c7b913990adb014c3048
+      download_url: https://dataverse.nl/api/access/datafile/46471
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-010/
+      qualified_part:
+        - relation: sub-010/anat/
+          name: anat
+        - relation: sub-010/func/
+          name: func
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-010/anat/
+      qualified_part:
+        - relation: b3077aed8b42c7b913990adb014c3048
+          name: sub-010_T1w.nii
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d7902ae5755e22be8fa2d6b8d0884caa
+      byte_size: 1042
+      checksum:
+        algorithm: md5
+        digest: d7902ae5755e22be8fa2d6b8d0884caa
+      download_url: https://dataverse.nl/api/access/datafile/45248
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-010/func/
+      qualified_part:
+        - relation: d7902ae5755e22be8fa2d6b8d0884caa
+          name: sub-010_task-emotionProcessing_echo-1_bold.json
+        - relation: 3d565ac576fdae0bccaf91a945b4e6e0
+          name: sub-010_task-emotionProcessing_echo-1_bold.nii
+        - relation: 2737d5e2127911240a0668c1ee439f71
+          name: sub-010_task-emotionProcessing_echo-2_bold.json
+        - relation: 35c37986da86c0212ff6293e50bba0dc
+          name: sub-010_task-emotionProcessing_echo-2_bold.nii
+        - relation: 32066bc8ff38a2d996177efeeacece1a
+          name: sub-010_task-emotionProcessing_echo-3_bold.json
+        - relation: 304fc0316cd8bdc94d86c0cdf0fffc6d
+          name: sub-010_task-emotionProcessing_echo-3_bold.nii
+        - relation: b9b914b29a4a98a38f3687d506ff1382
+          name: sub-010_task-emotionProcessing_events.tsv.gz
+        - relation: 7e2ebc1a862896ec2c579d602c90ecf4
+          name: sub-010_task-emotionProcessingImagined_echo-1_bold.json
+        - relation: 92fc1ca8f032ad7ad4cf6a38d5bd83b6
+          name: sub-010_task-emotionProcessingImagined_echo-1_bold.nii
+        - relation: ed835fe6ac5c46db6a78becb00b9a6b3
+          name: sub-010_task-emotionProcessingImagined_echo-2_bold.json
+        - relation: 6a1cb1c4be9e0bc6372c50abf0e475ff
+          name: sub-010_task-emotionProcessingImagined_echo-2_bold.nii
+        - relation: f25f858d4fb92f3782ed330a8246988a
+          name: sub-010_task-emotionProcessingImagined_echo-3_bold.json
+        - relation: 834e21e666bf2b6fd0a9d91da6496033
+          name: sub-010_task-emotionProcessingImagined_echo-3_bold.nii
+        - relation: 90fe04ee120c67a7736e7d57e494b3a7
+          name: sub-010_task-emotionProcessingImagined_events.tsv.gz
+        - relation: 4c0258f56ab2d5b9c849a907fbe99370
+          name: sub-010_task-emotionProcessingImagined_physio.json
+        - relation: d8a6822cee54e4f25fa51962ac919f16
+          name: sub-010_task-emotionProcessingImagined_physio.tsv.gz
+        - relation: 1b303daf14c578e9af688ffe870d007e
+          name: sub-010_task-emotionProcessing_physio.json
+        - relation: 719ea8f9d5b8da93a26e672b28903983
+          name: sub-010_task-emotionProcessing_physio.tsv.gz
+        - relation: 41f79f2307ebac763f7a4130024a1ad5
+          name: sub-010_task-fingerTapping_echo-1_bold.json
+        - relation: 85bfb3b996a3e363341e71a3cd9fae42
+          name: sub-010_task-fingerTapping_echo-1_bold.nii
+        - relation: 3b54a011c9dc6999fa71ed00da1c7b02
+          name: sub-010_task-fingerTapping_echo-2_bold.json
+        - relation: b48377a889536602e998ee678696daec
+          name: sub-010_task-fingerTapping_echo-2_bold.nii
+        - relation: 925a84e91f2ba11ea6d7e1bfa6ea32aa
+          name: sub-010_task-fingerTapping_echo-3_bold.json
+        - relation: 7b6a9bbaf03466614419c88ead447c63
+          name: sub-010_task-fingerTapping_echo-3_bold.nii
+        - relation: 13eecaf8e5d96e416ecc8d9f9d741dbb
+          name: sub-010_task-fingerTapping_events.tsv.gz
+        - relation: 0c664901323404e22f267dcb240647d8
+          name: sub-010_task-fingerTappingImagined_echo-1_bold.json
+        - relation: ce3af5c2a3f18df9ee255e0752dee7d0
+          name: sub-010_task-fingerTappingImagined_echo-1_bold.nii
+        - relation: 74af5cbb23fe19b5e0b77b6c1cf400b8
+          name: sub-010_task-fingerTappingImagined_echo-2_bold.json
+        - relation: 3c40888bc656e6497dcb1bcdd0576f44
+          name: sub-010_task-fingerTappingImagined_echo-2_bold.nii
+        - relation: dc2b090512113f82d5606d3adc06f616
+          name: sub-010_task-fingerTappingImagined_echo-3_bold.json
+        - relation: af351919e3f9eb6b8ae1b6648f4ed9c4
+          name: sub-010_task-fingerTappingImagined_echo-3_bold.nii
+        - relation: d32cce9233e1ec88d65e121fe1d46bf5
+          name: sub-010_task-fingerTappingImagined_events.tsv.gz
+        - relation: 40496512d9d271d8d4777a5ba8a45020
+          name: sub-010_task-fingerTappingImagined_physio.json
+        - relation: b7ddc4eab27aea3d811b52302b447c3d
+          name: sub-010_task-fingerTappingImagined_physio.tsv.gz
+        - relation: 01f363feb27b24b1d987ceebff33c223
+          name: sub-010_task-fingerTapping_physio.json
+        - relation: d93c77119a2e47f583488fe26339e20a
+          name: sub-010_task-fingerTapping_physio.tsv.gz
+        - relation: 8b40a3a3357d881c508208473509c5f3
+          name: sub-010_task-rest_run-1_echo-1_bold.json
+        - relation: 782e1f1a21fa2241d559e7c3283ffa39
+          name: sub-010_task-rest_run-1_echo-1_bold.nii
+        - relation: 10fa6a7d96f3792f52e375350918ee86
+          name: sub-010_task-rest_run-1_echo-2_bold.json
+        - relation: fa62a534801a97ae30eb84c3394e7dcd
+          name: sub-010_task-rest_run-1_echo-2_bold.nii
+        - relation: 763295aba2ac0ba5bf10fea22c41f404
+          name: sub-010_task-rest_run-1_echo-3_bold.json
+        - relation: 663fb57530eef754952991dec16af2b3
+          name: sub-010_task-rest_run-1_echo-3_bold.nii
+        - relation: b3c24aa9b3f9b5e8addebc27680ca61c
+          name: sub-010_task-rest_run-1_physio.json
+        - relation: 517b4d76691685dd772eeaf35023c8a5
+          name: sub-010_task-rest_run-1_physio.tsv.gz
+        - relation: 849ddca842961f33bd2a508b4b66243e
+          name: sub-010_task-rest_run-2_echo-1_bold.json
+        - relation: b772fa7627a2c78cbf6bbc7aa8e15fc5
+          name: sub-010_task-rest_run-2_echo-1_bold.nii
+        - relation: e181c7d8e19289a06d9d934cbec46373
+          name: sub-010_task-rest_run-2_echo-2_bold.json
+        - relation: 061f466079bc706ddb09c4dc7f1f7ec8
+          name: sub-010_task-rest_run-2_echo-2_bold.nii
+        - relation: da466649c5100e5c28b525ef4bbed378
+          name: sub-010_task-rest_run-2_echo-3_bold.json
+        - relation: 2ad6ec828be8d507d6a9f96050cb024d
+          name: sub-010_task-rest_run-2_echo-3_bold.nii
+        - relation: cd63bc3de6119017f97434fcefd06cd6
+          name: sub-010_task-rest_run-2_physio.json
+        - relation: 1763774e3b11a68c20653f60dbbfc9ea
+          name: sub-010_task-rest_run-2_physio.tsv.gz
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 3d565ac576fdae0bccaf91a945b4e6e0
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 3d565ac576fdae0bccaf91a945b4e6e0
+      download_url: https://dataverse.nl/api/access/datafile/46438
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2737d5e2127911240a0668c1ee439f71
+      byte_size: 1042
+      checksum:
+        algorithm: md5
+        digest: 2737d5e2127911240a0668c1ee439f71
+      download_url: https://dataverse.nl/api/access/datafile/45984
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 35c37986da86c0212ff6293e50bba0dc
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 35c37986da86c0212ff6293e50bba0dc
+      download_url: https://dataverse.nl/api/access/datafile/46338
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 32066bc8ff38a2d996177efeeacece1a
+      byte_size: 1042
+      checksum:
+        algorithm: md5
+        digest: 32066bc8ff38a2d996177efeeacece1a
+      download_url: https://dataverse.nl/api/access/datafile/46136
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 304fc0316cd8bdc94d86c0cdf0fffc6d
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 304fc0316cd8bdc94d86c0cdf0fffc6d
+      download_url: https://dataverse.nl/api/access/datafile/45448
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b9b914b29a4a98a38f3687d506ff1382
+      byte_size: 1918
+      checksum:
+        algorithm: md5
+        digest: b9b914b29a4a98a38f3687d506ff1382
+      download_url: https://dataverse.nl/api/access/datafile/46656
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 7e2ebc1a862896ec2c579d602c90ecf4
+      byte_size: 1050
+      checksum:
+        algorithm: md5
+        digest: 7e2ebc1a862896ec2c579d602c90ecf4
+      download_url: https://dataverse.nl/api/access/datafile/46539
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 92fc1ca8f032ad7ad4cf6a38d5bd83b6
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 92fc1ca8f032ad7ad4cf6a38d5bd83b6
+      download_url: https://dataverse.nl/api/access/datafile/45431
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ed835fe6ac5c46db6a78becb00b9a6b3
+      byte_size: 1050
+      checksum:
+        algorithm: md5
+        digest: ed835fe6ac5c46db6a78becb00b9a6b3
+      download_url: https://dataverse.nl/api/access/datafile/46088
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6a1cb1c4be9e0bc6372c50abf0e475ff
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 6a1cb1c4be9e0bc6372c50abf0e475ff
+      download_url: https://dataverse.nl/api/access/datafile/45216
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f25f858d4fb92f3782ed330a8246988a
+      byte_size: 1050
+      checksum:
+        algorithm: md5
+        digest: f25f858d4fb92f3782ed330a8246988a
+      download_url: https://dataverse.nl/api/access/datafile/46156
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 834e21e666bf2b6fd0a9d91da6496033
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 834e21e666bf2b6fd0a9d91da6496033
+      download_url: https://dataverse.nl/api/access/datafile/46397
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 90fe04ee120c67a7736e7d57e494b3a7
+      byte_size: 178
+      checksum:
+        algorithm: md5
+        digest: 90fe04ee120c67a7736e7d57e494b3a7
+      download_url: https://dataverse.nl/api/access/datafile/46631
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4c0258f56ab2d5b9c849a907fbe99370
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 4c0258f56ab2d5b9c849a907fbe99370
+      download_url: https://dataverse.nl/api/access/datafile/46301
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d8a6822cee54e4f25fa51962ac919f16
+      byte_size: 608637
+      checksum:
+        algorithm: md5
+        digest: d8a6822cee54e4f25fa51962ac919f16
+      download_url: https://dataverse.nl/api/access/datafile/45161
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1b303daf14c578e9af688ffe870d007e
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 1b303daf14c578e9af688ffe870d007e
+      download_url: https://dataverse.nl/api/access/datafile/46087
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 719ea8f9d5b8da93a26e672b28903983
+      byte_size: 474961
+      checksum:
+        algorithm: md5
+        digest: 719ea8f9d5b8da93a26e672b28903983
+      download_url: https://dataverse.nl/api/access/datafile/46415
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 41f79f2307ebac763f7a4130024a1ad5
+      byte_size: 1038
+      checksum:
+        algorithm: md5
+        digest: 41f79f2307ebac763f7a4130024a1ad5
+      download_url: https://dataverse.nl/api/access/datafile/46267
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 85bfb3b996a3e363341e71a3cd9fae42
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 85bfb3b996a3e363341e71a3cd9fae42
+      download_url: https://dataverse.nl/api/access/datafile/45855
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 3b54a011c9dc6999fa71ed00da1c7b02
+      byte_size: 1038
+      checksum:
+        algorithm: md5
+        digest: 3b54a011c9dc6999fa71ed00da1c7b02
+      download_url: https://dataverse.nl/api/access/datafile/46181
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b48377a889536602e998ee678696daec
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: b48377a889536602e998ee678696daec
+      download_url: https://dataverse.nl/api/access/datafile/45719
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 925a84e91f2ba11ea6d7e1bfa6ea32aa
+      byte_size: 1038
+      checksum:
+        algorithm: md5
+        digest: 925a84e91f2ba11ea6d7e1bfa6ea32aa
+      download_url: https://dataverse.nl/api/access/datafile/45862
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 7b6a9bbaf03466614419c88ead447c63
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 7b6a9bbaf03466614419c88ead447c63
+      download_url: https://dataverse.nl/api/access/datafile/45928
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 13eecaf8e5d96e416ecc8d9f9d741dbb
+      byte_size: 162
+      checksum:
+        algorithm: md5
+        digest: 13eecaf8e5d96e416ecc8d9f9d741dbb
+      download_url: https://dataverse.nl/api/access/datafile/46623
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 0c664901323404e22f267dcb240647d8
+      byte_size: 1045
+      checksum:
+        algorithm: md5
+        digest: 0c664901323404e22f267dcb240647d8
+      download_url: https://dataverse.nl/api/access/datafile/46081
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ce3af5c2a3f18df9ee255e0752dee7d0
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: ce3af5c2a3f18df9ee255e0752dee7d0
+      download_url: https://dataverse.nl/api/access/datafile/46476
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 74af5cbb23fe19b5e0b77b6c1cf400b8
+      byte_size: 1045
+      checksum:
+        algorithm: md5
+        digest: 74af5cbb23fe19b5e0b77b6c1cf400b8
+      download_url: https://dataverse.nl/api/access/datafile/45825
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 3c40888bc656e6497dcb1bcdd0576f44
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 3c40888bc656e6497dcb1bcdd0576f44
+      download_url: https://dataverse.nl/api/access/datafile/45869
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: dc2b090512113f82d5606d3adc06f616
+      byte_size: 1045
+      checksum:
+        algorithm: md5
+        digest: dc2b090512113f82d5606d3adc06f616
+      download_url: https://dataverse.nl/api/access/datafile/46494
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: af351919e3f9eb6b8ae1b6648f4ed9c4
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: af351919e3f9eb6b8ae1b6648f4ed9c4
+      download_url: https://dataverse.nl/api/access/datafile/45986
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d32cce9233e1ec88d65e121fe1d46bf5
+      byte_size: 178
+      checksum:
+        algorithm: md5
+        digest: d32cce9233e1ec88d65e121fe1d46bf5
+      download_url: https://dataverse.nl/api/access/datafile/46640
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 40496512d9d271d8d4777a5ba8a45020
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 40496512d9d271d8d4777a5ba8a45020
+      download_url: https://dataverse.nl/api/access/datafile/45305
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b7ddc4eab27aea3d811b52302b447c3d
+      byte_size: 502922
+      checksum:
+        algorithm: md5
+        digest: b7ddc4eab27aea3d811b52302b447c3d
+      download_url: https://dataverse.nl/api/access/datafile/45956
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 01f363feb27b24b1d987ceebff33c223
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 01f363feb27b24b1d987ceebff33c223
+      download_url: https://dataverse.nl/api/access/datafile/46215
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d93c77119a2e47f583488fe26339e20a
+      byte_size: 524308
+      checksum:
+        algorithm: md5
+        digest: d93c77119a2e47f583488fe26339e20a
+      download_url: https://dataverse.nl/api/access/datafile/45185
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8b40a3a3357d881c508208473509c5f3
+      byte_size: 1027
+      checksum:
+        algorithm: md5
+        digest: 8b40a3a3357d881c508208473509c5f3
+      download_url: https://dataverse.nl/api/access/datafile/45098
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 782e1f1a21fa2241d559e7c3283ffa39
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 782e1f1a21fa2241d559e7c3283ffa39
+      download_url: https://dataverse.nl/api/access/datafile/45598
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 10fa6a7d96f3792f52e375350918ee86
+      byte_size: 1027
+      checksum:
+        algorithm: md5
+        digest: 10fa6a7d96f3792f52e375350918ee86
+      download_url: https://dataverse.nl/api/access/datafile/45530
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: fa62a534801a97ae30eb84c3394e7dcd
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: fa62a534801a97ae30eb84c3394e7dcd
+      download_url: https://dataverse.nl/api/access/datafile/45995
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 763295aba2ac0ba5bf10fea22c41f404
+      byte_size: 1027
+      checksum:
+        algorithm: md5
+        digest: 763295aba2ac0ba5bf10fea22c41f404
+      download_url: https://dataverse.nl/api/access/datafile/46056
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 663fb57530eef754952991dec16af2b3
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 663fb57530eef754952991dec16af2b3
+      download_url: https://dataverse.nl/api/access/datafile/46284
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b3c24aa9b3f9b5e8addebc27680ca61c
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: b3c24aa9b3f9b5e8addebc27680ca61c
+      download_url: https://dataverse.nl/api/access/datafile/46158
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 517b4d76691685dd772eeaf35023c8a5
+      byte_size: 461533
+      checksum:
+        algorithm: md5
+        digest: 517b4d76691685dd772eeaf35023c8a5
+      download_url: https://dataverse.nl/api/access/datafile/45177
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 849ddca842961f33bd2a508b4b66243e
+      byte_size: 1027
+      checksum:
+        algorithm: md5
+        digest: 849ddca842961f33bd2a508b4b66243e
+      download_url: https://dataverse.nl/api/access/datafile/45118
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b772fa7627a2c78cbf6bbc7aa8e15fc5
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: b772fa7627a2c78cbf6bbc7aa8e15fc5
+      download_url: https://dataverse.nl/api/access/datafile/45387
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e181c7d8e19289a06d9d934cbec46373
+      byte_size: 1027
+      checksum:
+        algorithm: md5
+        digest: e181c7d8e19289a06d9d934cbec46373
+      download_url: https://dataverse.nl/api/access/datafile/46001
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 061f466079bc706ddb09c4dc7f1f7ec8
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 061f466079bc706ddb09c4dc7f1f7ec8
+      download_url: https://dataverse.nl/api/access/datafile/46398
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: da466649c5100e5c28b525ef4bbed378
+      byte_size: 1027
+      checksum:
+        algorithm: md5
+        digest: da466649c5100e5c28b525ef4bbed378
+      download_url: https://dataverse.nl/api/access/datafile/45689
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2ad6ec828be8d507d6a9f96050cb024d
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 2ad6ec828be8d507d6a9f96050cb024d
+      download_url: https://dataverse.nl/api/access/datafile/45404
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: cd63bc3de6119017f97434fcefd06cd6
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: cd63bc3de6119017f97434fcefd06cd6
+      download_url: https://dataverse.nl/api/access/datafile/45527
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1763774e3b11a68c20653f60dbbfc9ea
+      byte_size: 469789
+      checksum:
+        algorithm: md5
+        digest: 1763774e3b11a68c20653f60dbbfc9ea
+      download_url: https://dataverse.nl/api/access/datafile/45509
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d79a9ccb0fb162198b466b5fdd3eb48a
+      byte_size: 20736352
+      checksum:
+        algorithm: md5
+        digest: d79a9ccb0fb162198b466b5fdd3eb48a
+      download_url: https://dataverse.nl/api/access/datafile/45153
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-011/
+      qualified_part:
+        - relation: sub-011/anat/
+          name: anat
+        - relation: sub-011/func/
+          name: func
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-011/anat/
+      qualified_part:
+        - relation: d79a9ccb0fb162198b466b5fdd3eb48a
+          name: sub-011_T1w.nii
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b1ee64a3d382b49939d138dd4f44449a
+      byte_size: 1039
+      checksum:
+        algorithm: md5
+        digest: b1ee64a3d382b49939d138dd4f44449a
+      download_url: https://dataverse.nl/api/access/datafile/46084
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-011/func/
+      qualified_part:
+        - relation: b1ee64a3d382b49939d138dd4f44449a
+          name: sub-011_task-emotionProcessing_echo-1_bold.json
+        - relation: 9721f67b8fef76ba6a0330c0556cf4d7
+          name: sub-011_task-emotionProcessing_echo-1_bold.nii
+        - relation: 92ae7f4d53aaa1dfcb6b1aa4831e2b01
+          name: sub-011_task-emotionProcessing_echo-2_bold.json
+        - relation: cd28ad527b17d01fdb165a8187f9edd0
+          name: sub-011_task-emotionProcessing_echo-2_bold.nii
+        - relation: 1a6854b2757b610ba1cd38e38052807a
+          name: sub-011_task-emotionProcessing_echo-3_bold.json
+        - relation: 6b54bde4edbc9783b4fec3f4ff5dbf99
+          name: sub-011_task-emotionProcessing_echo-3_bold.nii
+        - relation: 44a21e171d72d65a62e26533d1c13c35
+          name: sub-011_task-emotionProcessing_events.tsv.gz
+        - relation: d5c1c4ed0bcb9763c953698de001df64
+          name: sub-011_task-emotionProcessingImagined_echo-1_bold.json
+        - relation: 251cda48fe3fc0ff19a7bb7aaf832a27
+          name: sub-011_task-emotionProcessingImagined_echo-1_bold.nii
+        - relation: bfe715ec7a82f1ee4af69387207bed99
+          name: sub-011_task-emotionProcessingImagined_echo-2_bold.json
+        - relation: 75fe1c10b3ea1ff1215e64d3e08b441e
+          name: sub-011_task-emotionProcessingImagined_echo-2_bold.nii
+        - relation: da20dd65ebd552dff0227a15340490db
+          name: sub-011_task-emotionProcessingImagined_echo-3_bold.json
+        - relation: 41ce6c032b35b7ad8416302af406668f
+          name: sub-011_task-emotionProcessingImagined_echo-3_bold.nii
+        - relation: bcb0401f7c891a209243d32ef16f439a
+          name: sub-011_task-emotionProcessingImagined_events.tsv.gz
+        - relation: 4dc4089ecb97f39170ea2d120a5c93e5
+          name: sub-011_task-emotionProcessingImagined_physio.json
+        - relation: 46b5fb70b031ce15fb5e7b60188cece3
+          name: sub-011_task-emotionProcessingImagined_physio.tsv.gz
+        - relation: 67f253b34a9bae8537f3bcdbafe722de
+          name: sub-011_task-emotionProcessing_physio.json
+        - relation: f78c15f33b5a48a9dd7dc7646ce379f6
+          name: sub-011_task-emotionProcessing_physio.tsv.gz
+        - relation: f68613335edd1800b81176499103cf90
+          name: sub-011_task-fingerTapping_echo-1_bold.json
+        - relation: 5a16b498dcaccd3dcc624918af24a44c
+          name: sub-011_task-fingerTapping_echo-1_bold.nii
+        - relation: 67493d53087a90ed9a788b156c7156f7
+          name: sub-011_task-fingerTapping_echo-2_bold.json
+        - relation: 2c2acd45644590194b1cf8e73ad92783
+          name: sub-011_task-fingerTapping_echo-2_bold.nii
+        - relation: 55555dc1b04e4999a286e7533504c00c
+          name: sub-011_task-fingerTapping_echo-3_bold.json
+        - relation: 879269a51ef784261e097fca08e77c91
+          name: sub-011_task-fingerTapping_echo-3_bold.nii
+        - relation: 67e6b607675a3b5675a20c0593b0ba2e
+          name: sub-011_task-fingerTapping_events.tsv.gz
+        - relation: 62152681cf9c628c2e244f6a4c54806a
+          name: sub-011_task-fingerTappingImagined_echo-1_bold.json
+        - relation: 7df91aa22b60c6e5fd5db9f55108b860
+          name: sub-011_task-fingerTappingImagined_echo-1_bold.nii
+        - relation: 8db4cdcd06a3a3d5414e024ab6150ea0
+          name: sub-011_task-fingerTappingImagined_echo-2_bold.json
+        - relation: c8a4081202b2d5d174b3d294d1ba5612
+          name: sub-011_task-fingerTappingImagined_echo-2_bold.nii
+        - relation: d9cf03c8282508c2bf3eec29b63bd178
+          name: sub-011_task-fingerTappingImagined_echo-3_bold.json
+        - relation: c9f183132721513e629b5e1b52f348a9
+          name: sub-011_task-fingerTappingImagined_echo-3_bold.nii
+        - relation: b99b1551578390d5d9370833fe4dfd57
+          name: sub-011_task-fingerTappingImagined_events.tsv.gz
+        - relation: 3869cd5c408fe7d4931ddef3af2c9034
+          name: sub-011_task-fingerTappingImagined_physio.json
+        - relation: 6b89f5151428bdcebabdf1213eaf0d0a
+          name: sub-011_task-fingerTappingImagined_physio.tsv.gz
+        - relation: 345716ebcc9747689b51775cba0a324f
+          name: sub-011_task-fingerTapping_physio.json
+        - relation: 01c001d27101079d5192a3cd9a73030f
+          name: sub-011_task-fingerTapping_physio.tsv.gz
+        - relation: b10520e2662633d333bd9241847ef6cc
+          name: sub-011_task-rest_run-1_echo-1_bold.json
+        - relation: ce39533f0e6735ce343fcc97213b078e
+          name: sub-011_task-rest_run-1_echo-1_bold.nii
+        - relation: 9d15b7e87a5b0b54898f81593d98bc56
+          name: sub-011_task-rest_run-1_echo-2_bold.json
+        - relation: 9853e26d852f88d0fb0671632098ebc5
+          name: sub-011_task-rest_run-1_echo-2_bold.nii
+        - relation: 87f69b8909f5f31e28a899052c77c232
+          name: sub-011_task-rest_run-1_echo-3_bold.json
+        - relation: cf5370cc14cbeb0e6eeb053c2f2be559
+          name: sub-011_task-rest_run-1_echo-3_bold.nii
+        - relation: 06ccf364a78119afd801ef5870a3b5ce
+          name: sub-011_task-rest_run-1_physio.json
+        - relation: 9036b3c81432071b57427b4731cbe612
+          name: sub-011_task-rest_run-1_physio.tsv.gz
+        - relation: 734ec463c1346a0649d5aabbd3e66492
+          name: sub-011_task-rest_run-2_echo-1_bold.json
+        - relation: 8a2a4ccec405b9f83b593449a467b6b0
+          name: sub-011_task-rest_run-2_echo-1_bold.nii
+        - relation: 8856f20a4bb61095e41153ebfb24856a
+          name: sub-011_task-rest_run-2_echo-2_bold.json
+        - relation: 36bae91c122a3ce04df9bcee2a583d15
+          name: sub-011_task-rest_run-2_echo-2_bold.nii
+        - relation: cb9cf3f1a210b9e2a3ba359fea0c2779
+          name: sub-011_task-rest_run-2_echo-3_bold.json
+        - relation: 577b270c64d285540992f988d5aa4e8d
+          name: sub-011_task-rest_run-2_echo-3_bold.nii
+        - relation: ec4eedadf6dcf0c1941077b992168140
+          name: sub-011_task-rest_run-2_physio.json
+        - relation: 31c1315cca51318e840f45596998a980
+          name: sub-011_task-rest_run-2_physio.tsv.gz
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 9721f67b8fef76ba6a0330c0556cf4d7
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 9721f67b8fef76ba6a0330c0556cf4d7
+      download_url: https://dataverse.nl/api/access/datafile/46043
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 92ae7f4d53aaa1dfcb6b1aa4831e2b01
+      byte_size: 1039
+      checksum:
+        algorithm: md5
+        digest: 92ae7f4d53aaa1dfcb6b1aa4831e2b01
+      download_url: https://dataverse.nl/api/access/datafile/45758
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: cd28ad527b17d01fdb165a8187f9edd0
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: cd28ad527b17d01fdb165a8187f9edd0
+      download_url: https://dataverse.nl/api/access/datafile/45818
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1a6854b2757b610ba1cd38e38052807a
+      byte_size: 1039
+      checksum:
+        algorithm: md5
+        digest: 1a6854b2757b610ba1cd38e38052807a
+      download_url: https://dataverse.nl/api/access/datafile/46455
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6b54bde4edbc9783b4fec3f4ff5dbf99
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 6b54bde4edbc9783b4fec3f4ff5dbf99
+      download_url: https://dataverse.nl/api/access/datafile/45816
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 44a21e171d72d65a62e26533d1c13c35
+      byte_size: 1915
+      checksum:
+        algorithm: md5
+        digest: 44a21e171d72d65a62e26533d1c13c35
+      download_url: https://dataverse.nl/api/access/datafile/46644
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d5c1c4ed0bcb9763c953698de001df64
+      byte_size: 1047
+      checksum:
+        algorithm: md5
+        digest: d5c1c4ed0bcb9763c953698de001df64
+      download_url: https://dataverse.nl/api/access/datafile/45837
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 251cda48fe3fc0ff19a7bb7aaf832a27
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 251cda48fe3fc0ff19a7bb7aaf832a27
+      download_url: https://dataverse.nl/api/access/datafile/45433
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: bfe715ec7a82f1ee4af69387207bed99
+      byte_size: 1047
+      checksum:
+        algorithm: md5
+        digest: bfe715ec7a82f1ee4af69387207bed99
+      download_url: https://dataverse.nl/api/access/datafile/46409
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 75fe1c10b3ea1ff1215e64d3e08b441e
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 75fe1c10b3ea1ff1215e64d3e08b441e
+      download_url: https://dataverse.nl/api/access/datafile/46425
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: da20dd65ebd552dff0227a15340490db
+      byte_size: 1047
+      checksum:
+        algorithm: md5
+        digest: da20dd65ebd552dff0227a15340490db
+      download_url: https://dataverse.nl/api/access/datafile/45713
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 41ce6c032b35b7ad8416302af406668f
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 41ce6c032b35b7ad8416302af406668f
+      download_url: https://dataverse.nl/api/access/datafile/45969
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: bcb0401f7c891a209243d32ef16f439a
+      byte_size: 178
+      checksum:
+        algorithm: md5
+        digest: bcb0401f7c891a209243d32ef16f439a
+      download_url: https://dataverse.nl/api/access/datafile/46608
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4dc4089ecb97f39170ea2d120a5c93e5
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 4dc4089ecb97f39170ea2d120a5c93e5
+      download_url: https://dataverse.nl/api/access/datafile/46432
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 46b5fb70b031ce15fb5e7b60188cece3
+      byte_size: 598103
+      checksum:
+        algorithm: md5
+        digest: 46b5fb70b031ce15fb5e7b60188cece3
+      download_url: https://dataverse.nl/api/access/datafile/45231
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 67f253b34a9bae8537f3bcdbafe722de
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 67f253b34a9bae8537f3bcdbafe722de
+      download_url: https://dataverse.nl/api/access/datafile/46372
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f78c15f33b5a48a9dd7dc7646ce379f6
+      byte_size: 512048
+      checksum:
+        algorithm: md5
+        digest: f78c15f33b5a48a9dd7dc7646ce379f6
+      download_url: https://dataverse.nl/api/access/datafile/45297
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f68613335edd1800b81176499103cf90
+      byte_size: 1035
+      checksum:
+        algorithm: md5
+        digest: f68613335edd1800b81176499103cf90
+      download_url: https://dataverse.nl/api/access/datafile/45241
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5a16b498dcaccd3dcc624918af24a44c
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 5a16b498dcaccd3dcc624918af24a44c
+      download_url: https://dataverse.nl/api/access/datafile/46011
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 67493d53087a90ed9a788b156c7156f7
+      byte_size: 1035
+      checksum:
+        algorithm: md5
+        digest: 67493d53087a90ed9a788b156c7156f7
+      download_url: https://dataverse.nl/api/access/datafile/46464
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2c2acd45644590194b1cf8e73ad92783
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 2c2acd45644590194b1cf8e73ad92783
+      download_url: https://dataverse.nl/api/access/datafile/45235
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 55555dc1b04e4999a286e7533504c00c
+      byte_size: 1035
+      checksum:
+        algorithm: md5
+        digest: 55555dc1b04e4999a286e7533504c00c
+      download_url: https://dataverse.nl/api/access/datafile/45578
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 879269a51ef784261e097fca08e77c91
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 879269a51ef784261e097fca08e77c91
+      download_url: https://dataverse.nl/api/access/datafile/45698
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 67e6b607675a3b5675a20c0593b0ba2e
+      byte_size: 164
+      checksum:
+        algorithm: md5
+        digest: 67e6b607675a3b5675a20c0593b0ba2e
+      download_url: https://dataverse.nl/api/access/datafile/46596
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 62152681cf9c628c2e244f6a4c54806a
+      byte_size: 1043
+      checksum:
+        algorithm: md5
+        digest: 62152681cf9c628c2e244f6a4c54806a
+      download_url: https://dataverse.nl/api/access/datafile/46155
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 7df91aa22b60c6e5fd5db9f55108b860
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 7df91aa22b60c6e5fd5db9f55108b860
+      download_url: https://dataverse.nl/api/access/datafile/46139
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8db4cdcd06a3a3d5414e024ab6150ea0
+      byte_size: 1043
+      checksum:
+        algorithm: md5
+        digest: 8db4cdcd06a3a3d5414e024ab6150ea0
+      download_url: https://dataverse.nl/api/access/datafile/45811
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c8a4081202b2d5d174b3d294d1ba5612
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: c8a4081202b2d5d174b3d294d1ba5612
+      download_url: https://dataverse.nl/api/access/datafile/45382
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d9cf03c8282508c2bf3eec29b63bd178
+      byte_size: 1043
+      checksum:
+        algorithm: md5
+        digest: d9cf03c8282508c2bf3eec29b63bd178
+      download_url: https://dataverse.nl/api/access/datafile/46017
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c9f183132721513e629b5e1b52f348a9
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: c9f183132721513e629b5e1b52f348a9
+      download_url: https://dataverse.nl/api/access/datafile/45914
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b99b1551578390d5d9370833fe4dfd57
+      byte_size: 179
+      checksum:
+        algorithm: md5
+        digest: b99b1551578390d5d9370833fe4dfd57
+      download_url: https://dataverse.nl/api/access/datafile/46570
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 3869cd5c408fe7d4931ddef3af2c9034
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 3869cd5c408fe7d4931ddef3af2c9034
+      download_url: https://dataverse.nl/api/access/datafile/46331
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6b89f5151428bdcebabdf1213eaf0d0a
+      byte_size: 582479
+      checksum:
+        algorithm: md5
+        digest: 6b89f5151428bdcebabdf1213eaf0d0a
+      download_url: https://dataverse.nl/api/access/datafile/45574
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 345716ebcc9747689b51775cba0a324f
+      byte_size: 142
+      checksum:
+        algorithm: md5
+        digest: 345716ebcc9747689b51775cba0a324f
+      download_url: https://dataverse.nl/api/access/datafile/45920
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 01c001d27101079d5192a3cd9a73030f
+      byte_size: 525437
+      checksum:
+        algorithm: md5
+        digest: 01c001d27101079d5192a3cd9a73030f
+      download_url: https://dataverse.nl/api/access/datafile/45628
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b10520e2662633d333bd9241847ef6cc
+      byte_size: 1026
+      checksum:
+        algorithm: md5
+        digest: b10520e2662633d333bd9241847ef6cc
+      download_url: https://dataverse.nl/api/access/datafile/45561
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ce39533f0e6735ce343fcc97213b078e
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: ce39533f0e6735ce343fcc97213b078e
+      download_url: https://dataverse.nl/api/access/datafile/45890
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 9d15b7e87a5b0b54898f81593d98bc56
+      byte_size: 1026
+      checksum:
+        algorithm: md5
+        digest: 9d15b7e87a5b0b54898f81593d98bc56
+      download_url: https://dataverse.nl/api/access/datafile/45714
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 9853e26d852f88d0fb0671632098ebc5
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 9853e26d852f88d0fb0671632098ebc5
+      download_url: https://dataverse.nl/api/access/datafile/45392
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 87f69b8909f5f31e28a899052c77c232
+      byte_size: 1026
+      checksum:
+        algorithm: md5
+        digest: 87f69b8909f5f31e28a899052c77c232
+      download_url: https://dataverse.nl/api/access/datafile/45287
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: cf5370cc14cbeb0e6eeb053c2f2be559
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: cf5370cc14cbeb0e6eeb053c2f2be559
+      download_url: https://dataverse.nl/api/access/datafile/46150
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 06ccf364a78119afd801ef5870a3b5ce
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 06ccf364a78119afd801ef5870a3b5ce
+      download_url: https://dataverse.nl/api/access/datafile/45365
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 9036b3c81432071b57427b4731cbe612
+      byte_size: 469520
+      checksum:
+        algorithm: md5
+        digest: 9036b3c81432071b57427b4731cbe612
+      download_url: https://dataverse.nl/api/access/datafile/46032
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 734ec463c1346a0649d5aabbd3e66492
+      byte_size: 1026
+      checksum:
+        algorithm: md5
+        digest: 734ec463c1346a0649d5aabbd3e66492
+      download_url: https://dataverse.nl/api/access/datafile/46384
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8a2a4ccec405b9f83b593449a467b6b0
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 8a2a4ccec405b9f83b593449a467b6b0
+      download_url: https://dataverse.nl/api/access/datafile/45608
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8856f20a4bb61095e41153ebfb24856a
+      byte_size: 1026
+      checksum:
+        algorithm: md5
+        digest: 8856f20a4bb61095e41153ebfb24856a
+      download_url: https://dataverse.nl/api/access/datafile/46229
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 36bae91c122a3ce04df9bcee2a583d15
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 36bae91c122a3ce04df9bcee2a583d15
+      download_url: https://dataverse.nl/api/access/datafile/46359
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: cb9cf3f1a210b9e2a3ba359fea0c2779
+      byte_size: 1026
+      checksum:
+        algorithm: md5
+        digest: cb9cf3f1a210b9e2a3ba359fea0c2779
+      download_url: https://dataverse.nl/api/access/datafile/46066
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 577b270c64d285540992f988d5aa4e8d
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 577b270c64d285540992f988d5aa4e8d
+      download_url: https://dataverse.nl/api/access/datafile/46543
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ec4eedadf6dcf0c1941077b992168140
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: ec4eedadf6dcf0c1941077b992168140
+      download_url: https://dataverse.nl/api/access/datafile/46329
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 31c1315cca51318e840f45596998a980
+      byte_size: 487630
+      checksum:
+        algorithm: md5
+        digest: 31c1315cca51318e840f45596998a980
+      download_url: https://dataverse.nl/api/access/datafile/45977
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 795af637ef08412092a8026dc0ee140d
+      byte_size: 20736352
+      checksum:
+        algorithm: md5
+        digest: 795af637ef08412092a8026dc0ee140d
+      download_url: https://dataverse.nl/api/access/datafile/46047
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-012/
+      qualified_part:
+        - relation: sub-012/anat/
+          name: anat
+        - relation: sub-012/func/
+          name: func
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-012/anat/
+      qualified_part:
+        - relation: 795af637ef08412092a8026dc0ee140d
+          name: sub-012_T1w.nii
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 382a4823b9b110d0c58322e9c40570e1
+      byte_size: 1041
+      checksum:
+        algorithm: md5
+        digest: 382a4823b9b110d0c58322e9c40570e1
+      download_url: https://dataverse.nl/api/access/datafile/46354
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-012/func/
+      qualified_part:
+        - relation: 382a4823b9b110d0c58322e9c40570e1
+          name: sub-012_task-emotionProcessing_echo-1_bold.json
+        - relation: b6a195317631932eab859ad0c3d6ea33
+          name: sub-012_task-emotionProcessing_echo-1_bold.nii
+        - relation: 799090ea10892c2dd15b914a46564194
+          name: sub-012_task-emotionProcessing_echo-2_bold.json
+        - relation: ece612ba0853e7be290ec84604dfbd93
+          name: sub-012_task-emotionProcessing_echo-2_bold.nii
+        - relation: 7ef80e89f474467f5b3e969293f3467f
+          name: sub-012_task-emotionProcessing_echo-3_bold.json
+        - relation: 9ee8fff9e7c3ec8e70644854c7495c4c
+          name: sub-012_task-emotionProcessing_echo-3_bold.nii
+        - relation: 097058ecbe042066f14ed6220b0dfbd9
+          name: sub-012_task-emotionProcessing_events.tsv.gz
+        - relation: 050fb9dbf93e7c09df79e9efbb02fcb9
+          name: sub-012_task-emotionProcessingImagined_echo-1_bold.json
+        - relation: 8ae116e6ecd732f7600e04763fa2a705
+          name: sub-012_task-emotionProcessingImagined_echo-1_bold.nii
+        - relation: 196a26faa275c16e97365e3a8d92ff7d
+          name: sub-012_task-emotionProcessingImagined_echo-2_bold.json
+        - relation: c7bb51c9716c1e122ec8c2c4ae213c35
+          name: sub-012_task-emotionProcessingImagined_echo-2_bold.nii
+        - relation: b4442c318da703f7f578646358ad1d81
+          name: sub-012_task-emotionProcessingImagined_echo-3_bold.json
+        - relation: 7916e42076207b5848d0e1966997d8c2
+          name: sub-012_task-emotionProcessingImagined_echo-3_bold.nii
+        - relation: 3f246551ab4cffc672ab28c6c00df119
+          name: sub-012_task-emotionProcessingImagined_events.tsv.gz
+        - relation: f0530603563aa5bff37d429077bf63b1
+          name: sub-012_task-emotionProcessingImagined_physio.json
+        - relation: d3163cee8283f7d3a4e3eea656126800
+          name: sub-012_task-emotionProcessingImagined_physio.tsv.gz
+        - relation: dd61d969dba5f822d1341db9b2ea4131
+          name: sub-012_task-emotionProcessing_physio.json
+        - relation: 51bf4260d4068cd629c8fb1700b22fec
+          name: sub-012_task-emotionProcessing_physio.tsv.gz
+        - relation: de294fa441235170f805902ad31457e1
+          name: sub-012_task-fingerTapping_echo-1_bold.json
+        - relation: cd2c4d3cf939bf00b695ee6ecff33064
+          name: sub-012_task-fingerTapping_echo-1_bold.nii
+        - relation: ea835407d646a4bc33685ebc5c5b027d
+          name: sub-012_task-fingerTapping_echo-2_bold.json
+        - relation: 3c8f0fae13660639d328ecd1ec29c0a2
+          name: sub-012_task-fingerTapping_echo-2_bold.nii
+        - relation: 9a6686d65339d9d41577a6cdd9ffe09a
+          name: sub-012_task-fingerTapping_echo-3_bold.json
+        - relation: 8ed55bd04f00b343fbaa411c09f1cdea
+          name: sub-012_task-fingerTapping_echo-3_bold.nii
+        - relation: d1d06fd9f3ec1c7df5d2838923cb98bd
+          name: sub-012_task-fingerTapping_events.tsv.gz
+        - relation: 10a34c63d3a97b2adc98d1386df793d8
+          name: sub-012_task-fingerTappingImagined_echo-1_bold.json
+        - relation: 6f95650a96ab74622d4fa8f16d0c820f
+          name: sub-012_task-fingerTappingImagined_echo-1_bold.nii
+        - relation: 8ac3c9410fa371e8d49a02d68bb704ff
+          name: sub-012_task-fingerTappingImagined_echo-2_bold.json
+        - relation: d10693fd693c1db4f1ebaca74e52cbbd
+          name: sub-012_task-fingerTappingImagined_echo-2_bold.nii
+        - relation: 7a03104a2d2b3e4ccde0d1236fc995dc
+          name: sub-012_task-fingerTappingImagined_echo-3_bold.json
+        - relation: 0e1a64cd98ff26b34c4d14d0487e0636
+          name: sub-012_task-fingerTappingImagined_echo-3_bold.nii
+        - relation: 0ff7dc89c68f67fbc39672b7d3cc7023
+          name: sub-012_task-fingerTappingImagined_events.tsv.gz
+        - relation: c57f34d5f230fe2c01f06b4865f0325f
+          name: sub-012_task-fingerTappingImagined_physio.json
+        - relation: b26fc2f54c1b240cd8981fcb0224b4b1
+          name: sub-012_task-fingerTappingImagined_physio.tsv.gz
+        - relation: 1e300396dc5b59771f40ca8bc8b57e19
+          name: sub-012_task-fingerTapping_physio.json
+        - relation: 45f2c03f0fe510b4a3185ae6cbf496d8
+          name: sub-012_task-fingerTapping_physio.tsv.gz
+        - relation: e3a883756d27e5b8e09e93412825c7fe
+          name: sub-012_task-rest_run-1_echo-1_bold.json
+        - relation: 7b0ef606ddc57bac0c4a06c60f51a8f3
+          name: sub-012_task-rest_run-1_echo-1_bold.nii
+        - relation: f4ada1d0e02800ceb65f083847f950ba
+          name: sub-012_task-rest_run-1_echo-2_bold.json
+        - relation: c2ae5a5e4ea51ac54ae4d2cc4ef30f11
+          name: sub-012_task-rest_run-1_echo-2_bold.nii
+        - relation: dda69229fb84f9b9623f8f35de79b5e2
+          name: sub-012_task-rest_run-1_echo-3_bold.json
+        - relation: d12af16342d85ce006b676b14a8a79e2
+          name: sub-012_task-rest_run-1_echo-3_bold.nii
+        - relation: fadc5fbec6ea5f8adb2f31c8a837379f
+          name: sub-012_task-rest_run-1_physio.json
+        - relation: 4892d49ae507ce3fe61976ebb021cfec
+          name: sub-012_task-rest_run-1_physio.tsv.gz
+        - relation: 2c1dc9ae410b111eee9fcbd67674dd41
+          name: sub-012_task-rest_run-2_echo-1_bold.json
+        - relation: d2404c5a5d23dbf81d32995d653125ec
+          name: sub-012_task-rest_run-2_echo-1_bold.nii
+        - relation: 6dacd51f3fdb60a29f137fb5dcadc8d9
+          name: sub-012_task-rest_run-2_echo-2_bold.json
+        - relation: a4072099ef5cf2ec54ada3e56e44fe6d
+          name: sub-012_task-rest_run-2_echo-2_bold.nii
+        - relation: 1582d2d1a3c9da3568043e61046efc03
+          name: sub-012_task-rest_run-2_echo-3_bold.json
+        - relation: 991e8938d59ff3e37a2e5b2983b0805e
+          name: sub-012_task-rest_run-2_echo-3_bold.nii
+        - relation: a71c4b97ebdfa87fd1314ee245a018d6
+          name: sub-012_task-rest_run-2_physio.json
+        - relation: 702951e89ef28eecc2fb0431a7138703
+          name: sub-012_task-rest_run-2_physio.tsv.gz
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b6a195317631932eab859ad0c3d6ea33
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: b6a195317631932eab859ad0c3d6ea33
+      download_url: https://dataverse.nl/api/access/datafile/46535
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 799090ea10892c2dd15b914a46564194
+      byte_size: 1041
+      checksum:
+        algorithm: md5
+        digest: 799090ea10892c2dd15b914a46564194
+      download_url: https://dataverse.nl/api/access/datafile/45343
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ece612ba0853e7be290ec84604dfbd93
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: ece612ba0853e7be290ec84604dfbd93
+      download_url: https://dataverse.nl/api/access/datafile/45658
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 7ef80e89f474467f5b3e969293f3467f
+      byte_size: 1041
+      checksum:
+        algorithm: md5
+        digest: 7ef80e89f474467f5b3e969293f3467f
+      download_url: https://dataverse.nl/api/access/datafile/46061
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 9ee8fff9e7c3ec8e70644854c7495c4c
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 9ee8fff9e7c3ec8e70644854c7495c4c
+      download_url: https://dataverse.nl/api/access/datafile/45109
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 097058ecbe042066f14ed6220b0dfbd9
+      byte_size: 1895
+      checksum:
+        algorithm: md5
+        digest: 097058ecbe042066f14ed6220b0dfbd9
+      download_url: https://dataverse.nl/api/access/datafile/46562
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 050fb9dbf93e7c09df79e9efbb02fcb9
+      byte_size: 1048
+      checksum:
+        algorithm: md5
+        digest: 050fb9dbf93e7c09df79e9efbb02fcb9
+      download_url: https://dataverse.nl/api/access/datafile/46483
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8ae116e6ecd732f7600e04763fa2a705
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 8ae116e6ecd732f7600e04763fa2a705
+      download_url: https://dataverse.nl/api/access/datafile/46296
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 196a26faa275c16e97365e3a8d92ff7d
+      byte_size: 1048
+      checksum:
+        algorithm: md5
+        digest: 196a26faa275c16e97365e3a8d92ff7d
+      download_url: https://dataverse.nl/api/access/datafile/46294
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c7bb51c9716c1e122ec8c2c4ae213c35
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: c7bb51c9716c1e122ec8c2c4ae213c35
+      download_url: https://dataverse.nl/api/access/datafile/45192
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b4442c318da703f7f578646358ad1d81
+      byte_size: 1048
+      checksum:
+        algorithm: md5
+        digest: b4442c318da703f7f578646358ad1d81
+      download_url: https://dataverse.nl/api/access/datafile/46325
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 7916e42076207b5848d0e1966997d8c2
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 7916e42076207b5848d0e1966997d8c2
+      download_url: https://dataverse.nl/api/access/datafile/46120
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 3f246551ab4cffc672ab28c6c00df119
+      byte_size: 174
+      checksum:
+        algorithm: md5
+        digest: 3f246551ab4cffc672ab28c6c00df119
+      download_url: https://dataverse.nl/api/access/datafile/46599
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f0530603563aa5bff37d429077bf63b1
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: f0530603563aa5bff37d429077bf63b1
+      download_url: https://dataverse.nl/api/access/datafile/45190
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d3163cee8283f7d3a4e3eea656126800
+      byte_size: 463512
+      checksum:
+        algorithm: md5
+        digest: d3163cee8283f7d3a4e3eea656126800
+      download_url: https://dataverse.nl/api/access/datafile/45255
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: dd61d969dba5f822d1341db9b2ea4131
+      byte_size: 141
+      checksum:
+        algorithm: md5
+        digest: dd61d969dba5f822d1341db9b2ea4131
+      download_url: https://dataverse.nl/api/access/datafile/46530
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 51bf4260d4068cd629c8fb1700b22fec
+      byte_size: 525307
+      checksum:
+        algorithm: md5
+        digest: 51bf4260d4068cd629c8fb1700b22fec
+      download_url: https://dataverse.nl/api/access/datafile/45278
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: de294fa441235170f805902ad31457e1
+      byte_size: 1037
+      checksum:
+        algorithm: md5
+        digest: de294fa441235170f805902ad31457e1
+      download_url: https://dataverse.nl/api/access/datafile/45808
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: cd2c4d3cf939bf00b695ee6ecff33064
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: cd2c4d3cf939bf00b695ee6ecff33064
+      download_url: https://dataverse.nl/api/access/datafile/45618
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ea835407d646a4bc33685ebc5c5b027d
+      byte_size: 1037
+      checksum:
+        algorithm: md5
+        digest: ea835407d646a4bc33685ebc5c5b027d
+      download_url: https://dataverse.nl/api/access/datafile/46127
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 3c8f0fae13660639d328ecd1ec29c0a2
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 3c8f0fae13660639d328ecd1ec29c0a2
+      download_url: https://dataverse.nl/api/access/datafile/45517
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 9a6686d65339d9d41577a6cdd9ffe09a
+      byte_size: 1037
+      checksum:
+        algorithm: md5
+        digest: 9a6686d65339d9d41577a6cdd9ffe09a
+      download_url: https://dataverse.nl/api/access/datafile/45607
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8ed55bd04f00b343fbaa411c09f1cdea
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 8ed55bd04f00b343fbaa411c09f1cdea
+      download_url: https://dataverse.nl/api/access/datafile/45575
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d1d06fd9f3ec1c7df5d2838923cb98bd
+      byte_size: 164
+      checksum:
+        algorithm: md5
+        digest: d1d06fd9f3ec1c7df5d2838923cb98bd
+      download_url: https://dataverse.nl/api/access/datafile/46601
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 10a34c63d3a97b2adc98d1386df793d8
+      byte_size: 1045
+      checksum:
+        algorithm: md5
+        digest: 10a34c63d3a97b2adc98d1386df793d8
+      download_url: https://dataverse.nl/api/access/datafile/46524
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6f95650a96ab74622d4fa8f16d0c820f
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 6f95650a96ab74622d4fa8f16d0c820f
+      download_url: https://dataverse.nl/api/access/datafile/45099
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8ac3c9410fa371e8d49a02d68bb704ff
+      byte_size: 1045
+      checksum:
+        algorithm: md5
+        digest: 8ac3c9410fa371e8d49a02d68bb704ff
+      download_url: https://dataverse.nl/api/access/datafile/46225
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d10693fd693c1db4f1ebaca74e52cbbd
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: d10693fd693c1db4f1ebaca74e52cbbd
+      download_url: https://dataverse.nl/api/access/datafile/46151
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 7a03104a2d2b3e4ccde0d1236fc995dc
+      byte_size: 1045
+      checksum:
+        algorithm: md5
+        digest: 7a03104a2d2b3e4ccde0d1236fc995dc
+      download_url: https://dataverse.nl/api/access/datafile/46517
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 0e1a64cd98ff26b34c4d14d0487e0636
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 0e1a64cd98ff26b34c4d14d0487e0636
+      download_url: https://dataverse.nl/api/access/datafile/45763
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 0ff7dc89c68f67fbc39672b7d3cc7023
+      byte_size: 177
+      checksum:
+        algorithm: md5
+        digest: 0ff7dc89c68f67fbc39672b7d3cc7023
+      download_url: https://dataverse.nl/api/access/datafile/46569
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c57f34d5f230fe2c01f06b4865f0325f
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: c57f34d5f230fe2c01f06b4865f0325f
+      download_url: https://dataverse.nl/api/access/datafile/45374
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b26fc2f54c1b240cd8981fcb0224b4b1
+      byte_size: 490085
+      checksum:
+        algorithm: md5
+        digest: b26fc2f54c1b240cd8981fcb0224b4b1
+      download_url: https://dataverse.nl/api/access/datafile/46532
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1e300396dc5b59771f40ca8bc8b57e19
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 1e300396dc5b59771f40ca8bc8b57e19
+      download_url: https://dataverse.nl/api/access/datafile/45142
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 45f2c03f0fe510b4a3185ae6cbf496d8
+      byte_size: 515014
+      checksum:
+        algorithm: md5
+        digest: 45f2c03f0fe510b4a3185ae6cbf496d8
+      download_url: https://dataverse.nl/api/access/datafile/45111
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e3a883756d27e5b8e09e93412825c7fe
+      byte_size: 1028
+      checksum:
+        algorithm: md5
+        digest: e3a883756d27e5b8e09e93412825c7fe
+      download_url: https://dataverse.nl/api/access/datafile/46540
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 7b0ef606ddc57bac0c4a06c60f51a8f3
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 7b0ef606ddc57bac0c4a06c60f51a8f3
+      download_url: https://dataverse.nl/api/access/datafile/45501
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f4ada1d0e02800ceb65f083847f950ba
+      byte_size: 1028
+      checksum:
+        algorithm: md5
+        digest: f4ada1d0e02800ceb65f083847f950ba
+      download_url: https://dataverse.nl/api/access/datafile/46034
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c2ae5a5e4ea51ac54ae4d2cc4ef30f11
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: c2ae5a5e4ea51ac54ae4d2cc4ef30f11
+      download_url: https://dataverse.nl/api/access/datafile/45636
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: dda69229fb84f9b9623f8f35de79b5e2
+      byte_size: 1028
+      checksum:
+        algorithm: md5
+        digest: dda69229fb84f9b9623f8f35de79b5e2
+      download_url: https://dataverse.nl/api/access/datafile/46443
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d12af16342d85ce006b676b14a8a79e2
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: d12af16342d85ce006b676b14a8a79e2
+      download_url: https://dataverse.nl/api/access/datafile/45709
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: fadc5fbec6ea5f8adb2f31c8a837379f
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: fadc5fbec6ea5f8adb2f31c8a837379f
+      download_url: https://dataverse.nl/api/access/datafile/45940
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4892d49ae507ce3fe61976ebb021cfec
+      byte_size: 463276
+      checksum:
+        algorithm: md5
+        digest: 4892d49ae507ce3fe61976ebb021cfec
+      download_url: https://dataverse.nl/api/access/datafile/46402
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2c1dc9ae410b111eee9fcbd67674dd41
+      byte_size: 1028
+      checksum:
+        algorithm: md5
+        digest: 2c1dc9ae410b111eee9fcbd67674dd41
+      download_url: https://dataverse.nl/api/access/datafile/46351
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d2404c5a5d23dbf81d32995d653125ec
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: d2404c5a5d23dbf81d32995d653125ec
+      download_url: https://dataverse.nl/api/access/datafile/46036
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6dacd51f3fdb60a29f137fb5dcadc8d9
+      byte_size: 1028
+      checksum:
+        algorithm: md5
+        digest: 6dacd51f3fdb60a29f137fb5dcadc8d9
+      download_url: https://dataverse.nl/api/access/datafile/45492
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a4072099ef5cf2ec54ada3e56e44fe6d
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: a4072099ef5cf2ec54ada3e56e44fe6d
+      download_url: https://dataverse.nl/api/access/datafile/46105
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1582d2d1a3c9da3568043e61046efc03
+      byte_size: 1028
+      checksum:
+        algorithm: md5
+        digest: 1582d2d1a3c9da3568043e61046efc03
+      download_url: https://dataverse.nl/api/access/datafile/46235
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 991e8938d59ff3e37a2e5b2983b0805e
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 991e8938d59ff3e37a2e5b2983b0805e
+      download_url: https://dataverse.nl/api/access/datafile/45625
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a71c4b97ebdfa87fd1314ee245a018d6
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: a71c4b97ebdfa87fd1314ee245a018d6
+      download_url: https://dataverse.nl/api/access/datafile/45460
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 702951e89ef28eecc2fb0431a7138703
+      byte_size: 451048
+      checksum:
+        algorithm: md5
+        digest: 702951e89ef28eecc2fb0431a7138703
+      download_url: https://dataverse.nl/api/access/datafile/45281
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 35f0db586ee930c7cca38874da209ee8
+      byte_size: 20736352
+      checksum:
+        algorithm: md5
+        digest: 35f0db586ee930c7cca38874da209ee8
+      download_url: https://dataverse.nl/api/access/datafile/45230
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-013/
+      qualified_part:
+        - relation: sub-013/anat/
+          name: anat
+        - relation: sub-013/func/
+          name: func
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-013/anat/
+      qualified_part:
+        - relation: 35f0db586ee930c7cca38874da209ee8
+          name: sub-013_T1w.nii
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4c3cf2184e333516449b2fd9ab99e6f8
+      byte_size: 1039
+      checksum:
+        algorithm: md5
+        digest: 4c3cf2184e333516449b2fd9ab99e6f8
+      download_url: https://dataverse.nl/api/access/datafile/46300
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-013/func/
+      qualified_part:
+        - relation: 4c3cf2184e333516449b2fd9ab99e6f8
+          name: sub-013_task-emotionProcessing_echo-1_bold.json
+        - relation: 42da9e5f60b8474657f709ff80423b42
+          name: sub-013_task-emotionProcessing_echo-1_bold.nii
+        - relation: 428d8b271dfb0ae1adf5c4e550bd371d
+          name: sub-013_task-emotionProcessing_echo-2_bold.json
+        - relation: b29b1ffd8a68f4cde389e2150cb16e13
+          name: sub-013_task-emotionProcessing_echo-2_bold.nii
+        - relation: e9b416ede6a2a916a3a835654aed276c
+          name: sub-013_task-emotionProcessing_echo-3_bold.json
+        - relation: 154468e9d87e1b3daba28c51528aa2eb
+          name: sub-013_task-emotionProcessing_echo-3_bold.nii
+        - relation: 5b6fb06c3743fae4095da2eea36a5464
+          name: sub-013_task-emotionProcessing_events.tsv.gz
+        - relation: 39a8655efa4164001f70630f578860b5
+          name: sub-013_task-emotionProcessingImagined_echo-1_bold.json
+        - relation: a5eb50a3b6d8bd2d9b9afa4af09a1672
+          name: sub-013_task-emotionProcessingImagined_echo-1_bold.nii
+        - relation: 2d58a070af22c624dc461557f839120a
+          name: sub-013_task-emotionProcessingImagined_echo-2_bold.json
+        - relation: db16713e31fcb088bf8c209cf2ccadd8
+          name: sub-013_task-emotionProcessingImagined_echo-2_bold.nii
+        - relation: d71aa1888f2c0b09ac19b1ba85089fb3
+          name: sub-013_task-emotionProcessingImagined_echo-3_bold.json
+        - relation: 612187d0f7bc9a6ca680efe80b47802d
+          name: sub-013_task-emotionProcessingImagined_echo-3_bold.nii
+        - relation: adb70a52e07794ff600c3039e4773864
+          name: sub-013_task-emotionProcessingImagined_events.tsv.gz
+        - relation: b0f5c8f13d597a094a1aeb3c162588dd
+          name: sub-013_task-emotionProcessingImagined_physio.json
+        - relation: cbda14078ebecf0cb7dbce7c2f491725
+          name: sub-013_task-emotionProcessingImagined_physio.tsv.gz
+        - relation: d0f1d46c90bc3ff7fddcfec9826bbc14
+          name: sub-013_task-emotionProcessing_physio.json
+        - relation: 6035e0d678f0067761fcca4c5b7c0bea
+          name: sub-013_task-emotionProcessing_physio.tsv.gz
+        - relation: ab12231bb38f998b0c74148deecc6053
+          name: sub-013_task-fingerTapping_echo-1_bold.json
+        - relation: 2c0e630b0a1184a651e7c22bb47dfdf0
+          name: sub-013_task-fingerTapping_echo-1_bold.nii
+        - relation: 9ca509e0c01261e7c3ed94338394f0ca
+          name: sub-013_task-fingerTapping_echo-2_bold.json
+        - relation: 3ad4a140f2c76f0f5617eca438b2a82e
+          name: sub-013_task-fingerTapping_echo-2_bold.nii
+        - relation: 4a16fccd84cf4de9f19e99c54e681ddd
+          name: sub-013_task-fingerTapping_echo-3_bold.json
+        - relation: 8fadb476f9c9a61003e24e404e7c9237
+          name: sub-013_task-fingerTapping_echo-3_bold.nii
+        - relation: f2f1ec4918c4fed24c7cab1b3cd4a67f
+          name: sub-013_task-fingerTapping_events.tsv.gz
+        - relation: a02e3e3953d7f52cab57250d2114050e
+          name: sub-013_task-fingerTappingImagined_echo-1_bold.json
+        - relation: 256e93aa12107151a7656df8208f8f82
+          name: sub-013_task-fingerTappingImagined_echo-1_bold.nii
+        - relation: 488c3478ab3a82b0040606e7792083dc
+          name: sub-013_task-fingerTappingImagined_echo-2_bold.json
+        - relation: 057370dbee8f6dd21a7b8c5a51782ec4
+          name: sub-013_task-fingerTappingImagined_echo-2_bold.nii
+        - relation: 6b02ab76f155bb7170609f6ff2449f2e
+          name: sub-013_task-fingerTappingImagined_echo-3_bold.json
+        - relation: 147b61f47296003c21ab27a66ef64aad
+          name: sub-013_task-fingerTappingImagined_echo-3_bold.nii
+        - relation: 284434bd2be53609b41ff2d7bcaf33b2
+          name: sub-013_task-fingerTappingImagined_events.tsv.gz
+        - relation: 0e63bbb9fdc6ec15fb2ed4287485919b
+          name: sub-013_task-fingerTappingImagined_physio.json
+        - relation: 5eabf83c020779e7cf2d45e8a89cc7fa
+          name: sub-013_task-fingerTappingImagined_physio.tsv.gz
+        - relation: 735f2308bddbdd5c49117730a5de9d94
+          name: sub-013_task-fingerTapping_physio.json
+        - relation: 56f78b4bf78e6f5bbea9f758b867bb75
+          name: sub-013_task-fingerTapping_physio.tsv.gz
+        - relation: d04baff7ec38efc1cf1c7dd5f3d88863
+          name: sub-013_task-rest_run-1_echo-1_bold.json
+        - relation: 5351444b82f30e3188c4afce97b5636a
+          name: sub-013_task-rest_run-1_echo-1_bold.nii
+        - relation: c76360cc45e8f6240d909fdce03aab99
+          name: sub-013_task-rest_run-1_echo-2_bold.json
+        - relation: dd0e2c99669e92efeecb0ef43e0f94b3
+          name: sub-013_task-rest_run-1_echo-2_bold.nii
+        - relation: 64c1f677782135ea0fa494767c387168
+          name: sub-013_task-rest_run-1_echo-3_bold.json
+        - relation: afbcd0293b5deec30840611b2cc6cf31
+          name: sub-013_task-rest_run-1_echo-3_bold.nii
+        - relation: 979fda86b6c63e7652a8985cae52adf9
+          name: sub-013_task-rest_run-1_physio.json
+        - relation: def5bd7e52762f2163b0d5ec6217b362
+          name: sub-013_task-rest_run-1_physio.tsv.gz
+        - relation: 42c0cb9985346cd68316fcbe48a8f368
+          name: sub-013_task-rest_run-2_echo-1_bold.json
+        - relation: 43cfafd2ae5359fb8e447fa19f19c36c
+          name: sub-013_task-rest_run-2_echo-1_bold.nii
+        - relation: d8d7338d9fe7676ffc6afef85edb81c9
+          name: sub-013_task-rest_run-2_echo-2_bold.json
+        - relation: af2f57986f7d007905fcbe99a28f7674
+          name: sub-013_task-rest_run-2_echo-2_bold.nii
+        - relation: 43a8d6de09dbc08e15946c5a02ff7da0
+          name: sub-013_task-rest_run-2_echo-3_bold.json
+        - relation: d10ad38ae6a94e6bd64e73aaa648a10e
+          name: sub-013_task-rest_run-2_echo-3_bold.nii
+        - relation: 325a060b570ee400010c4eccbb4a1359
+          name: sub-013_task-rest_run-2_physio.json
+        - relation: a64f2d494aaf61668dce532ba4a248a6
+          name: sub-013_task-rest_run-2_physio.tsv.gz
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 42da9e5f60b8474657f709ff80423b42
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 42da9e5f60b8474657f709ff80423b42
+      download_url: https://dataverse.nl/api/access/datafile/46508
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 428d8b271dfb0ae1adf5c4e550bd371d
+      byte_size: 1039
+      checksum:
+        algorithm: md5
+        digest: 428d8b271dfb0ae1adf5c4e550bd371d
+      download_url: https://dataverse.nl/api/access/datafile/45647
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b29b1ffd8a68f4cde389e2150cb16e13
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: b29b1ffd8a68f4cde389e2150cb16e13
+      download_url: https://dataverse.nl/api/access/datafile/45416
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e9b416ede6a2a916a3a835654aed276c
+      byte_size: 1039
+      checksum:
+        algorithm: md5
+        digest: e9b416ede6a2a916a3a835654aed276c
+      download_url: https://dataverse.nl/api/access/datafile/45669
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 154468e9d87e1b3daba28c51528aa2eb
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 154468e9d87e1b3daba28c51528aa2eb
+      download_url: https://dataverse.nl/api/access/datafile/45722
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5b6fb06c3743fae4095da2eea36a5464
+      byte_size: 1889
+      checksum:
+        algorithm: md5
+        digest: 5b6fb06c3743fae4095da2eea36a5464
+      download_url: https://dataverse.nl/api/access/datafile/46604
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 39a8655efa4164001f70630f578860b5
+      byte_size: 1046
+      checksum:
+        algorithm: md5
+        digest: 39a8655efa4164001f70630f578860b5
+      download_url: https://dataverse.nl/api/access/datafile/45673
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a5eb50a3b6d8bd2d9b9afa4af09a1672
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: a5eb50a3b6d8bd2d9b9afa4af09a1672
+      download_url: https://dataverse.nl/api/access/datafile/45132
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2d58a070af22c624dc461557f839120a
+      byte_size: 1046
+      checksum:
+        algorithm: md5
+        digest: 2d58a070af22c624dc461557f839120a
+      download_url: https://dataverse.nl/api/access/datafile/46169
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: db16713e31fcb088bf8c209cf2ccadd8
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: db16713e31fcb088bf8c209cf2ccadd8
+      download_url: https://dataverse.nl/api/access/datafile/45234
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d71aa1888f2c0b09ac19b1ba85089fb3
+      byte_size: 1046
+      checksum:
+        algorithm: md5
+        digest: d71aa1888f2c0b09ac19b1ba85089fb3
+      download_url: https://dataverse.nl/api/access/datafile/45830
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 612187d0f7bc9a6ca680efe80b47802d
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 612187d0f7bc9a6ca680efe80b47802d
+      download_url: https://dataverse.nl/api/access/datafile/45369
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: adb70a52e07794ff600c3039e4773864
+      byte_size: 178
+      checksum:
+        algorithm: md5
+        digest: adb70a52e07794ff600c3039e4773864
+      download_url: https://dataverse.nl/api/access/datafile/46591
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b0f5c8f13d597a094a1aeb3c162588dd
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: b0f5c8f13d597a094a1aeb3c162588dd
+      download_url: https://dataverse.nl/api/access/datafile/46227
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: cbda14078ebecf0cb7dbce7c2f491725
+      byte_size: 453405
+      checksum:
+        algorithm: md5
+        digest: cbda14078ebecf0cb7dbce7c2f491725
+      download_url: https://dataverse.nl/api/access/datafile/46231
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d0f1d46c90bc3ff7fddcfec9826bbc14
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: d0f1d46c90bc3ff7fddcfec9826bbc14
+      download_url: https://dataverse.nl/api/access/datafile/46264
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6035e0d678f0067761fcca4c5b7c0bea
+      byte_size: 484357
+      checksum:
+        algorithm: md5
+        digest: 6035e0d678f0067761fcca4c5b7c0bea
+      download_url: https://dataverse.nl/api/access/datafile/46134
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ab12231bb38f998b0c74148deecc6053
+      byte_size: 1035
+      checksum:
+        algorithm: md5
+        digest: ab12231bb38f998b0c74148deecc6053
+      download_url: https://dataverse.nl/api/access/datafile/45955
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2c0e630b0a1184a651e7c22bb47dfdf0
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 2c0e630b0a1184a651e7c22bb47dfdf0
+      download_url: https://dataverse.nl/api/access/datafile/45946
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 9ca509e0c01261e7c3ed94338394f0ca
+      byte_size: 1035
+      checksum:
+        algorithm: md5
+        digest: 9ca509e0c01261e7c3ed94338394f0ca
+      download_url: https://dataverse.nl/api/access/datafile/45535
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 3ad4a140f2c76f0f5617eca438b2a82e
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 3ad4a140f2c76f0f5617eca438b2a82e
+      download_url: https://dataverse.nl/api/access/datafile/45493
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4a16fccd84cf4de9f19e99c54e681ddd
+      byte_size: 1035
+      checksum:
+        algorithm: md5
+        digest: 4a16fccd84cf4de9f19e99c54e681ddd
+      download_url: https://dataverse.nl/api/access/datafile/46214
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8fadb476f9c9a61003e24e404e7c9237
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 8fadb476f9c9a61003e24e404e7c9237
+      download_url: https://dataverse.nl/api/access/datafile/45521
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f2f1ec4918c4fed24c7cab1b3cd4a67f
+      byte_size: 164
+      checksum:
+        algorithm: md5
+        digest: f2f1ec4918c4fed24c7cab1b3cd4a67f
+      download_url: https://dataverse.nl/api/access/datafile/46579
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a02e3e3953d7f52cab57250d2114050e
+      byte_size: 1043
+      checksum:
+        algorithm: md5
+        digest: a02e3e3953d7f52cab57250d2114050e
+      download_url: https://dataverse.nl/api/access/datafile/45106
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 256e93aa12107151a7656df8208f8f82
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 256e93aa12107151a7656df8208f8f82
+      download_url: https://dataverse.nl/api/access/datafile/45347
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 488c3478ab3a82b0040606e7792083dc
+      byte_size: 1043
+      checksum:
+        algorithm: md5
+        digest: 488c3478ab3a82b0040606e7792083dc
+      download_url: https://dataverse.nl/api/access/datafile/46094
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 057370dbee8f6dd21a7b8c5a51782ec4
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 057370dbee8f6dd21a7b8c5a51782ec4
+      download_url: https://dataverse.nl/api/access/datafile/46292
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6b02ab76f155bb7170609f6ff2449f2e
+      byte_size: 1043
+      checksum:
+        algorithm: md5
+        digest: 6b02ab76f155bb7170609f6ff2449f2e
+      download_url: https://dataverse.nl/api/access/datafile/45731
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 147b61f47296003c21ab27a66ef64aad
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 147b61f47296003c21ab27a66ef64aad
+      download_url: https://dataverse.nl/api/access/datafile/45954
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 284434bd2be53609b41ff2d7bcaf33b2
+      byte_size: 179
+      checksum:
+        algorithm: md5
+        digest: 284434bd2be53609b41ff2d7bcaf33b2
+      download_url: https://dataverse.nl/api/access/datafile/46568
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 0e63bbb9fdc6ec15fb2ed4287485919b
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 0e63bbb9fdc6ec15fb2ed4287485919b
+      download_url: https://dataverse.nl/api/access/datafile/45422
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5eabf83c020779e7cf2d45e8a89cc7fa
+      byte_size: 454645
+      checksum:
+        algorithm: md5
+        digest: 5eabf83c020779e7cf2d45e8a89cc7fa
+      download_url: https://dataverse.nl/api/access/datafile/45571
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 735f2308bddbdd5c49117730a5de9d94
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 735f2308bddbdd5c49117730a5de9d94
+      download_url: https://dataverse.nl/api/access/datafile/45280
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 56f78b4bf78e6f5bbea9f758b867bb75
+      byte_size: 522038
+      checksum:
+        algorithm: md5
+        digest: 56f78b4bf78e6f5bbea9f758b867bb75
+      download_url: https://dataverse.nl/api/access/datafile/45644
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d04baff7ec38efc1cf1c7dd5f3d88863
+      byte_size: 1026
+      checksum:
+        algorithm: md5
+        digest: d04baff7ec38efc1cf1c7dd5f3d88863
+      download_url: https://dataverse.nl/api/access/datafile/46374
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5351444b82f30e3188c4afce97b5636a
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 5351444b82f30e3188c4afce97b5636a
+      download_url: https://dataverse.nl/api/access/datafile/46172
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c76360cc45e8f6240d909fdce03aab99
+      byte_size: 1026
+      checksum:
+        algorithm: md5
+        digest: c76360cc45e8f6240d909fdce03aab99
+      download_url: https://dataverse.nl/api/access/datafile/46435
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: dd0e2c99669e92efeecb0ef43e0f94b3
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: dd0e2c99669e92efeecb0ef43e0f94b3
+      download_url: https://dataverse.nl/api/access/datafile/46108
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 64c1f677782135ea0fa494767c387168
+      byte_size: 1026
+      checksum:
+        algorithm: md5
+        digest: 64c1f677782135ea0fa494767c387168
+      download_url: https://dataverse.nl/api/access/datafile/46437
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: afbcd0293b5deec30840611b2cc6cf31
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: afbcd0293b5deec30840611b2cc6cf31
+      download_url: https://dataverse.nl/api/access/datafile/46321
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 979fda86b6c63e7652a8985cae52adf9
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 979fda86b6c63e7652a8985cae52adf9
+      download_url: https://dataverse.nl/api/access/datafile/45645
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: def5bd7e52762f2163b0d5ec6217b362
+      byte_size: 453506
+      checksum:
+        algorithm: md5
+        digest: def5bd7e52762f2163b0d5ec6217b362
+      download_url: https://dataverse.nl/api/access/datafile/45151
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 42c0cb9985346cd68316fcbe48a8f368
+      byte_size: 1025
+      checksum:
+        algorithm: md5
+        digest: 42c0cb9985346cd68316fcbe48a8f368
+      download_url: https://dataverse.nl/api/access/datafile/46023
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 43cfafd2ae5359fb8e447fa19f19c36c
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 43cfafd2ae5359fb8e447fa19f19c36c
+      download_url: https://dataverse.nl/api/access/datafile/45624
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d8d7338d9fe7676ffc6afef85edb81c9
+      byte_size: 1025
+      checksum:
+        algorithm: md5
+        digest: d8d7338d9fe7676ffc6afef85edb81c9
+      download_url: https://dataverse.nl/api/access/datafile/45885
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: af2f57986f7d007905fcbe99a28f7674
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: af2f57986f7d007905fcbe99a28f7674
+      download_url: https://dataverse.nl/api/access/datafile/45262
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 43a8d6de09dbc08e15946c5a02ff7da0
+      byte_size: 1025
+      checksum:
+        algorithm: md5
+        digest: 43a8d6de09dbc08e15946c5a02ff7da0
+      download_url: https://dataverse.nl/api/access/datafile/45884
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d10ad38ae6a94e6bd64e73aaa648a10e
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: d10ad38ae6a94e6bd64e73aaa648a10e
+      download_url: https://dataverse.nl/api/access/datafile/46048
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 325a060b570ee400010c4eccbb4a1359
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 325a060b570ee400010c4eccbb4a1359
+      download_url: https://dataverse.nl/api/access/datafile/45948
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a64f2d494aaf61668dce532ba4a248a6
+      byte_size: 451134
+      checksum:
+        algorithm: md5
+        digest: a64f2d494aaf61668dce532ba4a248a6
+      download_url: https://dataverse.nl/api/access/datafile/45809
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 88afdfebbc04230478e37729e2b3f721
+      byte_size: 20736352
+      checksum:
+        algorithm: md5
+        digest: 88afdfebbc04230478e37729e2b3f721
+      download_url: https://dataverse.nl/api/access/datafile/46499
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-015/
+      qualified_part:
+        - relation: sub-015/anat/
+          name: anat
+        - relation: sub-015/func/
+          name: func
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-015/anat/
+      qualified_part:
+        - relation: 88afdfebbc04230478e37729e2b3f721
+          name: sub-015_T1w.nii
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e34120816cd5c0bdbcd0ad658edbba83
+      byte_size: 1042
+      checksum:
+        algorithm: md5
+        digest: e34120816cd5c0bdbcd0ad658edbba83
+      download_url: https://dataverse.nl/api/access/datafile/45114
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-015/func/
+      qualified_part:
+        - relation: e34120816cd5c0bdbcd0ad658edbba83
+          name: sub-015_task-emotionProcessing_echo-1_bold.json
+        - relation: c4f4862cfe0ec835801044fdef643eb8
+          name: sub-015_task-emotionProcessing_echo-1_bold.nii
+        - relation: da28d9f7598921b29c7c8b1cfde51760
+          name: sub-015_task-emotionProcessing_echo-2_bold.json
+        - relation: 6350675b0a5449fc341702a1e797a496
+          name: sub-015_task-emotionProcessing_echo-2_bold.nii
+        - relation: 85be727178c6906ab4191aa061d7e062
+          name: sub-015_task-emotionProcessing_echo-3_bold.json
+        - relation: ea75db2b708aa51f91cfe0385e2e40d7
+          name: sub-015_task-emotionProcessing_echo-3_bold.nii
+        - relation: 326ca4adf81e609245fe034068456435
+          name: sub-015_task-emotionProcessing_events.tsv.gz
+        - relation: 872a7f47690c97733de490f79c640f98
+          name: sub-015_task-emotionProcessingImagined_echo-1_bold.json
+        - relation: 1955df590f59261e51b1223ac656275c
+          name: sub-015_task-emotionProcessingImagined_echo-1_bold.nii
+        - relation: a224651fde289975bbb82313bd6c150f
+          name: sub-015_task-emotionProcessingImagined_echo-2_bold.json
+        - relation: ffcc052a264c93f46d1d92789ab31ae8
+          name: sub-015_task-emotionProcessingImagined_echo-2_bold.nii
+        - relation: cfc596e4689c6c034a6f856db2cb5b97
+          name: sub-015_task-emotionProcessingImagined_echo-3_bold.json
+        - relation: 96a0121b2b151d673be11a230c686734
+          name: sub-015_task-emotionProcessingImagined_echo-3_bold.nii
+        - relation: 1c79205bc8559203086dc94a4b0bb65e
+          name: sub-015_task-emotionProcessingImagined_events.tsv.gz
+        - relation: 3d4d62a9a2163fb86392bbf84b5f859d
+          name: sub-015_task-emotionProcessingImagined_physio.json
+        - relation: 6133d70b03c4f51c70e396973ea82385
+          name: sub-015_task-emotionProcessingImagined_physio.tsv.gz
+        - relation: 8feb93770421265f6f1661f8c6ec04ff
+          name: sub-015_task-emotionProcessing_physio.json
+        - relation: 137568dffa4ffbc20f1f6fa6f39cfe55
+          name: sub-015_task-emotionProcessing_physio.tsv.gz
+        - relation: b89ec3da1b58f481388a5f3fcc8f4829
+          name: sub-015_task-fingerTapping_echo-1_bold.json
+        - relation: 8762710b3a1640653f95ac0be249be19
+          name: sub-015_task-fingerTapping_echo-1_bold.nii
+        - relation: 5fb29bdd93aef561498e3589cb02f3cf
+          name: sub-015_task-fingerTapping_echo-2_bold.json
+        - relation: 74c02f0a65f121ab49d411d45328e0b1
+          name: sub-015_task-fingerTapping_echo-2_bold.nii
+        - relation: 3f4552ae365c2cb7475c6c86cbf6c38e
+          name: sub-015_task-fingerTapping_echo-3_bold.json
+        - relation: 5207fe7a02f624ba589113d071dfeca6
+          name: sub-015_task-fingerTapping_echo-3_bold.nii
+        - relation: 5e35a4bc332d46f5a7a5a9c43e484528
+          name: sub-015_task-fingerTapping_events.tsv.gz
+        - relation: 1d1f6527f07c9a5e0d31945da0845d7d
+          name: sub-015_task-fingerTappingImagined_echo-1_bold.json
+        - relation: 5f68b6fb473779bdbff68a8bad9fa6b7
+          name: sub-015_task-fingerTappingImagined_echo-1_bold.nii
+        - relation: bd90e2394796a552e249cd243d132138
+          name: sub-015_task-fingerTappingImagined_echo-2_bold.json
+        - relation: fe551edd889621ed399f7326c4226966
+          name: sub-015_task-fingerTappingImagined_echo-2_bold.nii
+        - relation: 18d87d036fbfdeda251d459b3b06edfa
+          name: sub-015_task-fingerTappingImagined_echo-3_bold.json
+        - relation: 989e2e3ef6fa5bc0c0a66a160ba865b3
+          name: sub-015_task-fingerTappingImagined_echo-3_bold.nii
+        - relation: c443bfaaf23700ea97fe30cec70c288d
+          name: sub-015_task-fingerTappingImagined_events.tsv.gz
+        - relation: c2ddbb68d9d67c56140f6bb9010eedfc
+          name: sub-015_task-fingerTappingImagined_physio.json
+        - relation: da35b5b1491a0f48718389a2705f281a
+          name: sub-015_task-fingerTappingImagined_physio.tsv.gz
+        - relation: ddbfe6f792ffd8a9f2188637ea838e76
+          name: sub-015_task-fingerTapping_physio.json
+        - relation: 8193c1d45a3b81190ed3f359256b9dae
+          name: sub-015_task-fingerTapping_physio.tsv.gz
+        - relation: b2008f846b94285f46b7ff0aa4b8116b
+          name: sub-015_task-rest_run-1_echo-1_bold.json
+        - relation: a5264529e7bc3b589a9fd9564a809639
+          name: sub-015_task-rest_run-1_echo-1_bold.nii
+        - relation: 0fab7eb93c9cb4e9412fdf078ced4d5f
+          name: sub-015_task-rest_run-1_echo-2_bold.json
+        - relation: f8fd22cfecbc61a942031c81077dafc3
+          name: sub-015_task-rest_run-1_echo-2_bold.nii
+        - relation: 771d2ee1db43888675efa14349f68ca0
+          name: sub-015_task-rest_run-1_echo-3_bold.json
+        - relation: cef947dcd2cbf4567fb5189670544df5
+          name: sub-015_task-rest_run-1_echo-3_bold.nii
+        - relation: d44f0f7ec71d61a858c1daaee5cfb10c
+          name: sub-015_task-rest_run-1_physio.json
+        - relation: 62335324d50f4057f2958b816a39ac22
+          name: sub-015_task-rest_run-1_physio.tsv.gz
+        - relation: 57e0d4362eca162d5911e2d54923d9c3
+          name: sub-015_task-rest_run-2_echo-1_bold.json
+        - relation: d57f18c07866ce290bd12113c8eea00a
+          name: sub-015_task-rest_run-2_echo-1_bold.nii
+        - relation: e3bacec427ab14cf578613c06c37d0e6
+          name: sub-015_task-rest_run-2_echo-2_bold.json
+        - relation: 5d3d93fc7d0c2ea6252499f8960b1723
+          name: sub-015_task-rest_run-2_echo-2_bold.nii
+        - relation: bebbfe796e2da76a7f6690b6ab54f03a
+          name: sub-015_task-rest_run-2_echo-3_bold.json
+        - relation: 9c0d403a28c6bd3600ca21f8dc4095dc
+          name: sub-015_task-rest_run-2_echo-3_bold.nii
+        - relation: 986bbaac9424c364df4be2bda84111c2
+          name: sub-015_task-rest_run-2_physio.json
+        - relation: ba40101046df40b0be95469ba89170f6
+          name: sub-015_task-rest_run-2_physio.tsv.gz
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c4f4862cfe0ec835801044fdef643eb8
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: c4f4862cfe0ec835801044fdef643eb8
+      download_url: https://dataverse.nl/api/access/datafile/46163
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: da28d9f7598921b29c7c8b1cfde51760
+      byte_size: 1042
+      checksum:
+        algorithm: md5
+        digest: da28d9f7598921b29c7c8b1cfde51760
+      download_url: https://dataverse.nl/api/access/datafile/45686
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6350675b0a5449fc341702a1e797a496
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 6350675b0a5449fc341702a1e797a496
+      download_url: https://dataverse.nl/api/access/datafile/46185
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 85be727178c6906ab4191aa061d7e062
+      byte_size: 1042
+      checksum:
+        algorithm: md5
+        digest: 85be727178c6906ab4191aa061d7e062
+      download_url: https://dataverse.nl/api/access/datafile/46041
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ea75db2b708aa51f91cfe0385e2e40d7
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: ea75db2b708aa51f91cfe0385e2e40d7
+      download_url: https://dataverse.nl/api/access/datafile/46251
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 326ca4adf81e609245fe034068456435
+      byte_size: 1880
+      checksum:
+        algorithm: md5
+        digest: 326ca4adf81e609245fe034068456435
+      download_url: https://dataverse.nl/api/access/datafile/46586
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 872a7f47690c97733de490f79c640f98
+      byte_size: 1050
+      checksum:
+        algorithm: md5
+        digest: 872a7f47690c97733de490f79c640f98
+      download_url: https://dataverse.nl/api/access/datafile/46146
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1955df590f59261e51b1223ac656275c
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 1955df590f59261e51b1223ac656275c
+      download_url: https://dataverse.nl/api/access/datafile/46447
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a224651fde289975bbb82313bd6c150f
+      byte_size: 1050
+      checksum:
+        algorithm: md5
+        digest: a224651fde289975bbb82313bd6c150f
+      download_url: https://dataverse.nl/api/access/datafile/45288
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ffcc052a264c93f46d1d92789ab31ae8
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: ffcc052a264c93f46d1d92789ab31ae8
+      download_url: https://dataverse.nl/api/access/datafile/46357
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: cfc596e4689c6c034a6f856db2cb5b97
+      byte_size: 1050
+      checksum:
+        algorithm: md5
+        digest: cfc596e4689c6c034a6f856db2cb5b97
+      download_url: https://dataverse.nl/api/access/datafile/45853
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 96a0121b2b151d673be11a230c686734
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 96a0121b2b151d673be11a230c686734
+      download_url: https://dataverse.nl/api/access/datafile/45478
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1c79205bc8559203086dc94a4b0bb65e
+      byte_size: 177
+      checksum:
+        algorithm: md5
+        digest: 1c79205bc8559203086dc94a4b0bb65e
+      download_url: https://dataverse.nl/api/access/datafile/46653
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 3d4d62a9a2163fb86392bbf84b5f859d
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 3d4d62a9a2163fb86392bbf84b5f859d
+      download_url: https://dataverse.nl/api/access/datafile/46362
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6133d70b03c4f51c70e396973ea82385
+      byte_size: 472958
+      checksum:
+        algorithm: md5
+        digest: 6133d70b03c4f51c70e396973ea82385
+      download_url: https://dataverse.nl/api/access/datafile/46067
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8feb93770421265f6f1661f8c6ec04ff
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 8feb93770421265f6f1661f8c6ec04ff
+      download_url: https://dataverse.nl/api/access/datafile/45258
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 137568dffa4ffbc20f1f6fa6f39cfe55
+      byte_size: 539456
+      checksum:
+        algorithm: md5
+        digest: 137568dffa4ffbc20f1f6fa6f39cfe55
+      download_url: https://dataverse.nl/api/access/datafile/45573
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b89ec3da1b58f481388a5f3fcc8f4829
+      byte_size: 1038
+      checksum:
+        algorithm: md5
+        digest: b89ec3da1b58f481388a5f3fcc8f4829
+      download_url: https://dataverse.nl/api/access/datafile/45970
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8762710b3a1640653f95ac0be249be19
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 8762710b3a1640653f95ac0be249be19
+      download_url: https://dataverse.nl/api/access/datafile/45184
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5fb29bdd93aef561498e3589cb02f3cf
+      byte_size: 1038
+      checksum:
+        algorithm: md5
+        digest: 5fb29bdd93aef561498e3589cb02f3cf
+      download_url: https://dataverse.nl/api/access/datafile/46429
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 74c02f0a65f121ab49d411d45328e0b1
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 74c02f0a65f121ab49d411d45328e0b1
+      download_url: https://dataverse.nl/api/access/datafile/45815
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 3f4552ae365c2cb7475c6c86cbf6c38e
+      byte_size: 1038
+      checksum:
+        algorithm: md5
+        digest: 3f4552ae365c2cb7475c6c86cbf6c38e
+      download_url: https://dataverse.nl/api/access/datafile/45580
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5207fe7a02f624ba589113d071dfeca6
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 5207fe7a02f624ba589113d071dfeca6
+      download_url: https://dataverse.nl/api/access/datafile/45582
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5e35a4bc332d46f5a7a5a9c43e484528
+      byte_size: 164
+      checksum:
+        algorithm: md5
+        digest: 5e35a4bc332d46f5a7a5a9c43e484528
+      download_url: https://dataverse.nl/api/access/datafile/46603
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1d1f6527f07c9a5e0d31945da0845d7d
+      byte_size: 1046
+      checksum:
+        algorithm: md5
+        digest: 1d1f6527f07c9a5e0d31945da0845d7d
+      download_url: https://dataverse.nl/api/access/datafile/45900
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5f68b6fb473779bdbff68a8bad9fa6b7
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 5f68b6fb473779bdbff68a8bad9fa6b7
+      download_url: https://dataverse.nl/api/access/datafile/45391
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: bd90e2394796a552e249cd243d132138
+      byte_size: 1046
+      checksum:
+        algorithm: md5
+        digest: bd90e2394796a552e249cd243d132138
+      download_url: https://dataverse.nl/api/access/datafile/45819
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: fe551edd889621ed399f7326c4226966
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: fe551edd889621ed399f7326c4226966
+      download_url: https://dataverse.nl/api/access/datafile/45473
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 18d87d036fbfdeda251d459b3b06edfa
+      byte_size: 1046
+      checksum:
+        algorithm: md5
+        digest: 18d87d036fbfdeda251d459b3b06edfa
+      download_url: https://dataverse.nl/api/access/datafile/46118
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 989e2e3ef6fa5bc0c0a66a160ba865b3
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 989e2e3ef6fa5bc0c0a66a160ba865b3
+      download_url: https://dataverse.nl/api/access/datafile/46388
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c443bfaaf23700ea97fe30cec70c288d
+      byte_size: 177
+      checksum:
+        algorithm: md5
+        digest: c443bfaaf23700ea97fe30cec70c288d
+      download_url: https://dataverse.nl/api/access/datafile/46556
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c2ddbb68d9d67c56140f6bb9010eedfc
+      byte_size: 142
+      checksum:
+        algorithm: md5
+        digest: c2ddbb68d9d67c56140f6bb9010eedfc
+      download_url: https://dataverse.nl/api/access/datafile/45147
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: da35b5b1491a0f48718389a2705f281a
+      byte_size: 463339
+      checksum:
+        algorithm: md5
+        digest: da35b5b1491a0f48718389a2705f281a
+      download_url: https://dataverse.nl/api/access/datafile/45589
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ddbfe6f792ffd8a9f2188637ea838e76
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: ddbfe6f792ffd8a9f2188637ea838e76
+      download_url: https://dataverse.nl/api/access/datafile/45332
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8193c1d45a3b81190ed3f359256b9dae
+      byte_size: 525902
+      checksum:
+        algorithm: md5
+        digest: 8193c1d45a3b81190ed3f359256b9dae
+      download_url: https://dataverse.nl/api/access/datafile/45903
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b2008f846b94285f46b7ff0aa4b8116b
+      byte_size: 1029
+      checksum:
+        algorithm: md5
+        digest: b2008f846b94285f46b7ff0aa4b8116b
+      download_url: https://dataverse.nl/api/access/datafile/45963
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a5264529e7bc3b589a9fd9564a809639
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: a5264529e7bc3b589a9fd9564a809639
+      download_url: https://dataverse.nl/api/access/datafile/45993
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 0fab7eb93c9cb4e9412fdf078ced4d5f
+      byte_size: 1029
+      checksum:
+        algorithm: md5
+        digest: 0fab7eb93c9cb4e9412fdf078ced4d5f
+      download_url: https://dataverse.nl/api/access/datafile/46074
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f8fd22cfecbc61a942031c81077dafc3
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: f8fd22cfecbc61a942031c81077dafc3
+      download_url: https://dataverse.nl/api/access/datafile/45583
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 771d2ee1db43888675efa14349f68ca0
+      byte_size: 1029
+      checksum:
+        algorithm: md5
+        digest: 771d2ee1db43888675efa14349f68ca0
+      download_url: https://dataverse.nl/api/access/datafile/45320
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: cef947dcd2cbf4567fb5189670544df5
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: cef947dcd2cbf4567fb5189670544df5
+      download_url: https://dataverse.nl/api/access/datafile/45790
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d44f0f7ec71d61a858c1daaee5cfb10c
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: d44f0f7ec71d61a858c1daaee5cfb10c
+      download_url: https://dataverse.nl/api/access/datafile/45519
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 62335324d50f4057f2958b816a39ac22
+      byte_size: 446679
+      checksum:
+        algorithm: md5
+        digest: 62335324d50f4057f2958b816a39ac22
+      download_url: https://dataverse.nl/api/access/datafile/45791
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 57e0d4362eca162d5911e2d54923d9c3
+      byte_size: 1029
+      checksum:
+        algorithm: md5
+        digest: 57e0d4362eca162d5911e2d54923d9c3
+      download_url: https://dataverse.nl/api/access/datafile/45657
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d57f18c07866ce290bd12113c8eea00a
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: d57f18c07866ce290bd12113c8eea00a
+      download_url: https://dataverse.nl/api/access/datafile/45782
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e3bacec427ab14cf578613c06c37d0e6
+      byte_size: 1029
+      checksum:
+        algorithm: md5
+        digest: e3bacec427ab14cf578613c06c37d0e6
+      download_url: https://dataverse.nl/api/access/datafile/46145
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5d3d93fc7d0c2ea6252499f8960b1723
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 5d3d93fc7d0c2ea6252499f8960b1723
+      download_url: https://dataverse.nl/api/access/datafile/45157
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: bebbfe796e2da76a7f6690b6ab54f03a
+      byte_size: 1029
+      checksum:
+        algorithm: md5
+        digest: bebbfe796e2da76a7f6690b6ab54f03a
+      download_url: https://dataverse.nl/api/access/datafile/46052
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 9c0d403a28c6bd3600ca21f8dc4095dc
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 9c0d403a28c6bd3600ca21f8dc4095dc
+      download_url: https://dataverse.nl/api/access/datafile/46343
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 986bbaac9424c364df4be2bda84111c2
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 986bbaac9424c364df4be2bda84111c2
+      download_url: https://dataverse.nl/api/access/datafile/45439
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ba40101046df40b0be95469ba89170f6
+      byte_size: 459996
+      checksum:
+        algorithm: md5
+        digest: ba40101046df40b0be95469ba89170f6
+      download_url: https://dataverse.nl/api/access/datafile/45368
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 31d8026e20e90e8eb58f5c8369da33b9
+      byte_size: 20736352
+      checksum:
+        algorithm: md5
+        digest: 31d8026e20e90e8eb58f5c8369da33b9
+      download_url: https://dataverse.nl/api/access/datafile/45246
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-016/
+      qualified_part:
+        - relation: sub-016/anat/
+          name: anat
+        - relation: sub-016/func/
+          name: func
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-016/anat/
+      qualified_part:
+        - relation: 31d8026e20e90e8eb58f5c8369da33b9
+          name: sub-016_T1w.nii
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 08e8474c185376d0779ff3d59b2bff3c
+      byte_size: 1042
+      checksum:
+        algorithm: md5
+        digest: 08e8474c185376d0779ff3d59b2bff3c
+      download_url: https://dataverse.nl/api/access/datafile/45461
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-016/func/
+      qualified_part:
+        - relation: 08e8474c185376d0779ff3d59b2bff3c
+          name: sub-016_task-emotionProcessing_echo-1_bold.json
+        - relation: b0ae1b4660b02ce44f6fe8fb2e376a8b
+          name: sub-016_task-emotionProcessing_echo-1_bold.nii
+        - relation: ed1dee63197dd55d6e072e2f6f5405b2
+          name: sub-016_task-emotionProcessing_echo-2_bold.json
+        - relation: 80aa8e8b5b109e4a0ffff5a34a2fd34e
+          name: sub-016_task-emotionProcessing_echo-2_bold.nii
+        - relation: 38f5eaea9660539ecdd735ca35ab616e
+          name: sub-016_task-emotionProcessing_echo-3_bold.json
+        - relation: 40cb433e5c6fb302f54f6fb0e6facf33
+          name: sub-016_task-emotionProcessing_echo-3_bold.nii
+        - relation: dac29a68dc5c3f4f2ca10ec46f11c7eb
+          name: sub-016_task-emotionProcessing_events.tsv.gz
+        - relation: 3bb868574acd187ae6e7bbef7107f316
+          name: sub-016_task-emotionProcessingImagined_echo-1_bold.json
+        - relation: d245b1944f7c9b7a30330096fa9ea2a6
+          name: sub-016_task-emotionProcessingImagined_echo-1_bold.nii
+        - relation: 5f83ec535cdd690e0e325334e30f40fc
+          name: sub-016_task-emotionProcessingImagined_echo-2_bold.json
+        - relation: 8b448020772aa64321a9523fe0afe0a8
+          name: sub-016_task-emotionProcessingImagined_echo-2_bold.nii
+        - relation: 6751befbdf215f731ce2023a98546f1a
+          name: sub-016_task-emotionProcessingImagined_echo-3_bold.json
+        - relation: f2aa0fad61d8596559792ed080af9155
+          name: sub-016_task-emotionProcessingImagined_echo-3_bold.nii
+        - relation: c759824e08e5265a576a3ed30c41c9a8
+          name: sub-016_task-emotionProcessingImagined_events.tsv.gz
+        - relation: 7ffdf8881f8ca0fb33e3e295a0dfcbed
+          name: sub-016_task-emotionProcessingImagined_physio.json
+        - relation: 23ad5834ff7d3176559ce62569dbfdb1
+          name: sub-016_task-emotionProcessingImagined_physio.tsv.gz
+        - relation: 845c1ac8b70929f102b23512388aaae0
+          name: sub-016_task-emotionProcessing_physio.json
+        - relation: af36d726b8fc5b7ba253e32869ca16bc
+          name: sub-016_task-emotionProcessing_physio.tsv.gz
+        - relation: 9b8c71edb5f51fd9c5fa7f4be9b6972d
+          name: sub-016_task-fingerTapping_echo-1_bold.json
+        - relation: 444724a76166a7d01752c3139a54efce
+          name: sub-016_task-fingerTapping_echo-1_bold.nii
+        - relation: 46afa05e3f9bcc5a620f9a5e877c4002
+          name: sub-016_task-fingerTapping_echo-2_bold.json
+        - relation: 424531972f2df2146e7b9f180efadd95
+          name: sub-016_task-fingerTapping_echo-2_bold.nii
+        - relation: fac4ea384b9a185e10043873f781f607
+          name: sub-016_task-fingerTapping_echo-3_bold.json
+        - relation: abe4380cbfbb8d05eb71d189bbc7e370
+          name: sub-016_task-fingerTapping_echo-3_bold.nii
+        - relation: d314343e2900e7ba82ff56fdfa53e54d
+          name: sub-016_task-fingerTapping_events.tsv.gz
+        - relation: 4445e300960c70aeac5820f704add828
+          name: sub-016_task-fingerTappingImagined_echo-1_bold.json
+        - relation: 712ffd316600020031eeb25ce0ad1048
+          name: sub-016_task-fingerTappingImagined_echo-1_bold.nii
+        - relation: fa36384d47253e6f49fd1c3a84ce8ae1
+          name: sub-016_task-fingerTappingImagined_echo-2_bold.json
+        - relation: c3d90e1a44f369ee830fbc925846242a
+          name: sub-016_task-fingerTappingImagined_echo-2_bold.nii
+        - relation: 9445320d6da082a454ed1766fa19d3f5
+          name: sub-016_task-fingerTappingImagined_echo-3_bold.json
+        - relation: c586fd28791472c2ebdc9c657ffad17b
+          name: sub-016_task-fingerTappingImagined_echo-3_bold.nii
+        - relation: cfbd687636039bc92fa556dad233fc4f
+          name: sub-016_task-fingerTappingImagined_events.tsv.gz
+        - relation: 034768366c7e99c5ae5c7bd5d8062feb
+          name: sub-016_task-fingerTappingImagined_physio.json
+        - relation: 6438acf1576ca083bf8d44530648aa9a
+          name: sub-016_task-fingerTappingImagined_physio.tsv.gz
+        - relation: 41386e28ee5edf34ed2e10d5cf61bf41
+          name: sub-016_task-fingerTapping_physio.json
+        - relation: 6e0d586e839d86a2badb6b80926b641f
+          name: sub-016_task-fingerTapping_physio.tsv.gz
+        - relation: 48a0f7170aa013d14aeb303e3f856824
+          name: sub-016_task-rest_run-1_echo-1_bold.json
+        - relation: f532551700f959a6b9a9b78298d8ed33
+          name: sub-016_task-rest_run-1_echo-1_bold.nii
+        - relation: 4ae0b674baa370cd8825e53f413bab2e
+          name: sub-016_task-rest_run-1_echo-2_bold.json
+        - relation: 0241c09d9cba424e36bed06f41863ccd
+          name: sub-016_task-rest_run-1_echo-2_bold.nii
+        - relation: 963cce7febb74776ab3ec1c60588a5e2
+          name: sub-016_task-rest_run-1_echo-3_bold.json
+        - relation: 655370b635f41840115b4c560492d47e
+          name: sub-016_task-rest_run-1_echo-3_bold.nii
+        - relation: 6f93d507dfb2f0e8d5f1c701e4905883
+          name: sub-016_task-rest_run-1_physio.json
+        - relation: fcee2d47ec8682d2b225e8ab3fb9f04a
+          name: sub-016_task-rest_run-1_physio.tsv.gz
+        - relation: 84cc70775c04a49d194655df552503cc
+          name: sub-016_task-rest_run-2_echo-1_bold.json
+        - relation: 402f8627e49e317bfbe1a2cc698325e5
+          name: sub-016_task-rest_run-2_echo-1_bold.nii
+        - relation: 57434db2ad04582f7f96d8f037069076
+          name: sub-016_task-rest_run-2_echo-2_bold.json
+        - relation: 74ec0685e27a57412cb74d00d60813da
+          name: sub-016_task-rest_run-2_echo-2_bold.nii
+        - relation: 94f7316ef91ade5b966f52c68f6343a5
+          name: sub-016_task-rest_run-2_echo-3_bold.json
+        - relation: 1ac94022b69e64c4ff225f728ec49bc3
+          name: sub-016_task-rest_run-2_echo-3_bold.nii
+        - relation: 6ff54c42753602c542673831aae3e39c
+          name: sub-016_task-rest_run-2_physio.json
+        - relation: 1d6be496d3bb38563acfb4de457cca63
+          name: sub-016_task-rest_run-2_physio.tsv.gz
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b0ae1b4660b02ce44f6fe8fb2e376a8b
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: b0ae1b4660b02ce44f6fe8fb2e376a8b
+      download_url: https://dataverse.nl/api/access/datafile/45447
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ed1dee63197dd55d6e072e2f6f5405b2
+      byte_size: 1042
+      checksum:
+        algorithm: md5
+        digest: ed1dee63197dd55d6e072e2f6f5405b2
+      download_url: https://dataverse.nl/api/access/datafile/45953
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 80aa8e8b5b109e4a0ffff5a34a2fd34e
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 80aa8e8b5b109e4a0ffff5a34a2fd34e
+      download_url: https://dataverse.nl/api/access/datafile/45371
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 38f5eaea9660539ecdd735ca35ab616e
+      byte_size: 1042
+      checksum:
+        algorithm: md5
+        digest: 38f5eaea9660539ecdd735ca35ab616e
+      download_url: https://dataverse.nl/api/access/datafile/46161
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 40cb433e5c6fb302f54f6fb0e6facf33
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 40cb433e5c6fb302f54f6fb0e6facf33
+      download_url: https://dataverse.nl/api/access/datafile/45701
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: dac29a68dc5c3f4f2ca10ec46f11c7eb
+      byte_size: 1898
+      checksum:
+        algorithm: md5
+        digest: dac29a68dc5c3f4f2ca10ec46f11c7eb
+      download_url: https://dataverse.nl/api/access/datafile/46651
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 3bb868574acd187ae6e7bbef7107f316
+      byte_size: 1050
+      checksum:
+        algorithm: md5
+        digest: 3bb868574acd187ae6e7bbef7107f316
+      download_url: https://dataverse.nl/api/access/datafile/45814
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d245b1944f7c9b7a30330096fa9ea2a6
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: d245b1944f7c9b7a30330096fa9ea2a6
+      download_url: https://dataverse.nl/api/access/datafile/46162
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5f83ec535cdd690e0e325334e30f40fc
+      byte_size: 1050
+      checksum:
+        algorithm: md5
+        digest: 5f83ec535cdd690e0e325334e30f40fc
+      download_url: https://dataverse.nl/api/access/datafile/46542
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8b448020772aa64321a9523fe0afe0a8
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 8b448020772aa64321a9523fe0afe0a8
+      download_url: https://dataverse.nl/api/access/datafile/45494
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6751befbdf215f731ce2023a98546f1a
+      byte_size: 1050
+      checksum:
+        algorithm: md5
+        digest: 6751befbdf215f731ce2023a98546f1a
+      download_url: https://dataverse.nl/api/access/datafile/45325
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f2aa0fad61d8596559792ed080af9155
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: f2aa0fad61d8596559792ed080af9155
+      download_url: https://dataverse.nl/api/access/datafile/46187
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c759824e08e5265a576a3ed30c41c9a8
+      byte_size: 174
+      checksum:
+        algorithm: md5
+        digest: c759824e08e5265a576a3ed30c41c9a8
+      download_url: https://dataverse.nl/api/access/datafile/46585
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 7ffdf8881f8ca0fb33e3e295a0dfcbed
+      byte_size: 141
+      checksum:
+        algorithm: md5
+        digest: 7ffdf8881f8ca0fb33e3e295a0dfcbed
+      download_url: https://dataverse.nl/api/access/datafile/45285
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 23ad5834ff7d3176559ce62569dbfdb1
+      byte_size: 459585
+      checksum:
+        algorithm: md5
+        digest: 23ad5834ff7d3176559ce62569dbfdb1
+      download_url: https://dataverse.nl/api/access/datafile/46307
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 845c1ac8b70929f102b23512388aaae0
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 845c1ac8b70929f102b23512388aaae0
+      download_url: https://dataverse.nl/api/access/datafile/46018
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: af36d726b8fc5b7ba253e32869ca16bc
+      byte_size: 446734
+      checksum:
+        algorithm: md5
+        digest: af36d726b8fc5b7ba253e32869ca16bc
+      download_url: https://dataverse.nl/api/access/datafile/45169
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 9b8c71edb5f51fd9c5fa7f4be9b6972d
+      byte_size: 1038
+      checksum:
+        algorithm: md5
+        digest: 9b8c71edb5f51fd9c5fa7f4be9b6972d
+      download_url: https://dataverse.nl/api/access/datafile/46247
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 444724a76166a7d01752c3139a54efce
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 444724a76166a7d01752c3139a54efce
+      download_url: https://dataverse.nl/api/access/datafile/45507
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 46afa05e3f9bcc5a620f9a5e877c4002
+      byte_size: 1038
+      checksum:
+        algorithm: md5
+        digest: 46afa05e3f9bcc5a620f9a5e877c4002
+      download_url: https://dataverse.nl/api/access/datafile/45792
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 424531972f2df2146e7b9f180efadd95
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 424531972f2df2146e7b9f180efadd95
+      download_url: https://dataverse.nl/api/access/datafile/46378
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: fac4ea384b9a185e10043873f781f607
+      byte_size: 1038
+      checksum:
+        algorithm: md5
+        digest: fac4ea384b9a185e10043873f781f607
+      download_url: https://dataverse.nl/api/access/datafile/45844
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: abe4380cbfbb8d05eb71d189bbc7e370
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: abe4380cbfbb8d05eb71d189bbc7e370
+      download_url: https://dataverse.nl/api/access/datafile/45744
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d314343e2900e7ba82ff56fdfa53e54d
+      byte_size: 165
+      checksum:
+        algorithm: md5
+        digest: d314343e2900e7ba82ff56fdfa53e54d
+      download_url: https://dataverse.nl/api/access/datafile/46549
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4445e300960c70aeac5820f704add828
+      byte_size: 1046
+      checksum:
+        algorithm: md5
+        digest: 4445e300960c70aeac5820f704add828
+      download_url: https://dataverse.nl/api/access/datafile/45581
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 712ffd316600020031eeb25ce0ad1048
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 712ffd316600020031eeb25ce0ad1048
+      download_url: https://dataverse.nl/api/access/datafile/45586
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: fa36384d47253e6f49fd1c3a84ce8ae1
+      byte_size: 1046
+      checksum:
+        algorithm: md5
+        digest: fa36384d47253e6f49fd1c3a84ce8ae1
+      download_url: https://dataverse.nl/api/access/datafile/46058
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c3d90e1a44f369ee830fbc925846242a
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: c3d90e1a44f369ee830fbc925846242a
+      download_url: https://dataverse.nl/api/access/datafile/45379
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 9445320d6da082a454ed1766fa19d3f5
+      byte_size: 1046
+      checksum:
+        algorithm: md5
+        digest: 9445320d6da082a454ed1766fa19d3f5
+      download_url: https://dataverse.nl/api/access/datafile/45424
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c586fd28791472c2ebdc9c657ffad17b
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: c586fd28791472c2ebdc9c657ffad17b
+      download_url: https://dataverse.nl/api/access/datafile/45595
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: cfbd687636039bc92fa556dad233fc4f
+      byte_size: 178
+      checksum:
+        algorithm: md5
+        digest: cfbd687636039bc92fa556dad233fc4f
+      download_url: https://dataverse.nl/api/access/datafile/46564
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 034768366c7e99c5ae5c7bd5d8062feb
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 034768366c7e99c5ae5c7bd5d8062feb
+      download_url: https://dataverse.nl/api/access/datafile/45309
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6438acf1576ca083bf8d44530648aa9a
+      byte_size: 458214
+      checksum:
+        algorithm: md5
+        digest: 6438acf1576ca083bf8d44530648aa9a
+      download_url: https://dataverse.nl/api/access/datafile/46129
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 41386e28ee5edf34ed2e10d5cf61bf41
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 41386e28ee5edf34ed2e10d5cf61bf41
+      download_url: https://dataverse.nl/api/access/datafile/45924
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6e0d586e839d86a2badb6b80926b641f
+      byte_size: 372090
+      checksum:
+        algorithm: md5
+        digest: 6e0d586e839d86a2badb6b80926b641f
+      download_url: https://dataverse.nl/api/access/datafile/45695
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 48a0f7170aa013d14aeb303e3f856824
+      byte_size: 1029
+      checksum:
+        algorithm: md5
+        digest: 48a0f7170aa013d14aeb303e3f856824
+      download_url: https://dataverse.nl/api/access/datafile/45793
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f532551700f959a6b9a9b78298d8ed33
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: f532551700f959a6b9a9b78298d8ed33
+      download_url: https://dataverse.nl/api/access/datafile/46004
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4ae0b674baa370cd8825e53f413bab2e
+      byte_size: 1029
+      checksum:
+        algorithm: md5
+        digest: 4ae0b674baa370cd8825e53f413bab2e
+      download_url: https://dataverse.nl/api/access/datafile/46355
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 0241c09d9cba424e36bed06f41863ccd
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 0241c09d9cba424e36bed06f41863ccd
+      download_url: https://dataverse.nl/api/access/datafile/45901
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 963cce7febb74776ab3ec1c60588a5e2
+      byte_size: 1029
+      checksum:
+        algorithm: md5
+        digest: 963cce7febb74776ab3ec1c60588a5e2
+      download_url: https://dataverse.nl/api/access/datafile/46522
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 655370b635f41840115b4c560492d47e
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 655370b635f41840115b4c560492d47e
+      download_url: https://dataverse.nl/api/access/datafile/46224
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6f93d507dfb2f0e8d5f1c701e4905883
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 6f93d507dfb2f0e8d5f1c701e4905883
+      download_url: https://dataverse.nl/api/access/datafile/46241
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: fcee2d47ec8682d2b225e8ab3fb9f04a
+      byte_size: 430389
+      checksum:
+        algorithm: md5
+        digest: fcee2d47ec8682d2b225e8ab3fb9f04a
+      download_url: https://dataverse.nl/api/access/datafile/46289
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 84cc70775c04a49d194655df552503cc
+      byte_size: 1029
+      checksum:
+        algorithm: md5
+        digest: 84cc70775c04a49d194655df552503cc
+      download_url: https://dataverse.nl/api/access/datafile/45370
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 402f8627e49e317bfbe1a2cc698325e5
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 402f8627e49e317bfbe1a2cc698325e5
+      download_url: https://dataverse.nl/api/access/datafile/45523
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 57434db2ad04582f7f96d8f037069076
+      byte_size: 1029
+      checksum:
+        algorithm: md5
+        digest: 57434db2ad04582f7f96d8f037069076
+      download_url: https://dataverse.nl/api/access/datafile/45172
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 74ec0685e27a57412cb74d00d60813da
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 74ec0685e27a57412cb74d00d60813da
+      download_url: https://dataverse.nl/api/access/datafile/45560
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 94f7316ef91ade5b966f52c68f6343a5
+      byte_size: 1029
+      checksum:
+        algorithm: md5
+        digest: 94f7316ef91ade5b966f52c68f6343a5
+      download_url: https://dataverse.nl/api/access/datafile/45895
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1ac94022b69e64c4ff225f728ec49bc3
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 1ac94022b69e64c4ff225f728ec49bc3
+      download_url: https://dataverse.nl/api/access/datafile/45162
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6ff54c42753602c542673831aae3e39c
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 6ff54c42753602c542673831aae3e39c
+      download_url: https://dataverse.nl/api/access/datafile/46368
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1d6be496d3bb38563acfb4de457cca63
+      byte_size: 462641
+      checksum:
+        algorithm: md5
+        digest: 1d6be496d3bb38563acfb4de457cca63
+      download_url: https://dataverse.nl/api/access/datafile/46320
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8a31ce74ffb3bb8218e54828ce1bb7bc
+      byte_size: 20736352
+      checksum:
+        algorithm: md5
+        digest: 8a31ce74ffb3bb8218e54828ce1bb7bc
+      download_url: https://dataverse.nl/api/access/datafile/46093
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-017/
+      qualified_part:
+        - relation: sub-017/anat/
+          name: anat
+        - relation: sub-017/func/
+          name: func
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-017/anat/
+      qualified_part:
+        - relation: 8a31ce74ffb3bb8218e54828ce1bb7bc
+          name: sub-017_T1w.nii
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f0eff72e0e7149911dac1674911c0a53
+      byte_size: 1039
+      checksum:
+        algorithm: md5
+        digest: f0eff72e0e7149911dac1674911c0a53
+      download_url: https://dataverse.nl/api/access/datafile/46090
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-017/func/
+      qualified_part:
+        - relation: f0eff72e0e7149911dac1674911c0a53
+          name: sub-017_task-emotionProcessing_echo-1_bold.json
+        - relation: 49bd6392aabdd13fb1f061d584fdfc5d
+          name: sub-017_task-emotionProcessing_echo-1_bold.nii
+        - relation: c6792ff5c1c23b3515f3f1f9302baf75
+          name: sub-017_task-emotionProcessing_echo-2_bold.json
+        - relation: cfb6e06f72ecb8eabf9cd409edaeaf93
+          name: sub-017_task-emotionProcessing_echo-2_bold.nii
+        - relation: a528b89b95b3f3128e8e98a9237edc64
+          name: sub-017_task-emotionProcessing_echo-3_bold.json
+        - relation: 6f919d3a07df2b44ee4ebf59a04eefad
+          name: sub-017_task-emotionProcessing_echo-3_bold.nii
+        - relation: 512913b1b38ca0f4202f6ca3c3605ab7
+          name: sub-017_task-emotionProcessing_events.tsv.gz
+        - relation: 35681199bfc3e571aae5477ce1191bf3
+          name: sub-017_task-emotionProcessingImagined_echo-1_bold.json
+        - relation: 246521bd5001db167861cf5da9c9468e
+          name: sub-017_task-emotionProcessingImagined_echo-1_bold.nii
+        - relation: cd5b275b00155c6655e6163dc9563bac
+          name: sub-017_task-emotionProcessingImagined_echo-2_bold.json
+        - relation: 193cb8ecc6cd158d8ecd4764aeba0b02
+          name: sub-017_task-emotionProcessingImagined_echo-2_bold.nii
+        - relation: f4c03ab759da66ffb6774913e4bf6c70
+          name: sub-017_task-emotionProcessingImagined_echo-3_bold.json
+        - relation: e1f5d15b62dde1cde99e429788d7be0e
+          name: sub-017_task-emotionProcessingImagined_echo-3_bold.nii
+        - relation: 782ccc689087c2d7ebbac8acd4770997
+          name: sub-017_task-emotionProcessingImagined_events.tsv.gz
+        - relation: d09ab3c66bdfca4f24ca0495469c9b78
+          name: sub-017_task-emotionProcessingImagined_physio.json
+        - relation: 6a2527bd9a7c8b613cef15d92020f475
+          name: sub-017_task-emotionProcessingImagined_physio.tsv.gz
+        - relation: 5ab56953069930dde62e936cca3bb403
+          name: sub-017_task-emotionProcessing_physio.json
+        - relation: d2d2f6899051f0b2703084793376566a
+          name: sub-017_task-emotionProcessing_physio.tsv.gz
+        - relation: a81c54ce06347f213b53121dae0893cb
+          name: sub-017_task-fingerTapping_echo-1_bold.json
+        - relation: a3ae572c8c08c4f4439aedc929b2f764
+          name: sub-017_task-fingerTapping_echo-1_bold.nii
+        - relation: 1fae2f3de9799c2f5453c2fd7f1eb6b7
+          name: sub-017_task-fingerTapping_echo-2_bold.json
+        - relation: 91a3a7af3f8746d109626c0abe9047ac
+          name: sub-017_task-fingerTapping_echo-2_bold.nii
+        - relation: 21a1213eceb3fa03b239b84a2ee553b9
+          name: sub-017_task-fingerTapping_echo-3_bold.json
+        - relation: 05142b0bacff1ab7da64ebfcb73bae03
+          name: sub-017_task-fingerTapping_echo-3_bold.nii
+        - relation: f0f48d05413226bdc642faef1aa666ff
+          name: sub-017_task-fingerTapping_events.tsv.gz
+        - relation: 476d04c8a39a356361311baa48b3d47f
+          name: sub-017_task-fingerTappingImagined_echo-1_bold.json
+        - relation: 39110bab63dc3d41f3d09c1b5a5e6dd8
+          name: sub-017_task-fingerTappingImagined_echo-1_bold.nii
+        - relation: 27e9d3e5020feb7b3c45f290447b72da
+          name: sub-017_task-fingerTappingImagined_echo-2_bold.json
+        - relation: f0b062a4383267f9392126b8ded03250
+          name: sub-017_task-fingerTappingImagined_echo-2_bold.nii
+        - relation: 640d68482d7ca776db7d8ffd20c710f5
+          name: sub-017_task-fingerTappingImagined_echo-3_bold.json
+        - relation: 66f1619b1ba2e9eda4749c3aef4b552b
+          name: sub-017_task-fingerTappingImagined_echo-3_bold.nii
+        - relation: a98da27e0755ccefd4d98a77debc5e5f
+          name: sub-017_task-fingerTappingImagined_events.tsv.gz
+        - relation: 294a3c8ca8bfd7441b17a63378592daa
+          name: sub-017_task-fingerTappingImagined_physio.json
+        - relation: 46290d9393671049db251e3435e4aeef
+          name: sub-017_task-fingerTappingImagined_physio.tsv.gz
+        - relation: a3342ebda0beb4502ce9c9dd5ab527d6
+          name: sub-017_task-fingerTapping_physio.json
+        - relation: 6d23e1674aa125506ca24aa173282614
+          name: sub-017_task-fingerTapping_physio.tsv.gz
+        - relation: ea2c4f2379ca18e87ea3f6d52b0568e9
+          name: sub-017_task-rest_run-1_echo-1_bold.json
+        - relation: dd1fd2df29e32a6ea212fe640e375a39
+          name: sub-017_task-rest_run-1_echo-1_bold.nii
+        - relation: c1da6b603a1c3d11ff9cff5e78690a6e
+          name: sub-017_task-rest_run-1_echo-2_bold.json
+        - relation: baf772ab2471f417131cb7e9dda728f8
+          name: sub-017_task-rest_run-1_echo-2_bold.nii
+        - relation: 3a7f850a5b7f3465ae0c623be38910ec
+          name: sub-017_task-rest_run-1_echo-3_bold.json
+        - relation: a2a7e7eb3bcdf8a867ce1b99b653c4b9
+          name: sub-017_task-rest_run-1_echo-3_bold.nii
+        - relation: e8f482f7e7732c656de46ba094f00b71
+          name: sub-017_task-rest_run-1_physio.json
+        - relation: 78267cb7d6e83c76d9c0f993e3925f14
+          name: sub-017_task-rest_run-1_physio.tsv.gz
+        - relation: 20f75958d0053920cb12a8e5d594fc8c
+          name: sub-017_task-rest_run-2_echo-1_bold.json
+        - relation: 448b7a0ec38d72fce9923dfa86c90c74
+          name: sub-017_task-rest_run-2_echo-1_bold.nii
+        - relation: ac5b05347c7c89c81616416a4d599159
+          name: sub-017_task-rest_run-2_echo-2_bold.json
+        - relation: 1a9aebad3a6c4790cbd335d657be9fb8
+          name: sub-017_task-rest_run-2_echo-2_bold.nii
+        - relation: ab14d28bb0b0111dcbd82e34a685f0c9
+          name: sub-017_task-rest_run-2_echo-3_bold.json
+        - relation: 4699b14b4d1fc69be7e5753b10b4eb8a
+          name: sub-017_task-rest_run-2_echo-3_bold.nii
+        - relation: 36c47f48e263ca8084edd851e612d302
+          name: sub-017_task-rest_run-2_physio.json
+        - relation: b5790975f1314dc05b060076a288be5d
+          name: sub-017_task-rest_run-2_physio.tsv.gz
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 49bd6392aabdd13fb1f061d584fdfc5d
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 49bd6392aabdd13fb1f061d584fdfc5d
+      download_url: https://dataverse.nl/api/access/datafile/46395
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c6792ff5c1c23b3515f3f1f9302baf75
+      byte_size: 1039
+      checksum:
+        algorithm: md5
+        digest: c6792ff5c1c23b3515f3f1f9302baf75
+      download_url: https://dataverse.nl/api/access/datafile/46324
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: cfb6e06f72ecb8eabf9cd409edaeaf93
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: cfb6e06f72ecb8eabf9cd409edaeaf93
+      download_url: https://dataverse.nl/api/access/datafile/45754
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a528b89b95b3f3128e8e98a9237edc64
+      byte_size: 1039
+      checksum:
+        algorithm: md5
+        digest: a528b89b95b3f3128e8e98a9237edc64
+      download_url: https://dataverse.nl/api/access/datafile/45454
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6f919d3a07df2b44ee4ebf59a04eefad
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 6f919d3a07df2b44ee4ebf59a04eefad
+      download_url: https://dataverse.nl/api/access/datafile/45336
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 512913b1b38ca0f4202f6ca3c3605ab7
+      byte_size: 1896
+      checksum:
+        algorithm: md5
+        digest: 512913b1b38ca0f4202f6ca3c3605ab7
+      download_url: https://dataverse.nl/api/access/datafile/46557
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 35681199bfc3e571aae5477ce1191bf3
+      byte_size: 1047
+      checksum:
+        algorithm: md5
+        digest: 35681199bfc3e571aae5477ce1191bf3
+      download_url: https://dataverse.nl/api/access/datafile/46269
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 246521bd5001db167861cf5da9c9468e
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 246521bd5001db167861cf5da9c9468e
+      download_url: https://dataverse.nl/api/access/datafile/45687
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: cd5b275b00155c6655e6163dc9563bac
+      byte_size: 1047
+      checksum:
+        algorithm: md5
+        digest: cd5b275b00155c6655e6163dc9563bac
+      download_url: https://dataverse.nl/api/access/datafile/45243
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 193cb8ecc6cd158d8ecd4764aeba0b02
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 193cb8ecc6cd158d8ecd4764aeba0b02
+      download_url: https://dataverse.nl/api/access/datafile/46113
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f4c03ab759da66ffb6774913e4bf6c70
+      byte_size: 1047
+      checksum:
+        algorithm: md5
+        digest: f4c03ab759da66ffb6774913e4bf6c70
+      download_url: https://dataverse.nl/api/access/datafile/45935
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e1f5d15b62dde1cde99e429788d7be0e
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: e1f5d15b62dde1cde99e429788d7be0e
+      download_url: https://dataverse.nl/api/access/datafile/45362
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 782ccc689087c2d7ebbac8acd4770997
+      byte_size: 175
+      checksum:
+        algorithm: md5
+        digest: 782ccc689087c2d7ebbac8acd4770997
+      download_url: https://dataverse.nl/api/access/datafile/46561
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d09ab3c66bdfca4f24ca0495469c9b78
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: d09ab3c66bdfca4f24ca0495469c9b78
+      download_url: https://dataverse.nl/api/access/datafile/46165
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6a2527bd9a7c8b613cef15d92020f475
+      byte_size: 473929
+      checksum:
+        algorithm: md5
+        digest: 6a2527bd9a7c8b613cef15d92020f475
+      download_url: https://dataverse.nl/api/access/datafile/46168
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5ab56953069930dde62e936cca3bb403
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 5ab56953069930dde62e936cca3bb403
+      download_url: https://dataverse.nl/api/access/datafile/45735
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d2d2f6899051f0b2703084793376566a
+      byte_size: 499951
+      checksum:
+        algorithm: md5
+        digest: d2d2f6899051f0b2703084793376566a
+      download_url: https://dataverse.nl/api/access/datafile/45445
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a81c54ce06347f213b53121dae0893cb
+      byte_size: 1035
+      checksum:
+        algorithm: md5
+        digest: a81c54ce06347f213b53121dae0893cb
+      download_url: https://dataverse.nl/api/access/datafile/45678
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a3ae572c8c08c4f4439aedc929b2f764
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: a3ae572c8c08c4f4439aedc929b2f764
+      download_url: https://dataverse.nl/api/access/datafile/45804
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1fae2f3de9799c2f5453c2fd7f1eb6b7
+      byte_size: 1035
+      checksum:
+        algorithm: md5
+        digest: 1fae2f3de9799c2f5453c2fd7f1eb6b7
+      download_url: https://dataverse.nl/api/access/datafile/45440
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 91a3a7af3f8746d109626c0abe9047ac
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 91a3a7af3f8746d109626c0abe9047ac
+      download_url: https://dataverse.nl/api/access/datafile/45350
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 21a1213eceb3fa03b239b84a2ee553b9
+      byte_size: 1035
+      checksum:
+        algorithm: md5
+        digest: 21a1213eceb3fa03b239b84a2ee553b9
+      download_url: https://dataverse.nl/api/access/datafile/45344
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 05142b0bacff1ab7da64ebfcb73bae03
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 05142b0bacff1ab7da64ebfcb73bae03
+      download_url: https://dataverse.nl/api/access/datafile/46186
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f0f48d05413226bdc642faef1aa666ff
+      byte_size: 161
+      checksum:
+        algorithm: md5
+        digest: f0f48d05413226bdc642faef1aa666ff
+      download_url: https://dataverse.nl/api/access/datafile/46571
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 476d04c8a39a356361311baa48b3d47f
+      byte_size: 1043
+      checksum:
+        algorithm: md5
+        digest: 476d04c8a39a356361311baa48b3d47f
+      download_url: https://dataverse.nl/api/access/datafile/46078
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 39110bab63dc3d41f3d09c1b5a5e6dd8
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 39110bab63dc3d41f3d09c1b5a5e6dd8
+      download_url: https://dataverse.nl/api/access/datafile/45591
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 27e9d3e5020feb7b3c45f290447b72da
+      byte_size: 1043
+      checksum:
+        algorithm: md5
+        digest: 27e9d3e5020feb7b3c45f290447b72da
+      download_url: https://dataverse.nl/api/access/datafile/46274
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f0b062a4383267f9392126b8ded03250
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: f0b062a4383267f9392126b8ded03250
+      download_url: https://dataverse.nl/api/access/datafile/46407
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 640d68482d7ca776db7d8ffd20c710f5
+      byte_size: 1043
+      checksum:
+        algorithm: md5
+        digest: 640d68482d7ca776db7d8ffd20c710f5
+      download_url: https://dataverse.nl/api/access/datafile/45626
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 66f1619b1ba2e9eda4749c3aef4b552b
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 66f1619b1ba2e9eda4749c3aef4b552b
+      download_url: https://dataverse.nl/api/access/datafile/45550
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a98da27e0755ccefd4d98a77debc5e5f
+      byte_size: 176
+      checksum:
+        algorithm: md5
+        digest: a98da27e0755ccefd4d98a77debc5e5f
+      download_url: https://dataverse.nl/api/access/datafile/46621
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 294a3c8ca8bfd7441b17a63378592daa
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 294a3c8ca8bfd7441b17a63378592daa
+      download_url: https://dataverse.nl/api/access/datafile/45799
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 46290d9393671049db251e3435e4aeef
+      byte_size: 460894
+      checksum:
+        algorithm: md5
+        digest: 46290d9393671049db251e3435e4aeef
+      download_url: https://dataverse.nl/api/access/datafile/46012
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a3342ebda0beb4502ce9c9dd5ab527d6
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: a3342ebda0beb4502ce9c9dd5ab527d6
+      download_url: https://dataverse.nl/api/access/datafile/46160
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6d23e1674aa125506ca24aa173282614
+      byte_size: 495881
+      checksum:
+        algorithm: md5
+        digest: 6d23e1674aa125506ca24aa173282614
+      download_url: https://dataverse.nl/api/access/datafile/46344
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ea2c4f2379ca18e87ea3f6d52b0568e9
+      byte_size: 1024
+      checksum:
+        algorithm: md5
+        digest: ea2c4f2379ca18e87ea3f6d52b0568e9
+      download_url: https://dataverse.nl/api/access/datafile/45137
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: dd1fd2df29e32a6ea212fe640e375a39
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: dd1fd2df29e32a6ea212fe640e375a39
+      download_url: https://dataverse.nl/api/access/datafile/45140
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c1da6b603a1c3d11ff9cff5e78690a6e
+      byte_size: 1024
+      checksum:
+        algorithm: md5
+        digest: c1da6b603a1c3d11ff9cff5e78690a6e
+      download_url: https://dataverse.nl/api/access/datafile/45611
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: baf772ab2471f417131cb7e9dda728f8
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: baf772ab2471f417131cb7e9dda728f8
+      download_url: https://dataverse.nl/api/access/datafile/46306
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 3a7f850a5b7f3465ae0c623be38910ec
+      byte_size: 1024
+      checksum:
+        algorithm: md5
+        digest: 3a7f850a5b7f3465ae0c623be38910ec
+      download_url: https://dataverse.nl/api/access/datafile/45097
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a2a7e7eb3bcdf8a867ce1b99b653c4b9
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: a2a7e7eb3bcdf8a867ce1b99b653c4b9
+      download_url: https://dataverse.nl/api/access/datafile/46466
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e8f482f7e7732c656de46ba094f00b71
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: e8f482f7e7732c656de46ba094f00b71
+      download_url: https://dataverse.nl/api/access/datafile/46250
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 78267cb7d6e83c76d9c0f993e3925f14
+      byte_size: 456750
+      checksum:
+        algorithm: md5
+        digest: 78267cb7d6e83c76d9c0f993e3925f14
+      download_url: https://dataverse.nl/api/access/datafile/45691
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 20f75958d0053920cb12a8e5d594fc8c
+      byte_size: 1026
+      checksum:
+        algorithm: md5
+        digest: 20f75958d0053920cb12a8e5d594fc8c
+      download_url: https://dataverse.nl/api/access/datafile/46253
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 448b7a0ec38d72fce9923dfa86c90c74
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 448b7a0ec38d72fce9923dfa86c90c74
+      download_url: https://dataverse.nl/api/access/datafile/46485
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ac5b05347c7c89c81616416a4d599159
+      byte_size: 1026
+      checksum:
+        algorithm: md5
+        digest: ac5b05347c7c89c81616416a4d599159
+      download_url: https://dataverse.nl/api/access/datafile/46315
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1a9aebad3a6c4790cbd335d657be9fb8
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 1a9aebad3a6c4790cbd335d657be9fb8
+      download_url: https://dataverse.nl/api/access/datafile/45905
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ab14d28bb0b0111dcbd82e34a685f0c9
+      byte_size: 1026
+      checksum:
+        algorithm: md5
+        digest: ab14d28bb0b0111dcbd82e34a685f0c9
+      download_url: https://dataverse.nl/api/access/datafile/45665
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4699b14b4d1fc69be7e5753b10b4eb8a
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 4699b14b4d1fc69be7e5753b10b4eb8a
+      download_url: https://dataverse.nl/api/access/datafile/45364
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 36c47f48e263ca8084edd851e612d302
+      byte_size: 142
+      checksum:
+        algorithm: md5
+        digest: 36c47f48e263ca8084edd851e612d302
+      download_url: https://dataverse.nl/api/access/datafile/46523
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b5790975f1314dc05b060076a288be5d
+      byte_size: 464147
+      checksum:
+        algorithm: md5
+        digest: b5790975f1314dc05b060076a288be5d
+      download_url: https://dataverse.nl/api/access/datafile/45820
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 0562eacf5cf688fece5bb99d1bf11d7a
+      byte_size: 20736352
+      checksum:
+        algorithm: md5
+        digest: 0562eacf5cf688fece5bb99d1bf11d7a
+      download_url: https://dataverse.nl/api/access/datafile/46477
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-018/
+      qualified_part:
+        - relation: sub-018/anat/
+          name: anat
+        - relation: sub-018/func/
+          name: func
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-018/anat/
+      qualified_part:
+        - relation: 0562eacf5cf688fece5bb99d1bf11d7a
+          name: sub-018_T1w.nii
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c3469a90251c21df2cd808f4ab158b5e
+      byte_size: 1042
+      checksum:
+        algorithm: md5
+        digest: c3469a90251c21df2cd808f4ab158b5e
+      download_url: https://dataverse.nl/api/access/datafile/46027
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-018/func/
+      qualified_part:
+        - relation: c3469a90251c21df2cd808f4ab158b5e
+          name: sub-018_task-emotionProcessing_echo-1_bold.json
+        - relation: 10c530a30235ce16ca1f242f1741bf84
+          name: sub-018_task-emotionProcessing_echo-1_bold.nii
+        - relation: 9083871e42e383818f0153139602bcbe
+          name: sub-018_task-emotionProcessing_echo-2_bold.json
+        - relation: e9fceab854c3d0cdbfc49f0ca87636a0
+          name: sub-018_task-emotionProcessing_echo-2_bold.nii
+        - relation: 81812dbee74b11f9eb9ec34ed2267291
+          name: sub-018_task-emotionProcessing_echo-3_bold.json
+        - relation: b1182ef00fe01573f3673946877fbdd4
+          name: sub-018_task-emotionProcessing_echo-3_bold.nii
+        - relation: 94ab76b693f38ad49ee5371a27ab6276
+          name: sub-018_task-emotionProcessing_events.tsv.gz
+        - relation: 2160787763f6b9fbc2ae28d843f31279
+          name: sub-018_task-emotionProcessingImagined_echo-1_bold.json
+        - relation: 4df238d58b3bb698ce1be59503355897
+          name: sub-018_task-emotionProcessingImagined_echo-1_bold.nii
+        - relation: 62d008dae0c8adfbe27eb46a087c4b8c
+          name: sub-018_task-emotionProcessingImagined_echo-2_bold.json
+        - relation: 5a9413d4da22e50224287e8e96d41810
+          name: sub-018_task-emotionProcessingImagined_echo-2_bold.nii
+        - relation: c409998196cb9a5131a63402444232ac
+          name: sub-018_task-emotionProcessingImagined_echo-3_bold.json
+        - relation: 6a73e734759a10f82ff828482fe2d084
+          name: sub-018_task-emotionProcessingImagined_echo-3_bold.nii
+        - relation: 743a87b2467a7337dfb6390668a1eee7
+          name: sub-018_task-emotionProcessingImagined_events.tsv.gz
+        - relation: ec52dc6c7e742e9080a469c814e936e3
+          name: sub-018_task-emotionProcessingImagined_physio.json
+        - relation: 9f32c8d0c82ebe7a4c7c2f3ed1964bb3
+          name: sub-018_task-emotionProcessingImagined_physio.tsv.gz
+        - relation: 2aafbcf919a4ecd3813d471678b194e8
+          name: sub-018_task-emotionProcessing_physio.json
+        - relation: 4a6ecece2df4de53f22b90facf70accf
+          name: sub-018_task-emotionProcessing_physio.tsv.gz
+        - relation: e423c29e0444e827b1811bd8fd595528
+          name: sub-018_task-fingerTapping_echo-1_bold.json
+        - relation: f929fad9fa89daa7375f57c988e29302
+          name: sub-018_task-fingerTapping_echo-1_bold.nii
+        - relation: 861a3cd2e3a4fa2c191e262cabbbdef6
+          name: sub-018_task-fingerTapping_echo-2_bold.json
+        - relation: 27c2135927b49179019bcf61804f45bf
+          name: sub-018_task-fingerTapping_echo-2_bold.nii
+        - relation: d1e95a770e7b00f4cf23bfeed927ae4f
+          name: sub-018_task-fingerTapping_echo-3_bold.json
+        - relation: b94d5b9fb36479ec1f67582d78d07229
+          name: sub-018_task-fingerTapping_echo-3_bold.nii
+        - relation: e0f507974252817e79c9fbe4879847f0
+          name: sub-018_task-fingerTapping_events.tsv.gz
+        - relation: ced4090a09793017f415eebed9b3bc01
+          name: sub-018_task-fingerTappingImagined_echo-1_bold.json
+        - relation: abf2229dc1c0186c3c24b9f198142407
+          name: sub-018_task-fingerTappingImagined_echo-1_bold.nii
+        - relation: 09962b2c547b21ae031f3e440bd2f60c
+          name: sub-018_task-fingerTappingImagined_echo-2_bold.json
+        - relation: 4f3444ad5223f1996fbd107349c95486
+          name: sub-018_task-fingerTappingImagined_echo-2_bold.nii
+        - relation: 7bac8f37bec0dc4e0aab226b5edbf4c6
+          name: sub-018_task-fingerTappingImagined_echo-3_bold.json
+        - relation: 071183c6163bdbf82510bcee1592c3ff
+          name: sub-018_task-fingerTappingImagined_echo-3_bold.nii
+        - relation: a92cd802a259c806053f2408c3a9ced7
+          name: sub-018_task-fingerTappingImagined_events.tsv.gz
+        - relation: f8fba2227070030bfad34288122cfe9d
+          name: sub-018_task-fingerTappingImagined_physio.json
+        - relation: 743e580636625b4cd29911bdb803dda6
+          name: sub-018_task-fingerTappingImagined_physio.tsv.gz
+        - relation: aec3e1ac31432db849b7b97677b140e4
+          name: sub-018_task-fingerTapping_physio.json
+        - relation: bf9f8ed0e10c83d504f6b6ec5e565021
+          name: sub-018_task-fingerTapping_physio.tsv.gz
+        - relation: 582d335a6f1ff0292b253b6b7f7ac70f
+          name: sub-018_task-rest_run-1_echo-1_bold.json
+        - relation: 65f53aa192dcf0cfdb39272e50b4cd41
+          name: sub-018_task-rest_run-1_echo-1_bold.nii
+        - relation: 639e135352fd3dc65180f8741ddca7a5
+          name: sub-018_task-rest_run-1_echo-2_bold.json
+        - relation: 34704cd69f8ffe219490b9b8ac489bee
+          name: sub-018_task-rest_run-1_echo-2_bold.nii
+        - relation: fd5f69e655165421934afcb46d6d9ab7
+          name: sub-018_task-rest_run-1_echo-3_bold.json
+        - relation: 205ddb41c3fb0f6a75248fde2596ef9f
+          name: sub-018_task-rest_run-1_echo-3_bold.nii
+        - relation: fa48a2a92f511b5b2bf86f89eff447ea
+          name: sub-018_task-rest_run-1_physio.json
+        - relation: e6cd780a202753329df22e92906086ea
+          name: sub-018_task-rest_run-1_physio.tsv.gz
+        - relation: 9dd4558b268c0f1e51654984a9817602
+          name: sub-018_task-rest_run-2_echo-1_bold.json
+        - relation: dbda73c0db2c05ab9afc6d3bd7145618
+          name: sub-018_task-rest_run-2_echo-1_bold.nii
+        - relation: f1dca01b8dd106ea30e379432867b265
+          name: sub-018_task-rest_run-2_echo-2_bold.json
+        - relation: 8dcf40fa74d8d71fb5d04eddae09f246
+          name: sub-018_task-rest_run-2_echo-2_bold.nii
+        - relation: 7f32563d7e6d8f41efba1a2f2ffe2484
+          name: sub-018_task-rest_run-2_echo-3_bold.json
+        - relation: 28467ebfdcf77caaa83d407fe31c7464
+          name: sub-018_task-rest_run-2_echo-3_bold.nii
+        - relation: fd2778d2800a21e39b4561327eecb5ce
+          name: sub-018_task-rest_run-2_physio.json
+        - relation: 2b4b5e1520eea448d3df546544a719e7
+          name: sub-018_task-rest_run-2_physio.tsv.gz
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 10c530a30235ce16ca1f242f1741bf84
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 10c530a30235ce16ca1f242f1741bf84
+      download_url: https://dataverse.nl/api/access/datafile/46143
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 9083871e42e383818f0153139602bcbe
+      byte_size: 1042
+      checksum:
+        algorithm: md5
+        digest: 9083871e42e383818f0153139602bcbe
+      download_url: https://dataverse.nl/api/access/datafile/46243
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e9fceab854c3d0cdbfc49f0ca87636a0
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: e9fceab854c3d0cdbfc49f0ca87636a0
+      download_url: https://dataverse.nl/api/access/datafile/46498
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 81812dbee74b11f9eb9ec34ed2267291
+      byte_size: 1042
+      checksum:
+        algorithm: md5
+        digest: 81812dbee74b11f9eb9ec34ed2267291
+      download_url: https://dataverse.nl/api/access/datafile/45295
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b1182ef00fe01573f3673946877fbdd4
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: b1182ef00fe01573f3673946877fbdd4
+      download_url: https://dataverse.nl/api/access/datafile/45547
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 94ab76b693f38ad49ee5371a27ab6276
+      byte_size: 1936
+      checksum:
+        algorithm: md5
+        digest: 94ab76b693f38ad49ee5371a27ab6276
+      download_url: https://dataverse.nl/api/access/datafile/46558
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2160787763f6b9fbc2ae28d843f31279
+      byte_size: 1051
+      checksum:
+        algorithm: md5
+        digest: 2160787763f6b9fbc2ae28d843f31279
+      download_url: https://dataverse.nl/api/access/datafile/46416
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4df238d58b3bb698ce1be59503355897
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 4df238d58b3bb698ce1be59503355897
+      download_url: https://dataverse.nl/api/access/datafile/45962
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 62d008dae0c8adfbe27eb46a087c4b8c
+      byte_size: 1051
+      checksum:
+        algorithm: md5
+        digest: 62d008dae0c8adfbe27eb46a087c4b8c
+      download_url: https://dataverse.nl/api/access/datafile/45122
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5a9413d4da22e50224287e8e96d41810
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 5a9413d4da22e50224287e8e96d41810
+      download_url: https://dataverse.nl/api/access/datafile/46527
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c409998196cb9a5131a63402444232ac
+      byte_size: 1051
+      checksum:
+        algorithm: md5
+        digest: c409998196cb9a5131a63402444232ac
+      download_url: https://dataverse.nl/api/access/datafile/45774
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6a73e734759a10f82ff828482fe2d084
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 6a73e734759a10f82ff828482fe2d084
+      download_url: https://dataverse.nl/api/access/datafile/45101
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 743a87b2467a7337dfb6390668a1eee7
+      byte_size: 178
+      checksum:
+        algorithm: md5
+        digest: 743a87b2467a7337dfb6390668a1eee7
+      download_url: https://dataverse.nl/api/access/datafile/46550
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ec52dc6c7e742e9080a469c814e936e3
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: ec52dc6c7e742e9080a469c814e936e3
+      download_url: https://dataverse.nl/api/access/datafile/45479
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 9f32c8d0c82ebe7a4c7c2f3ed1964bb3
+      byte_size: 477438
+      checksum:
+        algorithm: md5
+        digest: 9f32c8d0c82ebe7a4c7c2f3ed1964bb3
+      download_url: https://dataverse.nl/api/access/datafile/45552
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2aafbcf919a4ecd3813d471678b194e8
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 2aafbcf919a4ecd3813d471678b194e8
+      download_url: https://dataverse.nl/api/access/datafile/45173
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4a6ecece2df4de53f22b90facf70accf
+      byte_size: 643344
+      checksum:
+        algorithm: md5
+        digest: 4a6ecece2df4de53f22b90facf70accf
+      download_url: https://dataverse.nl/api/access/datafile/45703
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e423c29e0444e827b1811bd8fd595528
+      byte_size: 1039
+      checksum:
+        algorithm: md5
+        digest: e423c29e0444e827b1811bd8fd595528
+      download_url: https://dataverse.nl/api/access/datafile/46195
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f929fad9fa89daa7375f57c988e29302
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: f929fad9fa89daa7375f57c988e29302
+      download_url: https://dataverse.nl/api/access/datafile/45261
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 861a3cd2e3a4fa2c191e262cabbbdef6
+      byte_size: 1039
+      checksum:
+        algorithm: md5
+        digest: 861a3cd2e3a4fa2c191e262cabbbdef6
+      download_url: https://dataverse.nl/api/access/datafile/45233
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 27c2135927b49179019bcf61804f45bf
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 27c2135927b49179019bcf61804f45bf
+      download_url: https://dataverse.nl/api/access/datafile/45747
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d1e95a770e7b00f4cf23bfeed927ae4f
+      byte_size: 1039
+      checksum:
+        algorithm: md5
+        digest: d1e95a770e7b00f4cf23bfeed927ae4f
+      download_url: https://dataverse.nl/api/access/datafile/45409
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b94d5b9fb36479ec1f67582d78d07229
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: b94d5b9fb36479ec1f67582d78d07229
+      download_url: https://dataverse.nl/api/access/datafile/45302
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e0f507974252817e79c9fbe4879847f0
+      byte_size: 167
+      checksum:
+        algorithm: md5
+        digest: e0f507974252817e79c9fbe4879847f0
+      download_url: https://dataverse.nl/api/access/datafile/46655
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ced4090a09793017f415eebed9b3bc01
+      byte_size: 1047
+      checksum:
+        algorithm: md5
+        digest: ced4090a09793017f415eebed9b3bc01
+      download_url: https://dataverse.nl/api/access/datafile/45428
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: abf2229dc1c0186c3c24b9f198142407
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: abf2229dc1c0186c3c24b9f198142407
+      download_url: https://dataverse.nl/api/access/datafile/45188
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 09962b2c547b21ae031f3e440bd2f60c
+      byte_size: 1047
+      checksum:
+        algorithm: md5
+        digest: 09962b2c547b21ae031f3e440bd2f60c
+      download_url: https://dataverse.nl/api/access/datafile/45745
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4f3444ad5223f1996fbd107349c95486
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 4f3444ad5223f1996fbd107349c95486
+      download_url: https://dataverse.nl/api/access/datafile/46038
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 7bac8f37bec0dc4e0aab226b5edbf4c6
+      byte_size: 1047
+      checksum:
+        algorithm: md5
+        digest: 7bac8f37bec0dc4e0aab226b5edbf4c6
+      download_url: https://dataverse.nl/api/access/datafile/45426
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 071183c6163bdbf82510bcee1592c3ff
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 071183c6163bdbf82510bcee1592c3ff
+      download_url: https://dataverse.nl/api/access/datafile/46069
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a92cd802a259c806053f2408c3a9ced7
+      byte_size: 179
+      checksum:
+        algorithm: md5
+        digest: a92cd802a259c806053f2408c3a9ced7
+      download_url: https://dataverse.nl/api/access/datafile/46602
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f8fba2227070030bfad34288122cfe9d
+      byte_size: 142
+      checksum:
+        algorithm: md5
+        digest: f8fba2227070030bfad34288122cfe9d
+      download_url: https://dataverse.nl/api/access/datafile/46138
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 743e580636625b4cd29911bdb803dda6
+      byte_size: 474630
+      checksum:
+        algorithm: md5
+        digest: 743e580636625b4cd29911bdb803dda6
+      download_url: https://dataverse.nl/api/access/datafile/46442
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: aec3e1ac31432db849b7b97677b140e4
+      byte_size: 142
+      checksum:
+        algorithm: md5
+        digest: aec3e1ac31432db849b7b97677b140e4
+      download_url: https://dataverse.nl/api/access/datafile/46322
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: bf9f8ed0e10c83d504f6b6ec5e565021
+      byte_size: 513523
+      checksum:
+        algorithm: md5
+        digest: bf9f8ed0e10c83d504f6b6ec5e565021
+      download_url: https://dataverse.nl/api/access/datafile/45579
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 582d335a6f1ff0292b253b6b7f7ac70f
+      byte_size: 1030
+      checksum:
+        algorithm: md5
+        digest: 582d335a6f1ff0292b253b6b7f7ac70f
+      download_url: https://dataverse.nl/api/access/datafile/46263
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 65f53aa192dcf0cfdb39272e50b4cd41
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 65f53aa192dcf0cfdb39272e50b4cd41
+      download_url: https://dataverse.nl/api/access/datafile/45916
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 639e135352fd3dc65180f8741ddca7a5
+      byte_size: 1030
+      checksum:
+        algorithm: md5
+        digest: 639e135352fd3dc65180f8741ddca7a5
+      download_url: https://dataverse.nl/api/access/datafile/45923
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 34704cd69f8ffe219490b9b8ac489bee
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 34704cd69f8ffe219490b9b8ac489bee
+      download_url: https://dataverse.nl/api/access/datafile/45123
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: fd5f69e655165421934afcb46d6d9ab7
+      byte_size: 1030
+      checksum:
+        algorithm: md5
+        digest: fd5f69e655165421934afcb46d6d9ab7
+      download_url: https://dataverse.nl/api/access/datafile/46188
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 205ddb41c3fb0f6a75248fde2596ef9f
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 205ddb41c3fb0f6a75248fde2596ef9f
+      download_url: https://dataverse.nl/api/access/datafile/46228
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: fa48a2a92f511b5b2bf86f89eff447ea
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: fa48a2a92f511b5b2bf86f89eff447ea
+      download_url: https://dataverse.nl/api/access/datafile/46339
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e6cd780a202753329df22e92906086ea
+      byte_size: 456499
+      checksum:
+        algorithm: md5
+        digest: e6cd780a202753329df22e92906086ea
+      download_url: https://dataverse.nl/api/access/datafile/45175
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 9dd4558b268c0f1e51654984a9817602
+      byte_size: 1030
+      checksum:
+        algorithm: md5
+        digest: 9dd4558b268c0f1e51654984a9817602
+      download_url: https://dataverse.nl/api/access/datafile/45961
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: dbda73c0db2c05ab9afc6d3bd7145618
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: dbda73c0db2c05ab9afc6d3bd7145618
+      download_url: https://dataverse.nl/api/access/datafile/46513
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f1dca01b8dd106ea30e379432867b265
+      byte_size: 1030
+      checksum:
+        algorithm: md5
+        digest: f1dca01b8dd106ea30e379432867b265
+      download_url: https://dataverse.nl/api/access/datafile/45557
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8dcf40fa74d8d71fb5d04eddae09f246
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 8dcf40fa74d8d71fb5d04eddae09f246
+      download_url: https://dataverse.nl/api/access/datafile/45376
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 7f32563d7e6d8f41efba1a2f2ffe2484
+      byte_size: 1030
+      checksum:
+        algorithm: md5
+        digest: 7f32563d7e6d8f41efba1a2f2ffe2484
+      download_url: https://dataverse.nl/api/access/datafile/46365
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 28467ebfdcf77caaa83d407fe31c7464
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 28467ebfdcf77caaa83d407fe31c7464
+      download_url: https://dataverse.nl/api/access/datafile/46249
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: fd2778d2800a21e39b4561327eecb5ce
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: fd2778d2800a21e39b4561327eecb5ce
+      download_url: https://dataverse.nl/api/access/datafile/45676
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2b4b5e1520eea448d3df546544a719e7
+      byte_size: 462069
+      checksum:
+        algorithm: md5
+        digest: 2b4b5e1520eea448d3df546544a719e7
+      download_url: https://dataverse.nl/api/access/datafile/45199
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2f4fa393be40ddc00c27a138b5f7fd48
+      byte_size: 20736352
+      checksum:
+        algorithm: md5
+        digest: 2f4fa393be40ddc00c27a138b5f7fd48
+      download_url: https://dataverse.nl/api/access/datafile/46125
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-019/
+      qualified_part:
+        - relation: sub-019/anat/
+          name: anat
+        - relation: sub-019/func/
+          name: func
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-019/anat/
+      qualified_part:
+        - relation: 2f4fa393be40ddc00c27a138b5f7fd48
+          name: sub-019_T1w.nii
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 26489abd8ee555b1de70af69095875e5
+      byte_size: 1038
+      checksum:
+        algorithm: md5
+        digest: 26489abd8ee555b1de70af69095875e5
+      download_url: https://dataverse.nl/api/access/datafile/45859
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-019/func/
+      qualified_part:
+        - relation: 26489abd8ee555b1de70af69095875e5
+          name: sub-019_task-emotionProcessing_echo-1_bold.json
+        - relation: 6aa733780d6bf9addd4ea3d05ed51924
+          name: sub-019_task-emotionProcessing_echo-1_bold.nii
+        - relation: 11c9a5133067418baba05651e4e6d53b
+          name: sub-019_task-emotionProcessing_echo-2_bold.json
+        - relation: 1855f130ac422e998e659ac0386e8ede
+          name: sub-019_task-emotionProcessing_echo-2_bold.nii
+        - relation: d19eb8cedec51262e5eb75d2785fca6a
+          name: sub-019_task-emotionProcessing_echo-3_bold.json
+        - relation: 08ca55e4d2fd91fc5b15a22b732938a3
+          name: sub-019_task-emotionProcessing_echo-3_bold.nii
+        - relation: bb5add688ff56a82bbca17a6eb55e7ca
+          name: sub-019_task-emotionProcessing_events.tsv.gz
+        - relation: b1a3e5cb27a2636734ba18ce531d9248
+          name: sub-019_task-emotionProcessingImagined_echo-1_bold.json
+        - relation: ee1d6e2cb43a658f018f3cee66691205
+          name: sub-019_task-emotionProcessingImagined_echo-1_bold.nii
+        - relation: cc8b80c64786026ecdb401d835b6c2ea
+          name: sub-019_task-emotionProcessingImagined_echo-2_bold.json
+        - relation: 07e6633e94e0e6e104ed0b768a685d97
+          name: sub-019_task-emotionProcessingImagined_echo-2_bold.nii
+        - relation: da2025294b29d05a04a3ce88334bb78e
+          name: sub-019_task-emotionProcessingImagined_echo-3_bold.json
+        - relation: 593b93faf187ed1529d0d67c70a52064
+          name: sub-019_task-emotionProcessingImagined_echo-3_bold.nii
+        - relation: 189b63cfd0ed5265678518483743162c
+          name: sub-019_task-emotionProcessingImagined_events.tsv.gz
+        - relation: af8c49a408751e4d2e1c7550ac3196ce
+          name: sub-019_task-emotionProcessingImagined_physio.json
+        - relation: 247a7ecbb38fef53debe799b72e7064e
+          name: sub-019_task-emotionProcessingImagined_physio.tsv.gz
+        - relation: 0b5cb7229e2fcbae77ef3ad2b2db8040
+          name: sub-019_task-emotionProcessing_physio.json
+        - relation: 3aa4c7b9e8339ac90a0e764c89ea6647
+          name: sub-019_task-emotionProcessing_physio.tsv.gz
+        - relation: 3d01dda30aaba71344aaaa17e47b8e11
+          name: sub-019_task-fingerTapping_echo-1_bold.json
+        - relation: a770d3f9ca52e238a5c322eda9a483c3
+          name: sub-019_task-fingerTapping_echo-1_bold.nii
+        - relation: 9270a115239c71322b2136225d1de014
+          name: sub-019_task-fingerTapping_echo-2_bold.json
+        - relation: ec9c3f2cded0b6462edf4727b4179bed
+          name: sub-019_task-fingerTapping_echo-2_bold.nii
+        - relation: 04d5039942c6ecb2b4cd0b84f256b2a7
+          name: sub-019_task-fingerTapping_echo-3_bold.json
+        - relation: 22d7379427b1021462add9190e53ebfc
+          name: sub-019_task-fingerTapping_echo-3_bold.nii
+        - relation: f1c6da5fca90a4d4da36d5cf97c31e2b
+          name: sub-019_task-fingerTapping_events.tsv.gz
+        - relation: 2d252ae6f47238c8407e63b425e1a323
+          name: sub-019_task-fingerTappingImagined_echo-1_bold.json
+        - relation: ffffccac3809ac8d3f344a8cdc59a967
+          name: sub-019_task-fingerTappingImagined_echo-1_bold.nii
+        - relation: 72a4cd3573a708d5ececf2b51097c5a8
+          name: sub-019_task-fingerTappingImagined_echo-2_bold.json
+        - relation: f77f9150229dd232cc026c61a8f936b9
+          name: sub-019_task-fingerTappingImagined_echo-2_bold.nii
+        - relation: 989b6c9e32ee328c74763545e14aa7ac
+          name: sub-019_task-fingerTappingImagined_echo-3_bold.json
+        - relation: f4d329cb4f46502b98ca797d6efb821a
+          name: sub-019_task-fingerTappingImagined_echo-3_bold.nii
+        - relation: e22a6384385779bfd07902623d084563
+          name: sub-019_task-fingerTappingImagined_events.tsv.gz
+        - relation: e5c279f326ee9a8d48e4fe532807129b
+          name: sub-019_task-fingerTappingImagined_physio.json
+        - relation: 63e7ec079d0b86765b16405bca76eaa7
+          name: sub-019_task-fingerTappingImagined_physio.tsv.gz
+        - relation: 3eee13807fa200e7c94d7241dd26cd7a
+          name: sub-019_task-fingerTapping_physio.json
+        - relation: ca4c0bbbb035517432413a9cbb5187cd
+          name: sub-019_task-fingerTapping_physio.tsv.gz
+        - relation: a0365d0d70eef29defbe1518c75efaf8
+          name: sub-019_task-rest_run-1_echo-1_bold.json
+        - relation: b3db2bf6ef1925eb2d0602e3318f5a3a
+          name: sub-019_task-rest_run-1_echo-1_bold.nii
+        - relation: ea41f1b42f6ccca0ba65174f3b2e3b6b
+          name: sub-019_task-rest_run-1_echo-2_bold.json
+        - relation: ed3231b108f5e7ad6749f2c8eef91cea
+          name: sub-019_task-rest_run-1_echo-2_bold.nii
+        - relation: 70a500bab6e0571167acf5378e335e0a
+          name: sub-019_task-rest_run-1_echo-3_bold.json
+        - relation: 754b73d4ff587d8bcd246fbb26e1fe83
+          name: sub-019_task-rest_run-1_echo-3_bold.nii
+        - relation: 276ce10bff283ab4d57782e8992d4593
+          name: sub-019_task-rest_run-1_physio.json
+        - relation: 515d8d65fbe994cfb276173666c5d084
+          name: sub-019_task-rest_run-1_physio.tsv.gz
+        - relation: ccea34f1f7872ae7188e375f7909c8d0
+          name: sub-019_task-rest_run-2_echo-1_bold.json
+        - relation: 89d7c2abf06fc026ad7dd36eb852748b
+          name: sub-019_task-rest_run-2_echo-1_bold.nii
+        - relation: cbfd7780f899b213b810417dab5bfed5
+          name: sub-019_task-rest_run-2_echo-2_bold.json
+        - relation: 4c5cee193ed25e8927d349759c4390bd
+          name: sub-019_task-rest_run-2_echo-2_bold.nii
+        - relation: fbc01f613cb706a07b5bd20a965962c5
+          name: sub-019_task-rest_run-2_echo-3_bold.json
+        - relation: 311ff32bb975770b4f8f5c822c4330cc
+          name: sub-019_task-rest_run-2_echo-3_bold.nii
+        - relation: 37c77f3c79b7551b8e19f42a7db9ea8d
+          name: sub-019_task-rest_run-2_physio.json
+        - relation: 5633574342d8f03a72e934625fa9201c
+          name: sub-019_task-rest_run-2_physio.tsv.gz
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6aa733780d6bf9addd4ea3d05ed51924
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 6aa733780d6bf9addd4ea3d05ed51924
+      download_url: https://dataverse.nl/api/access/datafile/45112
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 11c9a5133067418baba05651e4e6d53b
+      byte_size: 1038
+      checksum:
+        algorithm: md5
+        digest: 11c9a5133067418baba05651e4e6d53b
+      download_url: https://dataverse.nl/api/access/datafile/46261
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1855f130ac422e998e659ac0386e8ede
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 1855f130ac422e998e659ac0386e8ede
+      download_url: https://dataverse.nl/api/access/datafile/45769
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d19eb8cedec51262e5eb75d2785fca6a
+      byte_size: 1038
+      checksum:
+        algorithm: md5
+        digest: d19eb8cedec51262e5eb75d2785fca6a
+      download_url: https://dataverse.nl/api/access/datafile/45249
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 08ca55e4d2fd91fc5b15a22b732938a3
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 08ca55e4d2fd91fc5b15a22b732938a3
+      download_url: https://dataverse.nl/api/access/datafile/45554
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: bb5add688ff56a82bbca17a6eb55e7ca
+      byte_size: 1857
+      checksum:
+        algorithm: md5
+        digest: bb5add688ff56a82bbca17a6eb55e7ca
+      download_url: https://dataverse.nl/api/access/datafile/46612
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b1a3e5cb27a2636734ba18ce531d9248
+      byte_size: 1045
+      checksum:
+        algorithm: md5
+        digest: b1a3e5cb27a2636734ba18ce531d9248
+      download_url: https://dataverse.nl/api/access/datafile/45359
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ee1d6e2cb43a658f018f3cee66691205
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: ee1d6e2cb43a658f018f3cee66691205
+      download_url: https://dataverse.nl/api/access/datafile/45508
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: cc8b80c64786026ecdb401d835b6c2ea
+      byte_size: 1045
+      checksum:
+        algorithm: md5
+        digest: cc8b80c64786026ecdb401d835b6c2ea
+      download_url: https://dataverse.nl/api/access/datafile/46279
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 07e6633e94e0e6e104ed0b768a685d97
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 07e6633e94e0e6e104ed0b768a685d97
+      download_url: https://dataverse.nl/api/access/datafile/46117
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: da2025294b29d05a04a3ce88334bb78e
+      byte_size: 1045
+      checksum:
+        algorithm: md5
+        digest: da2025294b29d05a04a3ce88334bb78e
+      download_url: https://dataverse.nl/api/access/datafile/45807
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 593b93faf187ed1529d0d67c70a52064
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 593b93faf187ed1529d0d67c70a52064
+      download_url: https://dataverse.nl/api/access/datafile/46076
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 189b63cfd0ed5265678518483743162c
+      byte_size: 176
+      checksum:
+        algorithm: md5
+        digest: 189b63cfd0ed5265678518483743162c
+      download_url: https://dataverse.nl/api/access/datafile/46583
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: af8c49a408751e4d2e1c7550ac3196ce
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: af8c49a408751e4d2e1c7550ac3196ce
+      download_url: https://dataverse.nl/api/access/datafile/45805
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 247a7ecbb38fef53debe799b72e7064e
+      byte_size: 474948
+      checksum:
+        algorithm: md5
+        digest: 247a7ecbb38fef53debe799b72e7064e
+      download_url: https://dataverse.nl/api/access/datafile/45276
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 0b5cb7229e2fcbae77ef3ad2b2db8040
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 0b5cb7229e2fcbae77ef3ad2b2db8040
+      download_url: https://dataverse.nl/api/access/datafile/45225
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 3aa4c7b9e8339ac90a0e764c89ea6647
+      byte_size: 494275
+      checksum:
+        algorithm: md5
+        digest: 3aa4c7b9e8339ac90a0e764c89ea6647
+      download_url: https://dataverse.nl/api/access/datafile/45105
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 3d01dda30aaba71344aaaa17e47b8e11
+      byte_size: 1034
+      checksum:
+        algorithm: md5
+        digest: 3d01dda30aaba71344aaaa17e47b8e11
+      download_url: https://dataverse.nl/api/access/datafile/45937
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a770d3f9ca52e238a5c322eda9a483c3
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: a770d3f9ca52e238a5c322eda9a483c3
+      download_url: https://dataverse.nl/api/access/datafile/46149
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 9270a115239c71322b2136225d1de014
+      byte_size: 1034
+      checksum:
+        algorithm: md5
+        digest: 9270a115239c71322b2136225d1de014
+      download_url: https://dataverse.nl/api/access/datafile/46475
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ec9c3f2cded0b6462edf4727b4179bed
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: ec9c3f2cded0b6462edf4727b4179bed
+      download_url: https://dataverse.nl/api/access/datafile/46411
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 04d5039942c6ecb2b4cd0b84f256b2a7
+      byte_size: 1034
+      checksum:
+        algorithm: md5
+        digest: 04d5039942c6ecb2b4cd0b84f256b2a7
+      download_url: https://dataverse.nl/api/access/datafile/45683
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 22d7379427b1021462add9190e53ebfc
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 22d7379427b1021462add9190e53ebfc
+      download_url: https://dataverse.nl/api/access/datafile/46358
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f1c6da5fca90a4d4da36d5cf97c31e2b
+      byte_size: 167
+      checksum:
+        algorithm: md5
+        digest: f1c6da5fca90a4d4da36d5cf97c31e2b
+      download_url: https://dataverse.nl/api/access/datafile/46560
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2d252ae6f47238c8407e63b425e1a323
+      byte_size: 1042
+      checksum:
+        algorithm: md5
+        digest: 2d252ae6f47238c8407e63b425e1a323
+      download_url: https://dataverse.nl/api/access/datafile/45742
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ffffccac3809ac8d3f344a8cdc59a967
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: ffffccac3809ac8d3f344a8cdc59a967
+      download_url: https://dataverse.nl/api/access/datafile/45982
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 72a4cd3573a708d5ececf2b51097c5a8
+      byte_size: 1042
+      checksum:
+        algorithm: md5
+        digest: 72a4cd3573a708d5ececf2b51097c5a8
+      download_url: https://dataverse.nl/api/access/datafile/46217
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f77f9150229dd232cc026c61a8f936b9
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: f77f9150229dd232cc026c61a8f936b9
+      download_url: https://dataverse.nl/api/access/datafile/46457
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 989b6c9e32ee328c74763545e14aa7ac
+      byte_size: 1042
+      checksum:
+        algorithm: md5
+        digest: 989b6c9e32ee328c74763545e14aa7ac
+      download_url: https://dataverse.nl/api/access/datafile/46472
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f4d329cb4f46502b98ca797d6efb821a
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: f4d329cb4f46502b98ca797d6efb821a
+      download_url: https://dataverse.nl/api/access/datafile/46383
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e22a6384385779bfd07902623d084563
+      byte_size: 179
+      checksum:
+        algorithm: md5
+        digest: e22a6384385779bfd07902623d084563
+      download_url: https://dataverse.nl/api/access/datafile/46609
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e5c279f326ee9a8d48e4fe532807129b
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: e5c279f326ee9a8d48e4fe532807129b
+      download_url: https://dataverse.nl/api/access/datafile/45197
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 63e7ec079d0b86765b16405bca76eaa7
+      byte_size: 470533
+      checksum:
+        algorithm: md5
+        digest: 63e7ec079d0b86765b16405bca76eaa7
+      download_url: https://dataverse.nl/api/access/datafile/45525
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 3eee13807fa200e7c94d7241dd26cd7a
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 3eee13807fa200e7c94d7241dd26cd7a
+      download_url: https://dataverse.nl/api/access/datafile/45960
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ca4c0bbbb035517432413a9cbb5187cd
+      byte_size: 519192
+      checksum:
+        algorithm: md5
+        digest: ca4c0bbbb035517432413a9cbb5187cd
+      download_url: https://dataverse.nl/api/access/datafile/45252
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a0365d0d70eef29defbe1518c75efaf8
+      byte_size: 1023
+      checksum:
+        algorithm: md5
+        digest: a0365d0d70eef29defbe1518c75efaf8
+      download_url: https://dataverse.nl/api/access/datafile/46510
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b3db2bf6ef1925eb2d0602e3318f5a3a
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: b3db2bf6ef1925eb2d0602e3318f5a3a
+      download_url: https://dataverse.nl/api/access/datafile/45764
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ea41f1b42f6ccca0ba65174f3b2e3b6b
+      byte_size: 1023
+      checksum:
+        algorithm: md5
+        digest: ea41f1b42f6ccca0ba65174f3b2e3b6b
+      download_url: https://dataverse.nl/api/access/datafile/45777
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ed3231b108f5e7ad6749f2c8eef91cea
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: ed3231b108f5e7ad6749f2c8eef91cea
+      download_url: https://dataverse.nl/api/access/datafile/45346
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 70a500bab6e0571167acf5378e335e0a
+      byte_size: 1023
+      checksum:
+        algorithm: md5
+        digest: 70a500bab6e0571167acf5378e335e0a
+      download_url: https://dataverse.nl/api/access/datafile/45907
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 754b73d4ff587d8bcd246fbb26e1fe83
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 754b73d4ff587d8bcd246fbb26e1fe83
+      download_url: https://dataverse.nl/api/access/datafile/45616
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 276ce10bff283ab4d57782e8992d4593
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 276ce10bff283ab4d57782e8992d4593
+      download_url: https://dataverse.nl/api/access/datafile/46400
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 515d8d65fbe994cfb276173666c5d084
+      byte_size: 468658
+      checksum:
+        algorithm: md5
+        digest: 515d8d65fbe994cfb276173666c5d084
+      download_url: https://dataverse.nl/api/access/datafile/46079
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ccea34f1f7872ae7188e375f7909c8d0
+      byte_size: 1025
+      checksum:
+        algorithm: md5
+        digest: ccea34f1f7872ae7188e375f7909c8d0
+      download_url: https://dataverse.nl/api/access/datafile/46386
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 89d7c2abf06fc026ad7dd36eb852748b
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 89d7c2abf06fc026ad7dd36eb852748b
+      download_url: https://dataverse.nl/api/access/datafile/45866
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: cbfd7780f899b213b810417dab5bfed5
+      byte_size: 1025
+      checksum:
+        algorithm: md5
+        digest: cbfd7780f899b213b810417dab5bfed5
+      download_url: https://dataverse.nl/api/access/datafile/45680
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4c5cee193ed25e8927d349759c4390bd
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 4c5cee193ed25e8927d349759c4390bd
+      download_url: https://dataverse.nl/api/access/datafile/45378
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: fbc01f613cb706a07b5bd20a965962c5
+      byte_size: 1025
+      checksum:
+        algorithm: md5
+        digest: fbc01f613cb706a07b5bd20a965962c5
+      download_url: https://dataverse.nl/api/access/datafile/45828
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 311ff32bb975770b4f8f5c822c4330cc
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 311ff32bb975770b4f8f5c822c4330cc
+      download_url: https://dataverse.nl/api/access/datafile/46153
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 37c77f3c79b7551b8e19f42a7db9ea8d
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 37c77f3c79b7551b8e19f42a7db9ea8d
+      download_url: https://dataverse.nl/api/access/datafile/45966
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5633574342d8f03a72e934625fa9201c
+      byte_size: 467073
+      checksum:
+        algorithm: md5
+        digest: 5633574342d8f03a72e934625fa9201c
+      download_url: https://dataverse.nl/api/access/datafile/45497
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2031bfb21864f6e06400b510b8203044
+      byte_size: 20736352
+      checksum:
+        algorithm: md5
+        digest: 2031bfb21864f6e06400b510b8203044
+      download_url: https://dataverse.nl/api/access/datafile/45619
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-020/
+      qualified_part:
+        - relation: sub-020/anat/
+          name: anat
+        - relation: sub-020/func/
+          name: func
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-020/anat/
+      qualified_part:
+        - relation: 2031bfb21864f6e06400b510b8203044
+          name: sub-020_T1w.nii
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: af9d9451739f64a0f22ff1b30a3fa978
+      byte_size: 1041
+      checksum:
+        algorithm: md5
+        digest: af9d9451739f64a0f22ff1b30a3fa978
+      download_url: https://dataverse.nl/api/access/datafile/45324
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-020/func/
+      qualified_part:
+        - relation: af9d9451739f64a0f22ff1b30a3fa978
+          name: sub-020_task-emotionProcessing_echo-1_bold.json
+        - relation: a9236393e1e47f0b93eec303465128cb
+          name: sub-020_task-emotionProcessing_echo-1_bold.nii
+        - relation: 68a0cc41e95d67371eaaea84c0dbc4a6
+          name: sub-020_task-emotionProcessing_echo-2_bold.json
+        - relation: a773cd7727a540c59e6f360646037c27
+          name: sub-020_task-emotionProcessing_echo-2_bold.nii
+        - relation: 6bc691ba3a1cdd343b8f316e59f79f0f
+          name: sub-020_task-emotionProcessing_echo-3_bold.json
+        - relation: 4f896fe9c393d710e40dcea762abfb29
+          name: sub-020_task-emotionProcessing_echo-3_bold.nii
+        - relation: 18d24a490dfd820a1fb7b01308a7ac6f
+          name: sub-020_task-emotionProcessing_events.tsv.gz
+        - relation: 7043bbbcd78adf0cc7baf6dad05d43d6
+          name: sub-020_task-emotionProcessingImagined_echo-1_bold.json
+        - relation: 7fab3783b35f2a4965cf7b92cabcf99c
+          name: sub-020_task-emotionProcessingImagined_echo-1_bold.nii
+        - relation: 9696bd7cb2254077b09d1a659e634eef
+          name: sub-020_task-emotionProcessingImagined_echo-2_bold.json
+        - relation: 2f9286f8332bf92a2491e5ff12ef4680
+          name: sub-020_task-emotionProcessingImagined_echo-2_bold.nii
+        - relation: 71d6b2d68cace2c79dda7774f55df7ec
+          name: sub-020_task-emotionProcessingImagined_echo-3_bold.json
+        - relation: cf5c63c15cab2821cecf8856c4e2ef25
+          name: sub-020_task-emotionProcessingImagined_echo-3_bold.nii
+        - relation: b3077b1bd8ce0512419d6284e37f40c6
+          name: sub-020_task-emotionProcessingImagined_events.tsv.gz
+        - relation: 0bf96f9d17dae1e39fe5c65b0e55ed9d
+          name: sub-020_task-emotionProcessingImagined_physio.json
+        - relation: 5d0319f59b05a52823b0c79e79eb8a52
+          name: sub-020_task-emotionProcessingImagined_physio.tsv.gz
+        - relation: 4788b62f42bca229f416979a1a70f3af
+          name: sub-020_task-emotionProcessing_physio.json
+        - relation: 37f51d06e4000f7cead83073bdb49c90
+          name: sub-020_task-emotionProcessing_physio.tsv.gz
+        - relation: 91e9a2070f99e72c49bdd5f067cad2c0
+          name: sub-020_task-fingerTapping_echo-1_bold.json
+        - relation: 2b3c91a743b6a6e4c5a0e74389ec45a1
+          name: sub-020_task-fingerTapping_echo-1_bold.nii
+        - relation: 299e79b9c488c38b8708d86e1ad3ea54
+          name: sub-020_task-fingerTapping_echo-2_bold.json
+        - relation: 47a984ac1c5b613e9a2d280ed1dfd925
+          name: sub-020_task-fingerTapping_echo-2_bold.nii
+        - relation: b68ebef9beb3d443a8cda33c81eed151
+          name: sub-020_task-fingerTapping_echo-3_bold.json
+        - relation: 66ea37e8bb1555d1624e3a4e6a01ae64
+          name: sub-020_task-fingerTapping_echo-3_bold.nii
+        - relation: 470665491f9f9cc008c64311d0907b0f
+          name: sub-020_task-fingerTapping_events.tsv.gz
+        - relation: fc7a4059aa5d62bc93ef8a2d4af7bfbd
+          name: sub-020_task-fingerTappingImagined_echo-1_bold.json
+        - relation: b62010362a3182366cf429f65aca268b
+          name: sub-020_task-fingerTappingImagined_echo-1_bold.nii
+        - relation: b00ce22e507a1ef0de51435b0fc675b5
+          name: sub-020_task-fingerTappingImagined_echo-2_bold.json
+        - relation: 624d93602e8bdaa6b373a2851910dc7e
+          name: sub-020_task-fingerTappingImagined_echo-2_bold.nii
+        - relation: d497cf246c43221189d05e659d07387e
+          name: sub-020_task-fingerTappingImagined_echo-3_bold.json
+        - relation: 7f78ecccca242d27e608a4f7e5e6f716
+          name: sub-020_task-fingerTappingImagined_echo-3_bold.nii
+        - relation: 31ca847b21f8e14a7dd11e8bb92d56d4
+          name: sub-020_task-fingerTappingImagined_events.tsv.gz
+        - relation: 49b4f774348322000298d4f1fa57434b
+          name: sub-020_task-fingerTappingImagined_physio.json
+        - relation: 1268aae9d99d26faa2e0d0eb7cd9848e
+          name: sub-020_task-fingerTappingImagined_physio.tsv.gz
+        - relation: 6993ca98abbb4f4d0d8e666b7eb31d6f
+          name: sub-020_task-fingerTapping_physio.json
+        - relation: ac252b88b9d7469952d7d62b7a53bc76
+          name: sub-020_task-fingerTapping_physio.tsv.gz
+        - relation: ae71582204caffee278155a68df35674
+          name: sub-020_task-rest_run-1_echo-1_bold.json
+        - relation: ba087d91bd1df4b312360e0a4923fea2
+          name: sub-020_task-rest_run-1_echo-1_bold.nii
+        - relation: 98d7f873c7cebfb8da8498c9e97b2810
+          name: sub-020_task-rest_run-1_echo-2_bold.json
+        - relation: 92b3f5ebc3d4f75af4fe5bf9b179f77f
+          name: sub-020_task-rest_run-1_echo-2_bold.nii
+        - relation: 5c3f69bccff20a48110b0e530030dfa9
+          name: sub-020_task-rest_run-1_echo-3_bold.json
+        - relation: 8763f410a5a6a7dd1cfdf98f04b3d97b
+          name: sub-020_task-rest_run-1_echo-3_bold.nii
+        - relation: 30032943c7e6d421b524177d8a1afcfa
+          name: sub-020_task-rest_run-1_physio.json
+        - relation: c9cd7dd79bc049e4aca8997874ad5c3d
+          name: sub-020_task-rest_run-1_physio.tsv.gz
+        - relation: e117073f0b47f4dcbd4cc1765c1aa582
+          name: sub-020_task-rest_run-2_echo-1_bold.json
+        - relation: fb48a6a4aa6665b6908666ca166fa950
+          name: sub-020_task-rest_run-2_echo-1_bold.nii
+        - relation: 4db99ba729989081c0a195bfbf1ee245
+          name: sub-020_task-rest_run-2_echo-2_bold.json
+        - relation: 4e4e116169a7258dfc095073ce0079c3
+          name: sub-020_task-rest_run-2_echo-2_bold.nii
+        - relation: bc6d8b1879a42ca35c758b7a0299916a
+          name: sub-020_task-rest_run-2_echo-3_bold.json
+        - relation: 997be2b101d7cd226bac1edc5af3cd09
+          name: sub-020_task-rest_run-2_echo-3_bold.nii
+        - relation: 3dc97a367484e8ab554c66df31b45fe8
+          name: sub-020_task-rest_run-2_physio.json
+        - relation: e1aed881353ca29400e6a2190ced6f91
+          name: sub-020_task-rest_run-2_physio.tsv.gz
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a9236393e1e47f0b93eec303465128cb
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: a9236393e1e47f0b93eec303465128cb
+      download_url: https://dataverse.nl/api/access/datafile/46100
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 68a0cc41e95d67371eaaea84c0dbc4a6
+      byte_size: 1041
+      checksum:
+        algorithm: md5
+        digest: 68a0cc41e95d67371eaaea84c0dbc4a6
+      download_url: https://dataverse.nl/api/access/datafile/46423
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a773cd7727a540c59e6f360646037c27
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: a773cd7727a540c59e6f360646037c27
+      download_url: https://dataverse.nl/api/access/datafile/45677
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6bc691ba3a1cdd343b8f316e59f79f0f
+      byte_size: 1041
+      checksum:
+        algorithm: md5
+        digest: 6bc691ba3a1cdd343b8f316e59f79f0f
+      download_url: https://dataverse.nl/api/access/datafile/46257
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4f896fe9c393d710e40dcea762abfb29
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 4f896fe9c393d710e40dcea762abfb29
+      download_url: https://dataverse.nl/api/access/datafile/45780
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 18d24a490dfd820a1fb7b01308a7ac6f
+      byte_size: 1895
+      checksum:
+        algorithm: md5
+        digest: 18d24a490dfd820a1fb7b01308a7ac6f
+      download_url: https://dataverse.nl/api/access/datafile/46636
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 7043bbbcd78adf0cc7baf6dad05d43d6
+      byte_size: 1049
+      checksum:
+        algorithm: md5
+        digest: 7043bbbcd78adf0cc7baf6dad05d43d6
+      download_url: https://dataverse.nl/api/access/datafile/46316
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 7fab3783b35f2a4965cf7b92cabcf99c
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 7fab3783b35f2a4965cf7b92cabcf99c
+      download_url: https://dataverse.nl/api/access/datafile/45654
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 9696bd7cb2254077b09d1a659e634eef
+      byte_size: 1049
+      checksum:
+        algorithm: md5
+        digest: 9696bd7cb2254077b09d1a659e634eef
+      download_url: https://dataverse.nl/api/access/datafile/46252
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2f9286f8332bf92a2491e5ff12ef4680
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 2f9286f8332bf92a2491e5ff12ef4680
+      download_url: https://dataverse.nl/api/access/datafile/45835
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 71d6b2d68cace2c79dda7774f55df7ec
+      byte_size: 1049
+      checksum:
+        algorithm: md5
+        digest: 71d6b2d68cace2c79dda7774f55df7ec
+      download_url: https://dataverse.nl/api/access/datafile/46205
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: cf5c63c15cab2821cecf8856c4e2ef25
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: cf5c63c15cab2821cecf8856c4e2ef25
+      download_url: https://dataverse.nl/api/access/datafile/46070
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b3077b1bd8ce0512419d6284e37f40c6
+      byte_size: 178
+      checksum:
+        algorithm: md5
+        digest: b3077b1bd8ce0512419d6284e37f40c6
+      download_url: https://dataverse.nl/api/access/datafile/46567
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 0bf96f9d17dae1e39fe5c65b0e55ed9d
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 0bf96f9d17dae1e39fe5c65b0e55ed9d
+      download_url: https://dataverse.nl/api/access/datafile/46191
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5d0319f59b05a52823b0c79e79eb8a52
+      byte_size: 456047
+      checksum:
+        algorithm: md5
+        digest: 5d0319f59b05a52823b0c79e79eb8a52
+      download_url: https://dataverse.nl/api/access/datafile/45968
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4788b62f42bca229f416979a1a70f3af
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 4788b62f42bca229f416979a1a70f3af
+      download_url: https://dataverse.nl/api/access/datafile/45696
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 37f51d06e4000f7cead83073bdb49c90
+      byte_size: 480332
+      checksum:
+        algorithm: md5
+        digest: 37f51d06e4000f7cead83073bdb49c90
+      download_url: https://dataverse.nl/api/access/datafile/45632
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 91e9a2070f99e72c49bdd5f067cad2c0
+      byte_size: 1036
+      checksum:
+        algorithm: md5
+        digest: 91e9a2070f99e72c49bdd5f067cad2c0
+      download_url: https://dataverse.nl/api/access/datafile/45417
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2b3c91a743b6a6e4c5a0e74389ec45a1
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 2b3c91a743b6a6e4c5a0e74389ec45a1
+      download_url: https://dataverse.nl/api/access/datafile/45394
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 299e79b9c488c38b8708d86e1ad3ea54
+      byte_size: 1036
+      checksum:
+        algorithm: md5
+        digest: 299e79b9c488c38b8708d86e1ad3ea54
+      download_url: https://dataverse.nl/api/access/datafile/45776
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 47a984ac1c5b613e9a2d280ed1dfd925
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 47a984ac1c5b613e9a2d280ed1dfd925
+      download_url: https://dataverse.nl/api/access/datafile/46305
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b68ebef9beb3d443a8cda33c81eed151
+      byte_size: 1036
+      checksum:
+        algorithm: md5
+        digest: b68ebef9beb3d443a8cda33c81eed151
+      download_url: https://dataverse.nl/api/access/datafile/45734
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 66ea37e8bb1555d1624e3a4e6a01ae64
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 66ea37e8bb1555d1624e3a4e6a01ae64
+      download_url: https://dataverse.nl/api/access/datafile/45725
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 470665491f9f9cc008c64311d0907b0f
+      byte_size: 167
+      checksum:
+        algorithm: md5
+        digest: 470665491f9f9cc008c64311d0907b0f
+      download_url: https://dataverse.nl/api/access/datafile/46563
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: fc7a4059aa5d62bc93ef8a2d4af7bfbd
+      byte_size: 1045
+      checksum:
+        algorithm: md5
+        digest: fc7a4059aa5d62bc93ef8a2d4af7bfbd
+      download_url: https://dataverse.nl/api/access/datafile/45148
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b62010362a3182366cf429f65aca268b
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: b62010362a3182366cf429f65aca268b
+      download_url: https://dataverse.nl/api/access/datafile/46360
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b00ce22e507a1ef0de51435b0fc675b5
+      byte_size: 1045
+      checksum:
+        algorithm: md5
+        digest: b00ce22e507a1ef0de51435b0fc675b5
+      download_url: https://dataverse.nl/api/access/datafile/45536
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 624d93602e8bdaa6b373a2851910dc7e
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 624d93602e8bdaa6b373a2851910dc7e
+      download_url: https://dataverse.nl/api/access/datafile/45623
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d497cf246c43221189d05e659d07387e
+      byte_size: 1045
+      checksum:
+        algorithm: md5
+        digest: d497cf246c43221189d05e659d07387e
+      download_url: https://dataverse.nl/api/access/datafile/45936
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 7f78ecccca242d27e608a4f7e5e6f716
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 7f78ecccca242d27e608a4f7e5e6f716
+      download_url: https://dataverse.nl/api/access/datafile/45643
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 31ca847b21f8e14a7dd11e8bb92d56d4
+      byte_size: 179
+      checksum:
+        algorithm: md5
+        digest: 31ca847b21f8e14a7dd11e8bb92d56d4
+      download_url: https://dataverse.nl/api/access/datafile/46650
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 49b4f774348322000298d4f1fa57434b
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 49b4f774348322000298d4f1fa57434b
+      download_url: https://dataverse.nl/api/access/datafile/45559
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1268aae9d99d26faa2e0d0eb7cd9848e
+      byte_size: 460768
+      checksum:
+        algorithm: md5
+        digest: 1268aae9d99d26faa2e0d0eb7cd9848e
+      download_url: https://dataverse.nl/api/access/datafile/45600
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6993ca98abbb4f4d0d8e666b7eb31d6f
+      byte_size: 142
+      checksum:
+        algorithm: md5
+        digest: 6993ca98abbb4f4d0d8e666b7eb31d6f
+      download_url: https://dataverse.nl/api/access/datafile/45455
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ac252b88b9d7469952d7d62b7a53bc76
+      byte_size: 464906
+      checksum:
+        algorithm: md5
+        digest: ac252b88b9d7469952d7d62b7a53bc76
+      download_url: https://dataverse.nl/api/access/datafile/45450
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ae71582204caffee278155a68df35674
+      byte_size: 1028
+      checksum:
+        algorithm: md5
+        digest: ae71582204caffee278155a68df35674
+      download_url: https://dataverse.nl/api/access/datafile/46544
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ba087d91bd1df4b312360e0a4923fea2
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: ba087d91bd1df4b312360e0a4923fea2
+      download_url: https://dataverse.nl/api/access/datafile/45170
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 98d7f873c7cebfb8da8498c9e97b2810
+      byte_size: 1028
+      checksum:
+        algorithm: md5
+        digest: 98d7f873c7cebfb8da8498c9e97b2810
+      download_url: https://dataverse.nl/api/access/datafile/45400
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 92b3f5ebc3d4f75af4fe5bf9b179f77f
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 92b3f5ebc3d4f75af4fe5bf9b179f77f
+      download_url: https://dataverse.nl/api/access/datafile/45385
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5c3f69bccff20a48110b0e530030dfa9
+      byte_size: 1028
+      checksum:
+        algorithm: md5
+        digest: 5c3f69bccff20a48110b0e530030dfa9
+      download_url: https://dataverse.nl/api/access/datafile/45640
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8763f410a5a6a7dd1cfdf98f04b3d97b
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 8763f410a5a6a7dd1cfdf98f04b3d97b
+      download_url: https://dataverse.nl/api/access/datafile/45882
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 30032943c7e6d421b524177d8a1afcfa
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 30032943c7e6d421b524177d8a1afcfa
+      download_url: https://dataverse.nl/api/access/datafile/45333
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c9cd7dd79bc049e4aca8997874ad5c3d
+      byte_size: 462284
+      checksum:
+        algorithm: md5
+        digest: c9cd7dd79bc049e4aca8997874ad5c3d
+      download_url: https://dataverse.nl/api/access/datafile/45693
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e117073f0b47f4dcbd4cc1765c1aa582
+      byte_size: 1026
+      checksum:
+        algorithm: md5
+        digest: e117073f0b47f4dcbd4cc1765c1aa582
+      download_url: https://dataverse.nl/api/access/datafile/45504
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: fb48a6a4aa6665b6908666ca166fa950
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: fb48a6a4aa6665b6908666ca166fa950
+      download_url: https://dataverse.nl/api/access/datafile/45947
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4db99ba729989081c0a195bfbf1ee245
+      byte_size: 1026
+      checksum:
+        algorithm: md5
+        digest: 4db99ba729989081c0a195bfbf1ee245
+      download_url: https://dataverse.nl/api/access/datafile/46152
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4e4e116169a7258dfc095073ce0079c3
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 4e4e116169a7258dfc095073ce0079c3
+      download_url: https://dataverse.nl/api/access/datafile/46278
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: bc6d8b1879a42ca35c758b7a0299916a
+      byte_size: 1026
+      checksum:
+        algorithm: md5
+        digest: bc6d8b1879a42ca35c758b7a0299916a
+      download_url: https://dataverse.nl/api/access/datafile/45892
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 997be2b101d7cd226bac1edc5af3cd09
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 997be2b101d7cd226bac1edc5af3cd09
+      download_url: https://dataverse.nl/api/access/datafile/46404
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 3dc97a367484e8ab554c66df31b45fe8
+      byte_size: 142
+      checksum:
+        algorithm: md5
+        digest: 3dc97a367484e8ab554c66df31b45fe8
+      download_url: https://dataverse.nl/api/access/datafile/46174
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e1aed881353ca29400e6a2190ced6f91
+      byte_size: 457579
+      checksum:
+        algorithm: md5
+        digest: e1aed881353ca29400e6a2190ced6f91
+      download_url: https://dataverse.nl/api/access/datafile/45516
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 9591a73ee0d16e4b489af21b1bb91e05
+      byte_size: 20736352
+      checksum:
+        algorithm: md5
+        digest: 9591a73ee0d16e4b489af21b1bb91e05
+      download_url: https://dataverse.nl/api/access/datafile/45858
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-021/
+      qualified_part:
+        - relation: sub-021/anat/
+          name: anat
+        - relation: sub-021/func/
+          name: func
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-021/anat/
+      qualified_part:
+        - relation: 9591a73ee0d16e4b489af21b1bb91e05
+          name: sub-021_T1w.nii
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d0023eb081b190e3c8fc0dd8509bb0f9
+      byte_size: 1040
+      checksum:
+        algorithm: md5
+        digest: d0023eb081b190e3c8fc0dd8509bb0f9
+      download_url: https://dataverse.nl/api/access/datafile/45268
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-021/func/
+      qualified_part:
+        - relation: d0023eb081b190e3c8fc0dd8509bb0f9
+          name: sub-021_task-emotionProcessing_echo-1_bold.json
+        - relation: 57d9a3bf07cfe88fe10de40a8b4032d3
+          name: sub-021_task-emotionProcessing_echo-1_bold.nii
+        - relation: 645130bfc1161abba0de6ae3f3f4e6c9
+          name: sub-021_task-emotionProcessing_echo-2_bold.json
+        - relation: 8c0b8a19e338f222d0ce0ca1fda9588e
+          name: sub-021_task-emotionProcessing_echo-2_bold.nii
+        - relation: debb30a678f8fe0afecf0266d2bf6adf
+          name: sub-021_task-emotionProcessing_echo-3_bold.json
+        - relation: 5cd16353333566365b09a317b6fa8f4d
+          name: sub-021_task-emotionProcessing_echo-3_bold.nii
+        - relation: 759a80d55b3aa2f2796f5a25790bf290
+          name: sub-021_task-emotionProcessing_events.tsv.gz
+        - relation: a152a08f2e48f0b7b5cc243f7cc26f53
+          name: sub-021_task-emotionProcessingImagined_echo-1_bold.json
+        - relation: 1b82e698e524c8dcaa6b9e6bea44b1ca
+          name: sub-021_task-emotionProcessingImagined_echo-1_bold.nii
+        - relation: 873d7d8d93c7c346f8f4f598cc4e15c0
+          name: sub-021_task-emotionProcessingImagined_echo-2_bold.json
+        - relation: 351d54c39476a6491885442fc63604ef
+          name: sub-021_task-emotionProcessingImagined_echo-2_bold.nii
+        - relation: 89f70975ea2771e0ed50e8ea9720d55e
+          name: sub-021_task-emotionProcessingImagined_echo-3_bold.json
+        - relation: 8db1f89aba4a97bd203e827e4044318b
+          name: sub-021_task-emotionProcessingImagined_echo-3_bold.nii
+        - relation: 67ed2f653f579202ed7340435c6ab73b
+          name: sub-021_task-emotionProcessingImagined_events.tsv.gz
+        - relation: 4e10497094e60af65c678efe3925d47b
+          name: sub-021_task-emotionProcessingImagined_physio.json
+        - relation: 9b3bbbb443a9a48ef0c2d822cb1cb6b5
+          name: sub-021_task-emotionProcessingImagined_physio.tsv.gz
+        - relation: 32cd9758c3c70f30f9f6cf55829adc82
+          name: sub-021_task-emotionProcessing_physio.json
+        - relation: 6108f65d2b70c30e0d1175a95b20ad6c
+          name: sub-021_task-emotionProcessing_physio.tsv.gz
+        - relation: 8cf4e469e5ba11fa1919bee6736165ab
+          name: sub-021_task-fingerTapping_echo-1_bold.json
+        - relation: 5b2d8410ab537f6341837a8b7d43173f
+          name: sub-021_task-fingerTapping_echo-1_bold.nii
+        - relation: 438c6dba76ba2d63e2aaed7c147084ee
+          name: sub-021_task-fingerTapping_echo-2_bold.json
+        - relation: 8cdcaf74eede11999411bf9b662a7f00
+          name: sub-021_task-fingerTapping_echo-2_bold.nii
+        - relation: b406dd2f244b6773f01dd9f39d0ec087
+          name: sub-021_task-fingerTapping_echo-3_bold.json
+        - relation: e2c088d4f19fba0369901e56e3158501
+          name: sub-021_task-fingerTapping_echo-3_bold.nii
+        - relation: e92392f12915a922a166216e0c8a799f
+          name: sub-021_task-fingerTapping_events.tsv.gz
+        - relation: 00f67e6452f7bbb3118454730dc6d317
+          name: sub-021_task-fingerTappingImagined_echo-1_bold.json
+        - relation: 2ce149c5a4af8b9957da0dc40dc715cb
+          name: sub-021_task-fingerTappingImagined_echo-1_bold.nii
+        - relation: 43937553b0f8fad6ab85114f9b1fd135
+          name: sub-021_task-fingerTappingImagined_echo-2_bold.json
+        - relation: 2d838ecd17860236e958442999d380a6
+          name: sub-021_task-fingerTappingImagined_echo-2_bold.nii
+        - relation: 70d0a2ff1effbbb17bb3148cdd5a1c65
+          name: sub-021_task-fingerTappingImagined_echo-3_bold.json
+        - relation: 57ca7c934b6dfc41c14ea723ba6c0424
+          name: sub-021_task-fingerTappingImagined_echo-3_bold.nii
+        - relation: 5f2b58977057a2f8e8f3a63afdbf26cc
+          name: sub-021_task-fingerTappingImagined_events.tsv.gz
+        - relation: 20674885589debb9c452b1e18fa23a0a
+          name: sub-021_task-fingerTappingImagined_physio.json
+        - relation: c89e4808bbab12010f23016a0cf937ae
+          name: sub-021_task-fingerTappingImagined_physio.tsv.gz
+        - relation: 0a33dbb8d6e81df3efa76ea8a52b02bc
+          name: sub-021_task-fingerTapping_physio.json
+        - relation: 81ad87529d1a8598643ab6a282f424f1
+          name: sub-021_task-fingerTapping_physio.tsv.gz
+        - relation: 439532d80054b2f2b25bc5029f644101
+          name: sub-021_task-rest_run-1_echo-1_bold.json
+        - relation: d16963c7dd0eec20ffc6b1d61262e0f8
+          name: sub-021_task-rest_run-1_echo-1_bold.nii
+        - relation: 482b1c24457a0da28096c2a4a99c3ae1
+          name: sub-021_task-rest_run-1_echo-2_bold.json
+        - relation: ab844da48b9cd77cb915b4be5e32c053
+          name: sub-021_task-rest_run-1_echo-2_bold.nii
+        - relation: a99b02aa878cfb5f143bb91d3ede0087
+          name: sub-021_task-rest_run-1_echo-3_bold.json
+        - relation: e80f236e33afd69ae1b0f87ba29346b6
+          name: sub-021_task-rest_run-1_echo-3_bold.nii
+        - relation: d79c73483b13c27b4c5ce1e06ac44473
+          name: sub-021_task-rest_run-1_physio.json
+        - relation: 7a2374c3a0b447ef4e822a9010dfb1d5
+          name: sub-021_task-rest_run-1_physio.tsv.gz
+        - relation: 56619e6f98a70ea32e028893cbe358da
+          name: sub-021_task-rest_run-2_echo-1_bold.json
+        - relation: f4094fd68d34823fd6b4123c02129fa2
+          name: sub-021_task-rest_run-2_echo-1_bold.nii
+        - relation: 475d75d2c07d00ee4f24e4f9435bf949
+          name: sub-021_task-rest_run-2_echo-2_bold.json
+        - relation: 47e7d3ecfa69dc91f8316a1206bbb370
+          name: sub-021_task-rest_run-2_echo-2_bold.nii
+        - relation: 50722e2e70ab9b8e8f76933bc17604e5
+          name: sub-021_task-rest_run-2_echo-3_bold.json
+        - relation: 1c9f3613de8fb930b5f899b347062957
+          name: sub-021_task-rest_run-2_echo-3_bold.nii
+        - relation: 10a80fd8b46666dd4467720de4a113fb
+          name: sub-021_task-rest_run-2_physio.json
+        - relation: 7dfcc62dc4e2e6c62a344642dffa3d0d
+          name: sub-021_task-rest_run-2_physio.tsv.gz
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 57d9a3bf07cfe88fe10de40a8b4032d3
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 57d9a3bf07cfe88fe10de40a8b4032d3
+      download_url: https://dataverse.nl/api/access/datafile/45587
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 645130bfc1161abba0de6ae3f3f4e6c9
+      byte_size: 1040
+      checksum:
+        algorithm: md5
+        digest: 645130bfc1161abba0de6ae3f3f4e6c9
+      download_url: https://dataverse.nl/api/access/datafile/45307
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8c0b8a19e338f222d0ce0ca1fda9588e
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 8c0b8a19e338f222d0ce0ca1fda9588e
+      download_url: https://dataverse.nl/api/access/datafile/45761
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: debb30a678f8fe0afecf0266d2bf6adf
+      byte_size: 1040
+      checksum:
+        algorithm: md5
+        digest: debb30a678f8fe0afecf0266d2bf6adf
+      download_url: https://dataverse.nl/api/access/datafile/46479
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5cd16353333566365b09a317b6fa8f4d
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 5cd16353333566365b09a317b6fa8f4d
+      download_url: https://dataverse.nl/api/access/datafile/46112
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 759a80d55b3aa2f2796f5a25790bf290
+      byte_size: 1938
+      checksum:
+        algorithm: md5
+        digest: 759a80d55b3aa2f2796f5a25790bf290
+      download_url: https://dataverse.nl/api/access/datafile/46616
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a152a08f2e48f0b7b5cc243f7cc26f53
+      byte_size: 1048
+      checksum:
+        algorithm: md5
+        digest: a152a08f2e48f0b7b5cc243f7cc26f53
+      download_url: https://dataverse.nl/api/access/datafile/45414
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1b82e698e524c8dcaa6b9e6bea44b1ca
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 1b82e698e524c8dcaa6b9e6bea44b1ca
+      download_url: https://dataverse.nl/api/access/datafile/45569
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 873d7d8d93c7c346f8f4f598cc4e15c0
+      byte_size: 1048
+      checksum:
+        algorithm: md5
+        digest: 873d7d8d93c7c346f8f4f598cc4e15c0
+      download_url: https://dataverse.nl/api/access/datafile/46459
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 351d54c39476a6491885442fc63604ef
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 351d54c39476a6491885442fc63604ef
+      download_url: https://dataverse.nl/api/access/datafile/46246
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 89f70975ea2771e0ed50e8ea9720d55e
+      byte_size: 1048
+      checksum:
+        algorithm: md5
+        digest: 89f70975ea2771e0ed50e8ea9720d55e
+      download_url: https://dataverse.nl/api/access/datafile/46418
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8db1f89aba4a97bd203e827e4044318b
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 8db1f89aba4a97bd203e827e4044318b
+      download_url: https://dataverse.nl/api/access/datafile/46399
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 67ed2f653f579202ed7340435c6ab73b
+      byte_size: 173
+      checksum:
+        algorithm: md5
+        digest: 67ed2f653f579202ed7340435c6ab73b
+      download_url: https://dataverse.nl/api/access/datafile/46575
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4e10497094e60af65c678efe3925d47b
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 4e10497094e60af65c678efe3925d47b
+      download_url: https://dataverse.nl/api/access/datafile/46525
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 9b3bbbb443a9a48ef0c2d822cb1cb6b5
+      byte_size: 481794
+      checksum:
+        algorithm: md5
+        digest: 9b3bbbb443a9a48ef0c2d822cb1cb6b5
+      download_url: https://dataverse.nl/api/access/datafile/46501
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 32cd9758c3c70f30f9f6cf55829adc82
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 32cd9758c3c70f30f9f6cf55829adc82
+      download_url: https://dataverse.nl/api/access/datafile/45145
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6108f65d2b70c30e0d1175a95b20ad6c
+      byte_size: 515684
+      checksum:
+        algorithm: md5
+        digest: 6108f65d2b70c30e0d1175a95b20ad6c
+      download_url: https://dataverse.nl/api/access/datafile/46220
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8cf4e469e5ba11fa1919bee6736165ab
+      byte_size: 1036
+      checksum:
+        algorithm: md5
+        digest: 8cf4e469e5ba11fa1919bee6736165ab
+      download_url: https://dataverse.nl/api/access/datafile/45663
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5b2d8410ab537f6341837a8b7d43173f
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 5b2d8410ab537f6341837a8b7d43173f
+      download_url: https://dataverse.nl/api/access/datafile/45670
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 438c6dba76ba2d63e2aaed7c147084ee
+      byte_size: 1036
+      checksum:
+        algorithm: md5
+        digest: 438c6dba76ba2d63e2aaed7c147084ee
+      download_url: https://dataverse.nl/api/access/datafile/45727
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8cdcaf74eede11999411bf9b662a7f00
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 8cdcaf74eede11999411bf9b662a7f00
+      download_url: https://dataverse.nl/api/access/datafile/45684
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b406dd2f244b6773f01dd9f39d0ec087
+      byte_size: 1036
+      checksum:
+        algorithm: md5
+        digest: b406dd2f244b6773f01dd9f39d0ec087
+      download_url: https://dataverse.nl/api/access/datafile/45902
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e2c088d4f19fba0369901e56e3158501
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: e2c088d4f19fba0369901e56e3158501
+      download_url: https://dataverse.nl/api/access/datafile/45685
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e92392f12915a922a166216e0c8a799f
+      byte_size: 161
+      checksum:
+        algorithm: md5
+        digest: e92392f12915a922a166216e0c8a799f
+      download_url: https://dataverse.nl/api/access/datafile/46639
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 00f67e6452f7bbb3118454730dc6d317
+      byte_size: 1044
+      checksum:
+        algorithm: md5
+        digest: 00f67e6452f7bbb3118454730dc6d317
+      download_url: https://dataverse.nl/api/access/datafile/45179
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2ce149c5a4af8b9957da0dc40dc715cb
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 2ce149c5a4af8b9957da0dc40dc715cb
+      download_url: https://dataverse.nl/api/access/datafile/45209
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 43937553b0f8fad6ab85114f9b1fd135
+      byte_size: 1044
+      checksum:
+        algorithm: md5
+        digest: 43937553b0f8fad6ab85114f9b1fd135
+      download_url: https://dataverse.nl/api/access/datafile/45134
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2d838ecd17860236e958442999d380a6
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 2d838ecd17860236e958442999d380a6
+      download_url: https://dataverse.nl/api/access/datafile/45697
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 70d0a2ff1effbbb17bb3148cdd5a1c65
+      byte_size: 1044
+      checksum:
+        algorithm: md5
+        digest: 70d0a2ff1effbbb17bb3148cdd5a1c65
+      download_url: https://dataverse.nl/api/access/datafile/45842
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 57ca7c934b6dfc41c14ea723ba6c0424
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 57ca7c934b6dfc41c14ea723ba6c0424
+      download_url: https://dataverse.nl/api/access/datafile/45403
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5f2b58977057a2f8e8f3a63afdbf26cc
+      byte_size: 177
+      checksum:
+        algorithm: md5
+        digest: 5f2b58977057a2f8e8f3a63afdbf26cc
+      download_url: https://dataverse.nl/api/access/datafile/46559
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 20674885589debb9c452b1e18fa23a0a
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 20674885589debb9c452b1e18fa23a0a
+      download_url: https://dataverse.nl/api/access/datafile/45768
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c89e4808bbab12010f23016a0cf937ae
+      byte_size: 503755
+      checksum:
+        algorithm: md5
+        digest: c89e4808bbab12010f23016a0cf937ae
+      download_url: https://dataverse.nl/api/access/datafile/46371
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 0a33dbb8d6e81df3efa76ea8a52b02bc
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 0a33dbb8d6e81df3efa76ea8a52b02bc
+      download_url: https://dataverse.nl/api/access/datafile/46469
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 81ad87529d1a8598643ab6a282f424f1
+      byte_size: 493542
+      checksum:
+        algorithm: md5
+        digest: 81ad87529d1a8598643ab6a282f424f1
+      download_url: https://dataverse.nl/api/access/datafile/46045
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 439532d80054b2f2b25bc5029f644101
+      byte_size: 1027
+      checksum:
+        algorithm: md5
+        digest: 439532d80054b2f2b25bc5029f644101
+      download_url: https://dataverse.nl/api/access/datafile/45224
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d16963c7dd0eec20ffc6b1d61262e0f8
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: d16963c7dd0eec20ffc6b1d61262e0f8
+      download_url: https://dataverse.nl/api/access/datafile/46393
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 482b1c24457a0da28096c2a4a99c3ae1
+      byte_size: 1027
+      checksum:
+        algorithm: md5
+        digest: 482b1c24457a0da28096c2a4a99c3ae1
+      download_url: https://dataverse.nl/api/access/datafile/45913
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ab844da48b9cd77cb915b4be5e32c053
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: ab844da48b9cd77cb915b4be5e32c053
+      download_url: https://dataverse.nl/api/access/datafile/45702
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a99b02aa878cfb5f143bb91d3ede0087
+      byte_size: 1027
+      checksum:
+        algorithm: md5
+        digest: a99b02aa878cfb5f143bb91d3ede0087
+      download_url: https://dataverse.nl/api/access/datafile/45427
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e80f236e33afd69ae1b0f87ba29346b6
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: e80f236e33afd69ae1b0f87ba29346b6
+      download_url: https://dataverse.nl/api/access/datafile/45987
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d79c73483b13c27b4c5ce1e06ac44473
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: d79c73483b13c27b4c5ce1e06ac44473
+      download_url: https://dataverse.nl/api/access/datafile/45360
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 7a2374c3a0b447ef4e822a9010dfb1d5
+      byte_size: 472964
+      checksum:
+        algorithm: md5
+        digest: 7a2374c3a0b447ef4e822a9010dfb1d5
+      download_url: https://dataverse.nl/api/access/datafile/45548
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 56619e6f98a70ea32e028893cbe358da
+      byte_size: 1027
+      checksum:
+        algorithm: md5
+        digest: 56619e6f98a70ea32e028893cbe358da
+      download_url: https://dataverse.nl/api/access/datafile/46276
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f4094fd68d34823fd6b4123c02129fa2
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: f4094fd68d34823fd6b4123c02129fa2
+      download_url: https://dataverse.nl/api/access/datafile/45474
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 475d75d2c07d00ee4f24e4f9435bf949
+      byte_size: 1027
+      checksum:
+        algorithm: md5
+        digest: 475d75d2c07d00ee4f24e4f9435bf949
+      download_url: https://dataverse.nl/api/access/datafile/45540
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 47e7d3ecfa69dc91f8316a1206bbb370
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 47e7d3ecfa69dc91f8316a1206bbb370
+      download_url: https://dataverse.nl/api/access/datafile/45612
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 50722e2e70ab9b8e8f76933bc17604e5
+      byte_size: 1027
+      checksum:
+        algorithm: md5
+        digest: 50722e2e70ab9b8e8f76933bc17604e5
+      download_url: https://dataverse.nl/api/access/datafile/46202
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1c9f3613de8fb930b5f899b347062957
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 1c9f3613de8fb930b5f899b347062957
+      download_url: https://dataverse.nl/api/access/datafile/45272
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 10a80fd8b46666dd4467720de4a113fb
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 10a80fd8b46666dd4467720de4a113fb
+      download_url: https://dataverse.nl/api/access/datafile/46237
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 7dfcc62dc4e2e6c62a344642dffa3d0d
+      byte_size: 466392
+      checksum:
+        algorithm: md5
+        digest: 7dfcc62dc4e2e6c62a344642dffa3d0d
+      download_url: https://dataverse.nl/api/access/datafile/45168
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 485d9f7ff0ca722ebdb751023d3206f1
+      byte_size: 20736352
+      checksum:
+        algorithm: md5
+        digest: 485d9f7ff0ca722ebdb751023d3206f1
+      download_url: https://dataverse.nl/api/access/datafile/45406
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-022/
+      qualified_part:
+        - relation: sub-022/anat/
+          name: anat
+        - relation: sub-022/func/
+          name: func
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-022/anat/
+      qualified_part:
+        - relation: 485d9f7ff0ca722ebdb751023d3206f1
+          name: sub-022_T1w.nii
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e9bb70745528c4630bac456ea0b0c3e7
+      byte_size: 1040
+      checksum:
+        algorithm: md5
+        digest: e9bb70745528c4630bac456ea0b0c3e7
+      download_url: https://dataverse.nl/api/access/datafile/46392
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-022/func/
+      qualified_part:
+        - relation: e9bb70745528c4630bac456ea0b0c3e7
+          name: sub-022_task-emotionProcessing_echo-1_bold.json
+        - relation: 90c647375623883b3b8413095208c276
+          name: sub-022_task-emotionProcessing_echo-1_bold.nii
+        - relation: 857a1942641a85653c9ce048d46767ea
+          name: sub-022_task-emotionProcessing_echo-2_bold.json
+        - relation: bb86f022f1ebf2b26365d437ebe105df
+          name: sub-022_task-emotionProcessing_echo-2_bold.nii
+        - relation: 2bb9650a47d89ce97ca95a1a5fa6a3b1
+          name: sub-022_task-emotionProcessing_echo-3_bold.json
+        - relation: 17f5f08163012f6a580f98e82e87eb2c
+          name: sub-022_task-emotionProcessing_echo-3_bold.nii
+        - relation: 8189057888af59647daccefdc59e4eb4
+          name: sub-022_task-emotionProcessing_events.tsv.gz
+        - relation: dc7224e4a5ea9828b7ea312aaf7ba646
+          name: sub-022_task-emotionProcessingImagined_echo-1_bold.json
+        - relation: 823032ce07d962c4a133f74e121b3761
+          name: sub-022_task-emotionProcessingImagined_echo-1_bold.nii
+        - relation: 026cb0721fd8bf78490e741ea5d91794
+          name: sub-022_task-emotionProcessingImagined_echo-2_bold.json
+        - relation: 24a26e779af8ea625527291f9046aefb
+          name: sub-022_task-emotionProcessingImagined_echo-2_bold.nii
+        - relation: ce7c422b09e0f0b02f34d4613ccc4229
+          name: sub-022_task-emotionProcessingImagined_echo-3_bold.json
+        - relation: 1845ba28a5fc280f36b605043a38541b
+          name: sub-022_task-emotionProcessingImagined_echo-3_bold.nii
+        - relation: b241742b7e85b01450282a2e7aa4e058
+          name: sub-022_task-emotionProcessingImagined_events.tsv.gz
+        - relation: 32828a99a87019d6f9078e03c648c68d
+          name: sub-022_task-emotionProcessingImagined_physio.json
+        - relation: 82af247c3278288279a833073b9066db
+          name: sub-022_task-emotionProcessingImagined_physio.tsv.gz
+        - relation: fe69e80cf45f5e9d5310ed1a738a696e
+          name: sub-022_task-emotionProcessing_physio.json
+        - relation: dad4fcc69a0b3469fbf3a26b71965b55
+          name: sub-022_task-emotionProcessing_physio.tsv.gz
+        - relation: 7d197f0669600972b57583e3532570dd
+          name: sub-022_task-fingerTapping_echo-1_bold.json
+        - relation: fe849a80e4cd766fd6835344b8bd1f3d
+          name: sub-022_task-fingerTapping_echo-1_bold.nii
+        - relation: 52a2f13d5077977571bf6496be1c32a5
+          name: sub-022_task-fingerTapping_echo-2_bold.json
+        - relation: f210ac99e2c99a5bfa20be2b781f89ff
+          name: sub-022_task-fingerTapping_echo-2_bold.nii
+        - relation: 8e7a2146ec718c117d2b903b43af828a
+          name: sub-022_task-fingerTapping_echo-3_bold.json
+        - relation: c0b91f1e9a73301ba10b8eccff10a605
+          name: sub-022_task-fingerTapping_echo-3_bold.nii
+        - relation: 0aefea2893935c3e98e5c277f766941f
+          name: sub-022_task-fingerTapping_events.tsv.gz
+        - relation: 5533bdd647e1a2cabd33ed8d1acdde59
+          name: sub-022_task-fingerTappingImagined_echo-1_bold.json
+        - relation: dc4d3bc21a3c8ed6d4a7e65d2ac3199b
+          name: sub-022_task-fingerTappingImagined_echo-1_bold.nii
+        - relation: a13d744ad4c709cf59dc9e1b10a1b1f1
+          name: sub-022_task-fingerTappingImagined_echo-2_bold.json
+        - relation: e869e8e8559023be1856f208982d05d7
+          name: sub-022_task-fingerTappingImagined_echo-2_bold.nii
+        - relation: d1908bea5803e84906ad952c234953bb
+          name: sub-022_task-fingerTappingImagined_echo-3_bold.json
+        - relation: e49be718e9fb740f14a2bc7a4d3f0e3d
+          name: sub-022_task-fingerTappingImagined_echo-3_bold.nii
+        - relation: ad3350bfe793a923b57adc825e721fe0
+          name: sub-022_task-fingerTappingImagined_events.tsv.gz
+        - relation: 87ad0780b5acc158fd21bd4806f54b8c
+          name: sub-022_task-fingerTappingImagined_physio.json
+        - relation: 06420ff40545291d3103f32844fa3e8e
+          name: sub-022_task-fingerTappingImagined_physio.tsv.gz
+        - relation: 1293460b4ce9a1b3ae3e197acb543c0c
+          name: sub-022_task-fingerTapping_physio.json
+        - relation: ea398a208034c539761c427021944b9f
+          name: sub-022_task-fingerTapping_physio.tsv.gz
+        - relation: b5e25fbbb45223cccae01bd64ff64c06
+          name: sub-022_task-rest_run-1_echo-1_bold.json
+        - relation: ad1fcb25847e6546bdd84ec40742ae27
+          name: sub-022_task-rest_run-1_echo-1_bold.nii
+        - relation: 383dfc8610f1c4ac70ed6380d6024ada
+          name: sub-022_task-rest_run-1_echo-2_bold.json
+        - relation: 1209b5fd6974ffee065a3a6c5767fab5
+          name: sub-022_task-rest_run-1_echo-2_bold.nii
+        - relation: 6ff7e84e984a2a7a283ae0550acf5fa0
+          name: sub-022_task-rest_run-1_echo-3_bold.json
+        - relation: 215134b08c99ad535e216dce3cecef73
+          name: sub-022_task-rest_run-1_echo-3_bold.nii
+        - relation: 4f6504f90de8cc8caa5ed4eec7fc7a55
+          name: sub-022_task-rest_run-1_physio.json
+        - relation: dd889f338e9721209a5c7494ea542a48
+          name: sub-022_task-rest_run-1_physio.tsv.gz
+        - relation: 8a7a7e378d88a320bc13aa573e33e9cf
+          name: sub-022_task-rest_run-2_echo-1_bold.json
+        - relation: f26b54d5131b4150f67442ba57d247e1
+          name: sub-022_task-rest_run-2_echo-1_bold.nii
+        - relation: 794ddb9e826cd7224e77a581d33b2af5
+          name: sub-022_task-rest_run-2_echo-2_bold.json
+        - relation: f65dc11611257fa72e9ae4a1fa1061f9
+          name: sub-022_task-rest_run-2_echo-2_bold.nii
+        - relation: a21e290d360f3207465b7919fe9f97c4
+          name: sub-022_task-rest_run-2_echo-3_bold.json
+        - relation: 69773a651271d49947757f38d3a8a144
+          name: sub-022_task-rest_run-2_echo-3_bold.nii
+        - relation: 1b07b0c2da81eab7a599744912d99a4a
+          name: sub-022_task-rest_run-2_physio.json
+        - relation: 3ca0ba152166f56d7289348c95c3ff44
+          name: sub-022_task-rest_run-2_physio.tsv.gz
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 90c647375623883b3b8413095208c276
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 90c647375623883b3b8413095208c276
+      download_url: https://dataverse.nl/api/access/datafile/45206
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 857a1942641a85653c9ce048d46767ea
+      byte_size: 1040
+      checksum:
+        algorithm: md5
+        digest: 857a1942641a85653c9ce048d46767ea
+      download_url: https://dataverse.nl/api/access/datafile/45141
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: bb86f022f1ebf2b26365d437ebe105df
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: bb86f022f1ebf2b26365d437ebe105df
+      download_url: https://dataverse.nl/api/access/datafile/45822
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2bb9650a47d89ce97ca95a1a5fa6a3b1
+      byte_size: 1040
+      checksum:
+        algorithm: md5
+        digest: 2bb9650a47d89ce97ca95a1a5fa6a3b1
+      download_url: https://dataverse.nl/api/access/datafile/46114
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 17f5f08163012f6a580f98e82e87eb2c
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 17f5f08163012f6a580f98e82e87eb2c
+      download_url: https://dataverse.nl/api/access/datafile/45845
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8189057888af59647daccefdc59e4eb4
+      byte_size: 1899
+      checksum:
+        algorithm: md5
+        digest: 8189057888af59647daccefdc59e4eb4
+      download_url: https://dataverse.nl/api/access/datafile/46658
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: dc7224e4a5ea9828b7ea312aaf7ba646
+      byte_size: 1049
+      checksum:
+        algorithm: md5
+        digest: dc7224e4a5ea9828b7ea312aaf7ba646
+      download_url: https://dataverse.nl/api/access/datafile/46016
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 823032ce07d962c4a133f74e121b3761
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 823032ce07d962c4a133f74e121b3761
+      download_url: https://dataverse.nl/api/access/datafile/45906
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 026cb0721fd8bf78490e741ea5d91794
+      byte_size: 1049
+      checksum:
+        algorithm: md5
+        digest: 026cb0721fd8bf78490e741ea5d91794
+      download_url: https://dataverse.nl/api/access/datafile/45798
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 24a26e779af8ea625527291f9046aefb
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 24a26e779af8ea625527291f9046aefb
+      download_url: https://dataverse.nl/api/access/datafile/46133
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ce7c422b09e0f0b02f34d4613ccc4229
+      byte_size: 1049
+      checksum:
+        algorithm: md5
+        digest: ce7c422b09e0f0b02f34d4613ccc4229
+      download_url: https://dataverse.nl/api/access/datafile/45688
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1845ba28a5fc280f36b605043a38541b
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 1845ba28a5fc280f36b605043a38541b
+      download_url: https://dataverse.nl/api/access/datafile/46101
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b241742b7e85b01450282a2e7aa4e058
+      byte_size: 174
+      checksum:
+        algorithm: md5
+        digest: b241742b7e85b01450282a2e7aa4e058
+      download_url: https://dataverse.nl/api/access/datafile/46597
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 32828a99a87019d6f9078e03c648c68d
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 32828a99a87019d6f9078e03c648c68d
+      download_url: https://dataverse.nl/api/access/datafile/46389
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 82af247c3278288279a833073b9066db
+      byte_size: 461489
+      checksum:
+        algorithm: md5
+        digest: 82af247c3278288279a833073b9066db
+      download_url: https://dataverse.nl/api/access/datafile/45338
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: fe69e80cf45f5e9d5310ed1a738a696e
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: fe69e80cf45f5e9d5310ed1a738a696e
+      download_url: https://dataverse.nl/api/access/datafile/45655
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: dad4fcc69a0b3469fbf3a26b71965b55
+      byte_size: 568493
+      checksum:
+        algorithm: md5
+        digest: dad4fcc69a0b3469fbf3a26b71965b55
+      download_url: https://dataverse.nl/api/access/datafile/45300
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 7d197f0669600972b57583e3532570dd
+      byte_size: 1037
+      checksum:
+        algorithm: md5
+        digest: 7d197f0669600972b57583e3532570dd
+      download_url: https://dataverse.nl/api/access/datafile/45384
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: fe849a80e4cd766fd6835344b8bd1f3d
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: fe849a80e4cd766fd6835344b8bd1f3d
+      download_url: https://dataverse.nl/api/access/datafile/45472
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 52a2f13d5077977571bf6496be1c32a5
+      byte_size: 1037
+      checksum:
+        algorithm: md5
+        digest: 52a2f13d5077977571bf6496be1c32a5
+      download_url: https://dataverse.nl/api/access/datafile/45649
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f210ac99e2c99a5bfa20be2b781f89ff
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: f210ac99e2c99a5bfa20be2b781f89ff
+      download_url: https://dataverse.nl/api/access/datafile/45195
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8e7a2146ec718c117d2b903b43af828a
+      byte_size: 1037
+      checksum:
+        algorithm: md5
+        digest: 8e7a2146ec718c117d2b903b43af828a
+      download_url: https://dataverse.nl/api/access/datafile/46445
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c0b91f1e9a73301ba10b8eccff10a605
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: c0b91f1e9a73301ba10b8eccff10a605
+      download_url: https://dataverse.nl/api/access/datafile/46131
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 0aefea2893935c3e98e5c277f766941f
+      byte_size: 163
+      checksum:
+        algorithm: md5
+        digest: 0aefea2893935c3e98e5c277f766941f
+      download_url: https://dataverse.nl/api/access/datafile/46635
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5533bdd647e1a2cabd33ed8d1acdde59
+      byte_size: 1045
+      checksum:
+        algorithm: md5
+        digest: 5533bdd647e1a2cabd33ed8d1acdde59
+      download_url: https://dataverse.nl/api/access/datafile/46308
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: dc4d3bc21a3c8ed6d4a7e65d2ac3199b
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: dc4d3bc21a3c8ed6d4a7e65d2ac3199b
+      download_url: https://dataverse.nl/api/access/datafile/45788
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a13d744ad4c709cf59dc9e1b10a1b1f1
+      byte_size: 1045
+      checksum:
+        algorithm: md5
+        digest: a13d744ad4c709cf59dc9e1b10a1b1f1
+      download_url: https://dataverse.nl/api/access/datafile/45922
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e869e8e8559023be1856f208982d05d7
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: e869e8e8559023be1856f208982d05d7
+      download_url: https://dataverse.nl/api/access/datafile/46233
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d1908bea5803e84906ad952c234953bb
+      byte_size: 1045
+      checksum:
+        algorithm: md5
+        digest: d1908bea5803e84906ad952c234953bb
+      download_url: https://dataverse.nl/api/access/datafile/45939
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e49be718e9fb740f14a2bc7a4d3f0e3d
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: e49be718e9fb740f14a2bc7a4d3f0e3d
+      download_url: https://dataverse.nl/api/access/datafile/45797
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ad3350bfe793a923b57adc825e721fe0
+      byte_size: 177
+      checksum:
+        algorithm: md5
+        digest: ad3350bfe793a923b57adc825e721fe0
+      download_url: https://dataverse.nl/api/access/datafile/46625
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 87ad0780b5acc158fd21bd4806f54b8c
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 87ad0780b5acc158fd21bd4806f54b8c
+      download_url: https://dataverse.nl/api/access/datafile/45165
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 06420ff40545291d3103f32844fa3e8e
+      byte_size: 469899
+      checksum:
+        algorithm: md5
+        digest: 06420ff40545291d3103f32844fa3e8e
+      download_url: https://dataverse.nl/api/access/datafile/45556
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1293460b4ce9a1b3ae3e197acb543c0c
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 1293460b4ce9a1b3ae3e197acb543c0c
+      download_url: https://dataverse.nl/api/access/datafile/46109
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ea398a208034c539761c427021944b9f
+      byte_size: 485107
+      checksum:
+        algorithm: md5
+        digest: ea398a208034c539761c427021944b9f
+      download_url: https://dataverse.nl/api/access/datafile/45383
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b5e25fbbb45223cccae01bd64ff64c06
+      byte_size: 1027
+      checksum:
+        algorithm: md5
+        digest: b5e25fbbb45223cccae01bd64ff64c06
+      download_url: https://dataverse.nl/api/access/datafile/46473
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ad1fcb25847e6546bdd84ec40742ae27
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: ad1fcb25847e6546bdd84ec40742ae27
+      download_url: https://dataverse.nl/api/access/datafile/45419
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 383dfc8610f1c4ac70ed6380d6024ada
+      byte_size: 1027
+      checksum:
+        algorithm: md5
+        digest: 383dfc8610f1c4ac70ed6380d6024ada
+      download_url: https://dataverse.nl/api/access/datafile/45781
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1209b5fd6974ffee065a3a6c5767fab5
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 1209b5fd6974ffee065a3a6c5767fab5
+      download_url: https://dataverse.nl/api/access/datafile/46213
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6ff7e84e984a2a7a283ae0550acf5fa0
+      byte_size: 1027
+      checksum:
+        algorithm: md5
+        digest: 6ff7e84e984a2a7a283ae0550acf5fa0
+      download_url: https://dataverse.nl/api/access/datafile/45930
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 215134b08c99ad535e216dce3cecef73
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 215134b08c99ad535e216dce3cecef73
+      download_url: https://dataverse.nl/api/access/datafile/45795
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4f6504f90de8cc8caa5ed4eec7fc7a55
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 4f6504f90de8cc8caa5ed4eec7fc7a55
+      download_url: https://dataverse.nl/api/access/datafile/45989
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: dd889f338e9721209a5c7494ea542a48
+      byte_size: 456033
+      checksum:
+        algorithm: md5
+        digest: dd889f338e9721209a5c7494ea542a48
+      download_url: https://dataverse.nl/api/access/datafile/45891
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8a7a7e378d88a320bc13aa573e33e9cf
+      byte_size: 1028
+      checksum:
+        algorithm: md5
+        digest: 8a7a7e378d88a320bc13aa573e33e9cf
+      download_url: https://dataverse.nl/api/access/datafile/45988
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f26b54d5131b4150f67442ba57d247e1
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: f26b54d5131b4150f67442ba57d247e1
+      download_url: https://dataverse.nl/api/access/datafile/45375
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 794ddb9e826cd7224e77a581d33b2af5
+      byte_size: 1028
+      checksum:
+        algorithm: md5
+        digest: 794ddb9e826cd7224e77a581d33b2af5
+      download_url: https://dataverse.nl/api/access/datafile/46068
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f65dc11611257fa72e9ae4a1fa1061f9
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: f65dc11611257fa72e9ae4a1fa1061f9
+      download_url: https://dataverse.nl/api/access/datafile/45813
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a21e290d360f3207465b7919fe9f97c4
+      byte_size: 1028
+      checksum:
+        algorithm: md5
+        digest: a21e290d360f3207465b7919fe9f97c4
+      download_url: https://dataverse.nl/api/access/datafile/45513
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 69773a651271d49947757f38d3a8a144
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 69773a651271d49947757f38d3a8a144
+      download_url: https://dataverse.nl/api/access/datafile/46054
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1b07b0c2da81eab7a599744912d99a4a
+      byte_size: 142
+      checksum:
+        algorithm: md5
+        digest: 1b07b0c2da81eab7a599744912d99a4a
+      download_url: https://dataverse.nl/api/access/datafile/45850
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 3ca0ba152166f56d7289348c95c3ff44
+      byte_size: 462313
+      checksum:
+        algorithm: md5
+        digest: 3ca0ba152166f56d7289348c95c3ff44
+      download_url: https://dataverse.nl/api/access/datafile/46035
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a8bd0a40d6efca07de5655eac124c64e
+      byte_size: 20736352
+      checksum:
+        algorithm: md5
+        digest: a8bd0a40d6efca07de5655eac124c64e
+      download_url: https://dataverse.nl/api/access/datafile/46507
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-023/
+      qualified_part:
+        - relation: sub-023/anat/
+          name: anat
+        - relation: sub-023/func/
+          name: func
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-023/anat/
+      qualified_part:
+        - relation: a8bd0a40d6efca07de5655eac124c64e
+          name: sub-023_T1w.nii
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f37ca22703b567972aed652faea49d66
+      byte_size: 1039
+      checksum:
+        algorithm: md5
+        digest: f37ca22703b567972aed652faea49d66
+      download_url: https://dataverse.nl/api/access/datafile/45202
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-023/func/
+      qualified_part:
+        - relation: f37ca22703b567972aed652faea49d66
+          name: sub-023_task-emotionProcessing_echo-1_bold.json
+        - relation: 4342d0862f957a5f96fce660bac4e3af
+          name: sub-023_task-emotionProcessing_echo-1_bold.nii
+        - relation: 4792b52cd808c53813848c4abdd6f864
+          name: sub-023_task-emotionProcessing_echo-2_bold.json
+        - relation: 7c9f2a572ffc612408e129f3cfea236d
+          name: sub-023_task-emotionProcessing_echo-2_bold.nii
+        - relation: 69c92241ea01045e326f37299420d86d
+          name: sub-023_task-emotionProcessing_echo-3_bold.json
+        - relation: 51b324dfec485e2ff3e75c5cef9d20c7
+          name: sub-023_task-emotionProcessing_echo-3_bold.nii
+        - relation: abba89ac8fe77c31ff817fef92353cf6
+          name: sub-023_task-emotionProcessing_events.tsv.gz
+        - relation: 7a3ccbf6ebd56048969bb4c05f2a8182
+          name: sub-023_task-emotionProcessingImagined_echo-1_bold.json
+        - relation: fb4709163f5988471ffbe97dad8fd3da
+          name: sub-023_task-emotionProcessingImagined_echo-1_bold.nii
+        - relation: 693618fec310822d37d31a98f147884f
+          name: sub-023_task-emotionProcessingImagined_echo-2_bold.json
+        - relation: daca30ebb1bc9a4f3d08dcc91cfde3a2
+          name: sub-023_task-emotionProcessingImagined_echo-2_bold.nii
+        - relation: 3b2916f1db199f0ca145a15e09dd1a42
+          name: sub-023_task-emotionProcessingImagined_echo-3_bold.json
+        - relation: 70acf8b330aa822ed8eb3a9c15823317
+          name: sub-023_task-emotionProcessingImagined_echo-3_bold.nii
+        - relation: 6d33cc5bb73b310d1b1e36a0d53f7aba
+          name: sub-023_task-emotionProcessingImagined_events.tsv.gz
+        - relation: 19f64e4eb05f5fb5695085f7d85ec0a1
+          name: sub-023_task-emotionProcessingImagined_physio.json
+        - relation: c82c6f370103863643536b403619d87f
+          name: sub-023_task-emotionProcessingImagined_physio.tsv.gz
+        - relation: 3b2eb7eab727d8085bc51a521a7cd27c
+          name: sub-023_task-emotionProcessing_physio.json
+        - relation: 3885b28dbcccae475ad7dd0e70a1227e
+          name: sub-023_task-emotionProcessing_physio.tsv.gz
+        - relation: f6862966e25b9d2d40fa354843b873de
+          name: sub-023_task-fingerTapping_echo-1_bold.json
+        - relation: 44dd15ffab91487d67e8a82011de9b60
+          name: sub-023_task-fingerTapping_echo-1_bold.nii
+        - relation: dd25a8138eae63f4273b92f390706048
+          name: sub-023_task-fingerTapping_echo-2_bold.json
+        - relation: bfb8ba562c522a0c015a3df39391d4fd
+          name: sub-023_task-fingerTapping_echo-2_bold.nii
+        - relation: 2176277f29fc8dcc3e19f93da85b9197
+          name: sub-023_task-fingerTapping_echo-3_bold.json
+        - relation: dc634a1d9f10316e2278751c8473c0be
+          name: sub-023_task-fingerTapping_echo-3_bold.nii
+        - relation: d241154c30bcb0493e2d418d13f8c05f
+          name: sub-023_task-fingerTapping_events.tsv.gz
+        - relation: b69eed079d6bccffaf00bcb2cda51f57
+          name: sub-023_task-fingerTappingImagined_echo-1_bold.json
+        - relation: 8d92bad5d493f07867d69f7c5f6051b8
+          name: sub-023_task-fingerTappingImagined_echo-1_bold.nii
+        - relation: 44a46805d160d5767824d8cd4b070d58
+          name: sub-023_task-fingerTappingImagined_echo-2_bold.json
+        - relation: 00b2cad2433c881267fdfa02a43a2e45
+          name: sub-023_task-fingerTappingImagined_echo-2_bold.nii
+        - relation: 183ab485778295db7fd46441eacc886c
+          name: sub-023_task-fingerTappingImagined_echo-3_bold.json
+        - relation: 4d944b7ac858f2e9662476c1bf995b42
+          name: sub-023_task-fingerTappingImagined_echo-3_bold.nii
+        - relation: 70e60fa9882a8d30488b374824af6499
+          name: sub-023_task-fingerTappingImagined_events.tsv.gz
+        - relation: 0f0086173d1dcc8bb7d8ec9bdceeb315
+          name: sub-023_task-fingerTappingImagined_physio.json
+        - relation: 042cbbfef09292ac25d134d9135742b4
+          name: sub-023_task-fingerTappingImagined_physio.tsv.gz
+        - relation: 3c151582dfa12935a3e94fa555464670
+          name: sub-023_task-fingerTapping_physio.json
+        - relation: e31a50e5585dac5f86b14c40c44c4641
+          name: sub-023_task-fingerTapping_physio.tsv.gz
+        - relation: 09d9cda61bdca32169b87036a74e4493
+          name: sub-023_task-rest_run-1_echo-1_bold.json
+        - relation: b184d8b79dfd12b9faf0ab04261a1a8b
+          name: sub-023_task-rest_run-1_echo-1_bold.nii
+        - relation: c528f0904f8f45b0f3439a80555fe137
+          name: sub-023_task-rest_run-1_echo-2_bold.json
+        - relation: b0a4fb582ff06cb91fc852ae7e8c12c8
+          name: sub-023_task-rest_run-1_echo-2_bold.nii
+        - relation: 02b896802ac19ea84fb72bee5a6c5fa0
+          name: sub-023_task-rest_run-1_echo-3_bold.json
+        - relation: 5e311054a6aca83fedd5d9f8b2569212
+          name: sub-023_task-rest_run-1_echo-3_bold.nii
+        - relation: e030b0f4a3d319892d065cd5d6bc7494
+          name: sub-023_task-rest_run-1_physio.json
+        - relation: 9a120a93187292ef4529d19b1f18066a
+          name: sub-023_task-rest_run-1_physio.tsv.gz
+        - relation: 8bbcfc3a334247aa457bb6a6933500d4
+          name: sub-023_task-rest_run-2_echo-1_bold.json
+        - relation: 8b2d236b9fc049bc1e73c5f272803665
+          name: sub-023_task-rest_run-2_echo-1_bold.nii
+        - relation: 1560ffeb235caa9c32ac0b9fcb036329
+          name: sub-023_task-rest_run-2_echo-2_bold.json
+        - relation: eb6400394e46f8e946cac3f4ab9a9801
+          name: sub-023_task-rest_run-2_echo-2_bold.nii
+        - relation: 059ef7e442bd839ee701943a2610491b
+          name: sub-023_task-rest_run-2_echo-3_bold.json
+        - relation: cfba33beea207804ebb08ce5671d388f
+          name: sub-023_task-rest_run-2_echo-3_bold.nii
+        - relation: 21df412a6b8ed1f09cdcaa771100053e
+          name: sub-023_task-rest_run-2_physio.json
+        - relation: df611445b7a2a0b8c819f3f22303e501
+          name: sub-023_task-rest_run-2_physio.tsv.gz
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4342d0862f957a5f96fce660bac4e3af
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 4342d0862f957a5f96fce660bac4e3af
+      download_url: https://dataverse.nl/api/access/datafile/45222
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4792b52cd808c53813848c4abdd6f864
+      byte_size: 1039
+      checksum:
+        algorithm: md5
+        digest: 4792b52cd808c53813848c4abdd6f864
+      download_url: https://dataverse.nl/api/access/datafile/46387
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 7c9f2a572ffc612408e129f3cfea236d
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 7c9f2a572ffc612408e129f3cfea236d
+      download_url: https://dataverse.nl/api/access/datafile/45621
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 69c92241ea01045e326f37299420d86d
+      byte_size: 1039
+      checksum:
+        algorithm: md5
+        digest: 69c92241ea01045e326f37299420d86d
+      download_url: https://dataverse.nl/api/access/datafile/45317
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 51b324dfec485e2ff3e75c5cef9d20c7
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 51b324dfec485e2ff3e75c5cef9d20c7
+      download_url: https://dataverse.nl/api/access/datafile/45388
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: abba89ac8fe77c31ff817fef92353cf6
+      byte_size: 1906
+      checksum:
+        algorithm: md5
+        digest: abba89ac8fe77c31ff817fef92353cf6
+      download_url: https://dataverse.nl/api/access/datafile/46637
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 7a3ccbf6ebd56048969bb4c05f2a8182
+      byte_size: 1047
+      checksum:
+        algorithm: md5
+        digest: 7a3ccbf6ebd56048969bb4c05f2a8182
+      download_url: https://dataverse.nl/api/access/datafile/46022
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: fb4709163f5988471ffbe97dad8fd3da
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: fb4709163f5988471ffbe97dad8fd3da
+      download_url: https://dataverse.nl/api/access/datafile/45187
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 693618fec310822d37d31a98f147884f
+      byte_size: 1047
+      checksum:
+        algorithm: md5
+        digest: 693618fec310822d37d31a98f147884f
+      download_url: https://dataverse.nl/api/access/datafile/46208
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: daca30ebb1bc9a4f3d08dcc91cfde3a2
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: daca30ebb1bc9a4f3d08dcc91cfde3a2
+      download_url: https://dataverse.nl/api/access/datafile/45980
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 3b2916f1db199f0ca145a15e09dd1a42
+      byte_size: 1047
+      checksum:
+        algorithm: md5
+        digest: 3b2916f1db199f0ca145a15e09dd1a42
+      download_url: https://dataverse.nl/api/access/datafile/45739
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 70acf8b330aa822ed8eb3a9c15823317
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 70acf8b330aa822ed8eb3a9c15823317
+      download_url: https://dataverse.nl/api/access/datafile/45533
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6d33cc5bb73b310d1b1e36a0d53f7aba
+      byte_size: 177
+      checksum:
+        algorithm: md5
+        digest: 6d33cc5bb73b310d1b1e36a0d53f7aba
+      download_url: https://dataverse.nl/api/access/datafile/46619
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 19f64e4eb05f5fb5695085f7d85ec0a1
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 19f64e4eb05f5fb5695085f7d85ec0a1
+      download_url: https://dataverse.nl/api/access/datafile/46323
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c82c6f370103863643536b403619d87f
+      byte_size: 496920
+      checksum:
+        algorithm: md5
+        digest: c82c6f370103863643536b403619d87f
+      download_url: https://dataverse.nl/api/access/datafile/45298
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 3b2eb7eab727d8085bc51a521a7cd27c
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 3b2eb7eab727d8085bc51a521a7cd27c
+      download_url: https://dataverse.nl/api/access/datafile/46053
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 3885b28dbcccae475ad7dd0e70a1227e
+      byte_size: 488767
+      checksum:
+        algorithm: md5
+        digest: 3885b28dbcccae475ad7dd0e70a1227e
+      download_url: https://dataverse.nl/api/access/datafile/46283
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f6862966e25b9d2d40fa354843b873de
+      byte_size: 1034
+      checksum:
+        algorithm: md5
+        digest: f6862966e25b9d2d40fa354843b873de
+      download_url: https://dataverse.nl/api/access/datafile/45410
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 44dd15ffab91487d67e8a82011de9b60
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 44dd15ffab91487d67e8a82011de9b60
+      download_url: https://dataverse.nl/api/access/datafile/45103
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: dd25a8138eae63f4273b92f390706048
+      byte_size: 1034
+      checksum:
+        algorithm: md5
+        digest: dd25a8138eae63f4273b92f390706048
+      download_url: https://dataverse.nl/api/access/datafile/45638
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: bfb8ba562c522a0c015a3df39391d4fd
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: bfb8ba562c522a0c015a3df39391d4fd
+      download_url: https://dataverse.nl/api/access/datafile/46147
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2176277f29fc8dcc3e19f93da85b9197
+      byte_size: 1034
+      checksum:
+        algorithm: md5
+        digest: 2176277f29fc8dcc3e19f93da85b9197
+      download_url: https://dataverse.nl/api/access/datafile/46406
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: dc634a1d9f10316e2278751c8473c0be
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: dc634a1d9f10316e2278751c8473c0be
+      download_url: https://dataverse.nl/api/access/datafile/46448
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d241154c30bcb0493e2d418d13f8c05f
+      byte_size: 161
+      checksum:
+        algorithm: md5
+        digest: d241154c30bcb0493e2d418d13f8c05f
+      download_url: https://dataverse.nl/api/access/datafile/46649
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b69eed079d6bccffaf00bcb2cda51f57
+      byte_size: 1043
+      checksum:
+        algorithm: md5
+        digest: b69eed079d6bccffaf00bcb2cda51f57
+      download_url: https://dataverse.nl/api/access/datafile/45847
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8d92bad5d493f07867d69f7c5f6051b8
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 8d92bad5d493f07867d69f7c5f6051b8
+      download_url: https://dataverse.nl/api/access/datafile/45690
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 44a46805d160d5767824d8cd4b070d58
+      byte_size: 1043
+      checksum:
+        algorithm: md5
+        digest: 44a46805d160d5767824d8cd4b070d58
+      download_url: https://dataverse.nl/api/access/datafile/46212
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 00b2cad2433c881267fdfa02a43a2e45
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 00b2cad2433c881267fdfa02a43a2e45
+      download_url: https://dataverse.nl/api/access/datafile/45457
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 183ab485778295db7fd46441eacc886c
+      byte_size: 1043
+      checksum:
+        algorithm: md5
+        digest: 183ab485778295db7fd46441eacc886c
+      download_url: https://dataverse.nl/api/access/datafile/45785
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4d944b7ac858f2e9662476c1bf995b42
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 4d944b7ac858f2e9662476c1bf995b42
+      download_url: https://dataverse.nl/api/access/datafile/45219
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 70e60fa9882a8d30488b374824af6499
+      byte_size: 178
+      checksum:
+        algorithm: md5
+        digest: 70e60fa9882a8d30488b374824af6499
+      download_url: https://dataverse.nl/api/access/datafile/46592
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 0f0086173d1dcc8bb7d8ec9bdceeb315
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 0f0086173d1dcc8bb7d8ec9bdceeb315
+      download_url: https://dataverse.nl/api/access/datafile/46366
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 042cbbfef09292ac25d134d9135742b4
+      byte_size: 512377
+      checksum:
+        algorithm: md5
+        digest: 042cbbfef09292ac25d134d9135742b4
+      download_url: https://dataverse.nl/api/access/datafile/45932
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 3c151582dfa12935a3e94fa555464670
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 3c151582dfa12935a3e94fa555464670
+      download_url: https://dataverse.nl/api/access/datafile/46375
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e31a50e5585dac5f86b14c40c44c4641
+      byte_size: 573250
+      checksum:
+        algorithm: md5
+        digest: e31a50e5585dac5f86b14c40c44c4641
+      download_url: https://dataverse.nl/api/access/datafile/46026
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 09d9cda61bdca32169b87036a74e4493
+      byte_size: 1026
+      checksum:
+        algorithm: md5
+        digest: 09d9cda61bdca32169b87036a74e4493
+      download_url: https://dataverse.nl/api/access/datafile/45468
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b184d8b79dfd12b9faf0ab04261a1a8b
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: b184d8b79dfd12b9faf0ab04261a1a8b
+      download_url: https://dataverse.nl/api/access/datafile/45849
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c528f0904f8f45b0f3439a80555fe137
+      byte_size: 1026
+      checksum:
+        algorithm: md5
+        digest: c528f0904f8f45b0f3439a80555fe137
+      download_url: https://dataverse.nl/api/access/datafile/45499
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b0a4fb582ff06cb91fc852ae7e8c12c8
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: b0a4fb582ff06cb91fc852ae7e8c12c8
+      download_url: https://dataverse.nl/api/access/datafile/46210
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 02b896802ac19ea84fb72bee5a6c5fa0
+      byte_size: 1026
+      checksum:
+        algorithm: md5
+        digest: 02b896802ac19ea84fb72bee5a6c5fa0
+      download_url: https://dataverse.nl/api/access/datafile/46452
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5e311054a6aca83fedd5d9f8b2569212
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 5e311054a6aca83fedd5d9f8b2569212
+      download_url: https://dataverse.nl/api/access/datafile/46135
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e030b0f4a3d319892d065cd5d6bc7494
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: e030b0f4a3d319892d065cd5d6bc7494
+      download_url: https://dataverse.nl/api/access/datafile/45127
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 9a120a93187292ef4529d19b1f18066a
+      byte_size: 464020
+      checksum:
+        algorithm: md5
+        digest: 9a120a93187292ef4529d19b1f18066a
+      download_url: https://dataverse.nl/api/access/datafile/46312
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8bbcfc3a334247aa457bb6a6933500d4
+      byte_size: 1026
+      checksum:
+        algorithm: md5
+        digest: 8bbcfc3a334247aa457bb6a6933500d4
+      download_url: https://dataverse.nl/api/access/datafile/46167
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8b2d236b9fc049bc1e73c5f272803665
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 8b2d236b9fc049bc1e73c5f272803665
+      download_url: https://dataverse.nl/api/access/datafile/45755
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1560ffeb235caa9c32ac0b9fcb036329
+      byte_size: 1026
+      checksum:
+        algorithm: md5
+        digest: 1560ffeb235caa9c32ac0b9fcb036329
+      download_url: https://dataverse.nl/api/access/datafile/46424
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: eb6400394e46f8e946cac3f4ab9a9801
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: eb6400394e46f8e946cac3f4ab9a9801
+      download_url: https://dataverse.nl/api/access/datafile/46482
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 059ef7e442bd839ee701943a2610491b
+      byte_size: 1026
+      checksum:
+        algorithm: md5
+        digest: 059ef7e442bd839ee701943a2610491b
+      download_url: https://dataverse.nl/api/access/datafile/45909
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: cfba33beea207804ebb08ce5671d388f
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: cfba33beea207804ebb08ce5671d388f
+      download_url: https://dataverse.nl/api/access/datafile/46234
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 21df412a6b8ed1f09cdcaa771100053e
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 21df412a6b8ed1f09cdcaa771100053e
+      download_url: https://dataverse.nl/api/access/datafile/46072
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: df611445b7a2a0b8c819f3f22303e501
+      byte_size: 472513
+      checksum:
+        algorithm: md5
+        digest: df611445b7a2a0b8c819f3f22303e501
+      download_url: https://dataverse.nl/api/access/datafile/45943
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 190f6c4c0377b05944ce2878ec313e21
+      byte_size: 20736352
+      checksum:
+        algorithm: md5
+        digest: 190f6c4c0377b05944ce2878ec313e21
+      download_url: https://dataverse.nl/api/access/datafile/45183
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-024/
+      qualified_part:
+        - relation: sub-024/anat/
+          name: anat
+        - relation: sub-024/func/
+          name: func
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-024/anat/
+      qualified_part:
+        - relation: 190f6c4c0377b05944ce2878ec313e21
+          name: sub-024_T1w.nii
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 68900c5905293046b114fca82ab7d937
+      byte_size: 1034
+      checksum:
+        algorithm: md5
+        digest: 68900c5905293046b114fca82ab7d937
+      download_url: https://dataverse.nl/api/access/datafile/45242
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-024/func/
+      qualified_part:
+        - relation: 68900c5905293046b114fca82ab7d937
+          name: sub-024_task-emotionProcessing_echo-1_bold.json
+        - relation: 851427f1f7c032e5906507f7d0405bd5
+          name: sub-024_task-emotionProcessing_echo-1_bold.nii
+        - relation: e596a8ec961747ea3d4b3b1de556d7b0
+          name: sub-024_task-emotionProcessing_echo-2_bold.json
+        - relation: 4d38e51a3708d660e41987da08c79983
+          name: sub-024_task-emotionProcessing_echo-2_bold.nii
+        - relation: 5745803b05c755cfd680e0f53019ef27
+          name: sub-024_task-emotionProcessing_echo-3_bold.json
+        - relation: e15de8fbb70e212620b8493fd6ecc49b
+          name: sub-024_task-emotionProcessing_echo-3_bold.nii
+        - relation: 701119b52cf299609c5a915e6e2ffd51
+          name: sub-024_task-emotionProcessing_events.tsv.gz
+        - relation: 4a8d9600a8bf9a814c53283b0a8ff9be
+          name: sub-024_task-emotionProcessingImagined_echo-1_bold.json
+        - relation: d3bf097795db1903df7186d7f1e0bf1c
+          name: sub-024_task-emotionProcessingImagined_echo-1_bold.nii
+        - relation: 33809dec60e32503256f7c45c17797b3
+          name: sub-024_task-emotionProcessingImagined_echo-2_bold.json
+        - relation: 67d380c3bd9daeeb8460387ed87a29e8
+          name: sub-024_task-emotionProcessingImagined_echo-2_bold.nii
+        - relation: f62132b9d9a3dba3780c37681502185f
+          name: sub-024_task-emotionProcessingImagined_echo-3_bold.json
+        - relation: 639095cdb453f2822378e0bb565d37e4
+          name: sub-024_task-emotionProcessingImagined_echo-3_bold.nii
+        - relation: ce6d682d4ed61ae643a4a035008d7815
+          name: sub-024_task-emotionProcessingImagined_events.tsv.gz
+        - relation: 5688150bd72bd5aaaf6d4356ecafcf4a
+          name: sub-024_task-emotionProcessingImagined_physio.json
+        - relation: 39de7e6e8e2d3f2cfc6444da6338b4dd
+          name: sub-024_task-emotionProcessingImagined_physio.tsv.gz
+        - relation: 569846b608131148ba2ff54e8d610d04
+          name: sub-024_task-emotionProcessing_physio.json
+        - relation: 0cf2d5a06375a9955838110f934deb1b
+          name: sub-024_task-emotionProcessing_physio.tsv.gz
+        - relation: 3642c5b258b8fe806138da050fab7577
+          name: sub-024_task-fingerTapping_echo-1_bold.json
+        - relation: 867676e8bda9acb30d89a4f7ddbb270d
+          name: sub-024_task-fingerTapping_echo-1_bold.nii
+        - relation: 9dc29fcf832822fde8f681b6915eba97
+          name: sub-024_task-fingerTapping_echo-2_bold.json
+        - relation: fba3ceef317bd3f6b4e952fbe8e95f60
+          name: sub-024_task-fingerTapping_echo-2_bold.nii
+        - relation: e8b15f05c6532ff094f30434e58ecd54
+          name: sub-024_task-fingerTapping_echo-3_bold.json
+        - relation: 1926d0d618f52d3002e1e66a5760b540
+          name: sub-024_task-fingerTapping_echo-3_bold.nii
+        - relation: 2f57b6782192a800c7065db2a988071c
+          name: sub-024_task-fingerTapping_events.tsv.gz
+        - relation: 25d5c66a770a017ee0ae4663c77b1bd7
+          name: sub-024_task-fingerTappingImagined_echo-1_bold.json
+        - relation: 1cbb35815c5f6630a1a068598f67da0c
+          name: sub-024_task-fingerTappingImagined_echo-1_bold.nii
+        - relation: 6c1a5de28e56da183e2ee15608671ed1
+          name: sub-024_task-fingerTappingImagined_echo-2_bold.json
+        - relation: ad84562e4b9beb78396c96c2e1fda3d4
+          name: sub-024_task-fingerTappingImagined_echo-2_bold.nii
+        - relation: c59422134a338595b729c746363dbfaf
+          name: sub-024_task-fingerTappingImagined_echo-3_bold.json
+        - relation: e6e1463f8a5543ce4211ea9434bb0f84
+          name: sub-024_task-fingerTappingImagined_echo-3_bold.nii
+        - relation: 1112eaa2187cf14649e60accef58ce48
+          name: sub-024_task-fingerTappingImagined_events.tsv.gz
+        - relation: 7de904e51a84a1e94f4080c9dc80bae7
+          name: sub-024_task-fingerTappingImagined_physio.json
+        - relation: dbc6c08de56357e98e8fab751ec459ae
+          name: sub-024_task-fingerTappingImagined_physio.tsv.gz
+        - relation: 96cd7e0c51001877967102a056c08652
+          name: sub-024_task-fingerTapping_physio.json
+        - relation: 5bb5eb74cb99f2cc266f3439c9f1240e
+          name: sub-024_task-fingerTapping_physio.tsv.gz
+        - relation: f5c7158e1de14a6243ccb67928bf4a15
+          name: sub-024_task-rest_run-1_echo-1_bold.json
+        - relation: c7bf87ca41c8aa7eb8018a8b4e9c6571
+          name: sub-024_task-rest_run-1_echo-1_bold.nii
+        - relation: 0500137347eae1b221aa40a87a900413
+          name: sub-024_task-rest_run-1_echo-2_bold.json
+        - relation: 1d131b1c3c9d87d0260bcc1618485fe1
+          name: sub-024_task-rest_run-1_echo-2_bold.nii
+        - relation: 4141f90fef546e2fb5c9aad9ddd7b774
+          name: sub-024_task-rest_run-1_echo-3_bold.json
+        - relation: d0faca977d58aa06eff58b637cf9b906
+          name: sub-024_task-rest_run-1_echo-3_bold.nii
+        - relation: 7784a62a3163771005cac907491c3151
+          name: sub-024_task-rest_run-1_physio.json
+        - relation: eb419260bf47beaac73513690fbd877e
+          name: sub-024_task-rest_run-1_physio.tsv.gz
+        - relation: 1494bc84b63d4b5f16a1111227e6034d
+          name: sub-024_task-rest_run-2_echo-1_bold.json
+        - relation: 132d374f5df768f4109ad49ebc68b957
+          name: sub-024_task-rest_run-2_echo-1_bold.nii
+        - relation: 70c0a25802f20891aca37f2086d2f36d
+          name: sub-024_task-rest_run-2_echo-2_bold.json
+        - relation: 20b27c94c65afe4b35f4c69463b27f7c
+          name: sub-024_task-rest_run-2_echo-2_bold.nii
+        - relation: c8ee7ca3c82e8aeeee940a21ea760fd9
+          name: sub-024_task-rest_run-2_echo-3_bold.json
+        - relation: 681bd5c0caa8ab71f905c238ce037af3
+          name: sub-024_task-rest_run-2_echo-3_bold.nii
+        - relation: 15cc74fd2352e18be8675e2ffd1a327a
+          name: sub-024_task-rest_run-2_physio.json
+        - relation: 32435ea664e7ada98f766f86540c042a
+          name: sub-024_task-rest_run-2_physio.tsv.gz
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 851427f1f7c032e5906507f7d0405bd5
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 851427f1f7c032e5906507f7d0405bd5
+      download_url: https://dataverse.nl/api/access/datafile/45597
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e596a8ec961747ea3d4b3b1de556d7b0
+      byte_size: 1034
+      checksum:
+        algorithm: md5
+        digest: e596a8ec961747ea3d4b3b1de556d7b0
+      download_url: https://dataverse.nl/api/access/datafile/45549
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4d38e51a3708d660e41987da08c79983
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 4d38e51a3708d660e41987da08c79983
+      download_url: https://dataverse.nl/api/access/datafile/45641
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5745803b05c755cfd680e0f53019ef27
+      byte_size: 1034
+      checksum:
+        algorithm: md5
+        digest: 5745803b05c755cfd680e0f53019ef27
+      download_url: https://dataverse.nl/api/access/datafile/45512
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e15de8fbb70e212620b8493fd6ecc49b
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: e15de8fbb70e212620b8493fd6ecc49b
+      download_url: https://dataverse.nl/api/access/datafile/45518
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 701119b52cf299609c5a915e6e2ffd51
+      byte_size: 1897
+      checksum:
+        algorithm: md5
+        digest: 701119b52cf299609c5a915e6e2ffd51
+      download_url: https://dataverse.nl/api/access/datafile/46606
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4a8d9600a8bf9a814c53283b0a8ff9be
+      byte_size: 1042
+      checksum:
+        algorithm: md5
+        digest: 4a8d9600a8bf9a814c53283b0a8ff9be
+      download_url: https://dataverse.nl/api/access/datafile/46201
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d3bf097795db1903df7186d7f1e0bf1c
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: d3bf097795db1903df7186d7f1e0bf1c
+      download_url: https://dataverse.nl/api/access/datafile/45421
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 33809dec60e32503256f7c45c17797b3
+      byte_size: 1042
+      checksum:
+        algorithm: md5
+        digest: 33809dec60e32503256f7c45c17797b3
+      download_url: https://dataverse.nl/api/access/datafile/45979
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 67d380c3bd9daeeb8460387ed87a29e8
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 67d380c3bd9daeeb8460387ed87a29e8
+      download_url: https://dataverse.nl/api/access/datafile/45260
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f62132b9d9a3dba3780c37681502185f
+      byte_size: 1042
+      checksum:
+        algorithm: md5
+        digest: f62132b9d9a3dba3780c37681502185f
+      download_url: https://dataverse.nl/api/access/datafile/46287
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 639095cdb453f2822378e0bb565d37e4
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 639095cdb453f2822378e0bb565d37e4
+      download_url: https://dataverse.nl/api/access/datafile/45766
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ce6d682d4ed61ae643a4a035008d7815
+      byte_size: 180
+      checksum:
+        algorithm: md5
+        digest: ce6d682d4ed61ae643a4a035008d7815
+      download_url: https://dataverse.nl/api/access/datafile/46551
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5688150bd72bd5aaaf6d4356ecafcf4a
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 5688150bd72bd5aaaf6d4356ecafcf4a
+      download_url: https://dataverse.nl/api/access/datafile/46309
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 39de7e6e8e2d3f2cfc6444da6338b4dd
+      byte_size: 456438
+      checksum:
+        algorithm: md5
+        digest: 39de7e6e8e2d3f2cfc6444da6338b4dd
+      download_url: https://dataverse.nl/api/access/datafile/45481
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 569846b608131148ba2ff54e8d610d04
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 569846b608131148ba2ff54e8d610d04
+      download_url: https://dataverse.nl/api/access/datafile/45353
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 0cf2d5a06375a9955838110f934deb1b
+      byte_size: 524926
+      checksum:
+        algorithm: md5
+        digest: 0cf2d5a06375a9955838110f934deb1b
+      download_url: https://dataverse.nl/api/access/datafile/46080
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 3642c5b258b8fe806138da050fab7577
+      byte_size: 1031
+      checksum:
+        algorithm: md5
+        digest: 3642c5b258b8fe806138da050fab7577
+      download_url: https://dataverse.nl/api/access/datafile/45441
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 867676e8bda9acb30d89a4f7ddbb270d
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 867676e8bda9acb30d89a4f7ddbb270d
+      download_url: https://dataverse.nl/api/access/datafile/46486
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 9dc29fcf832822fde8f681b6915eba97
+      byte_size: 1031
+      checksum:
+        algorithm: md5
+        digest: 9dc29fcf832822fde8f681b6915eba97
+      download_url: https://dataverse.nl/api/access/datafile/45453
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: fba3ceef317bd3f6b4e952fbe8e95f60
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: fba3ceef317bd3f6b4e952fbe8e95f60
+      download_url: https://dataverse.nl/api/access/datafile/45546
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e8b15f05c6532ff094f30434e58ecd54
+      byte_size: 1031
+      checksum:
+        algorithm: md5
+        digest: e8b15f05c6532ff094f30434e58ecd54
+      download_url: https://dataverse.nl/api/access/datafile/45565
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1926d0d618f52d3002e1e66a5760b540
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 1926d0d618f52d3002e1e66a5760b540
+      download_url: https://dataverse.nl/api/access/datafile/45679
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2f57b6782192a800c7065db2a988071c
+      byte_size: 168
+      checksum:
+        algorithm: md5
+        digest: 2f57b6782192a800c7065db2a988071c
+      download_url: https://dataverse.nl/api/access/datafile/46654
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 25d5c66a770a017ee0ae4663c77b1bd7
+      byte_size: 1039
+      checksum:
+        algorithm: md5
+        digest: 25d5c66a770a017ee0ae4663c77b1bd7
+      download_url: https://dataverse.nl/api/access/datafile/45602
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1cbb35815c5f6630a1a068598f67da0c
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 1cbb35815c5f6630a1a068598f67da0c
+      download_url: https://dataverse.nl/api/access/datafile/45794
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6c1a5de28e56da183e2ee15608671ed1
+      byte_size: 1039
+      checksum:
+        algorithm: md5
+        digest: 6c1a5de28e56da183e2ee15608671ed1
+      download_url: https://dataverse.nl/api/access/datafile/45511
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ad84562e4b9beb78396c96c2e1fda3d4
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: ad84562e4b9beb78396c96c2e1fda3d4
+      download_url: https://dataverse.nl/api/access/datafile/46254
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c59422134a338595b729c746363dbfaf
+      byte_size: 1039
+      checksum:
+        algorithm: md5
+        digest: c59422134a338595b729c746363dbfaf
+      download_url: https://dataverse.nl/api/access/datafile/46268
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e6e1463f8a5543ce4211ea9434bb0f84
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: e6e1463f8a5543ce4211ea9434bb0f84
+      download_url: https://dataverse.nl/api/access/datafile/45870
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1112eaa2187cf14649e60accef58ce48
+      byte_size: 180
+      checksum:
+        algorithm: md5
+        digest: 1112eaa2187cf14649e60accef58ce48
+      download_url: https://dataverse.nl/api/access/datafile/46622
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 7de904e51a84a1e94f4080c9dc80bae7
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 7de904e51a84a1e94f4080c9dc80bae7
+      download_url: https://dataverse.nl/api/access/datafile/46104
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: dbc6c08de56357e98e8fab751ec459ae
+      byte_size: 459731
+      checksum:
+        algorithm: md5
+        digest: dbc6c08de56357e98e8fab751ec459ae
+      download_url: https://dataverse.nl/api/access/datafile/45215
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 96cd7e0c51001877967102a056c08652
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 96cd7e0c51001877967102a056c08652
+      download_url: https://dataverse.nl/api/access/datafile/46182
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5bb5eb74cb99f2cc266f3439c9f1240e
+      byte_size: 473161
+      checksum:
+        algorithm: md5
+        digest: 5bb5eb74cb99f2cc266f3439c9f1240e
+      download_url: https://dataverse.nl/api/access/datafile/45405
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f5c7158e1de14a6243ccb67928bf4a15
+      byte_size: 1022
+      checksum:
+        algorithm: md5
+        digest: f5c7158e1de14a6243ccb67928bf4a15
+      download_url: https://dataverse.nl/api/access/datafile/46189
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c7bf87ca41c8aa7eb8018a8b4e9c6571
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: c7bf87ca41c8aa7eb8018a8b4e9c6571
+      download_url: https://dataverse.nl/api/access/datafile/46019
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 0500137347eae1b221aa40a87a900413
+      byte_size: 1022
+      checksum:
+        algorithm: md5
+        digest: 0500137347eae1b221aa40a87a900413
+      download_url: https://dataverse.nl/api/access/datafile/46085
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1d131b1c3c9d87d0260bcc1618485fe1
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 1d131b1c3c9d87d0260bcc1618485fe1
+      download_url: https://dataverse.nl/api/access/datafile/45413
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4141f90fef546e2fb5c9aad9ddd7b774
+      byte_size: 1022
+      checksum:
+        algorithm: md5
+        digest: 4141f90fef546e2fb5c9aad9ddd7b774
+      download_url: https://dataverse.nl/api/access/datafile/45310
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d0faca977d58aa06eff58b637cf9b906
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: d0faca977d58aa06eff58b637cf9b906
+      download_url: https://dataverse.nl/api/access/datafile/45726
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 7784a62a3163771005cac907491c3151
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 7784a62a3163771005cac907491c3151
+      download_url: https://dataverse.nl/api/access/datafile/46221
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: eb419260bf47beaac73513690fbd877e
+      byte_size: 447685
+      checksum:
+        algorithm: md5
+        digest: eb419260bf47beaac73513690fbd877e
+      download_url: https://dataverse.nl/api/access/datafile/45352
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1494bc84b63d4b5f16a1111227e6034d
+      byte_size: 1022
+      checksum:
+        algorithm: md5
+        digest: 1494bc84b63d4b5f16a1111227e6034d
+      download_url: https://dataverse.nl/api/access/datafile/46310
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 132d374f5df768f4109ad49ebc68b957
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 132d374f5df768f4109ad49ebc68b957
+      download_url: https://dataverse.nl/api/access/datafile/45289
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 70c0a25802f20891aca37f2086d2f36d
+      byte_size: 1022
+      checksum:
+        algorithm: md5
+        digest: 70c0a25802f20891aca37f2086d2f36d
+      download_url: https://dataverse.nl/api/access/datafile/45214
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 20b27c94c65afe4b35f4c69463b27f7c
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 20b27c94c65afe4b35f4c69463b27f7c
+      download_url: https://dataverse.nl/api/access/datafile/45236
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c8ee7ca3c82e8aeeee940a21ea760fd9
+      byte_size: 1022
+      checksum:
+        algorithm: md5
+        digest: c8ee7ca3c82e8aeeee940a21ea760fd9
+      download_url: https://dataverse.nl/api/access/datafile/45894
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 681bd5c0caa8ab71f905c238ce037af3
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 681bd5c0caa8ab71f905c238ce037af3
+      download_url: https://dataverse.nl/api/access/datafile/45267
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 15cc74fd2352e18be8675e2ffd1a327a
+      byte_size: 141
+      checksum:
+        algorithm: md5
+        digest: 15cc74fd2352e18be8675e2ffd1a327a
+      download_url: https://dataverse.nl/api/access/datafile/45125
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 32435ea664e7ada98f766f86540c042a
+      byte_size: 462496
+      checksum:
+        algorithm: md5
+        digest: 32435ea664e7ada98f766f86540c042a
+      download_url: https://dataverse.nl/api/access/datafile/45692
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 7f7a942231041371976b996b0baadb9e
+      byte_size: 20736352
+      checksum:
+        algorithm: md5
+        digest: 7f7a942231041371976b996b0baadb9e
+      download_url: https://dataverse.nl/api/access/datafile/45306
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-025/
+      qualified_part:
+        - relation: sub-025/anat/
+          name: anat
+        - relation: sub-025/func/
+          name: func
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-025/anat/
+      qualified_part:
+        - relation: 7f7a942231041371976b996b0baadb9e
+          name: sub-025_T1w.nii
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 73a60ea9762e960d7701531a74a2ed9d
+      byte_size: 1042
+      checksum:
+        algorithm: md5
+        digest: 73a60ea9762e960d7701531a74a2ed9d
+      download_url: https://dataverse.nl/api/access/datafile/45958
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-025/func/
+      qualified_part:
+        - relation: 73a60ea9762e960d7701531a74a2ed9d
+          name: sub-025_task-emotionProcessing_echo-1_bold.json
+        - relation: 240a45381b94d5ca4d4ade6eaaf7c534
+          name: sub-025_task-emotionProcessing_echo-1_bold.nii
+        - relation: 18f17176166efa9151bb8ca293698c6c
+          name: sub-025_task-emotionProcessing_echo-2_bold.json
+        - relation: feca4cabeb9b08cf58eeb4c8ba952f77
+          name: sub-025_task-emotionProcessing_echo-2_bold.nii
+        - relation: 79a76423364b453c79bee24ab27fddaa
+          name: sub-025_task-emotionProcessing_echo-3_bold.json
+        - relation: 9f4e28cd101143505ac5185185124158
+          name: sub-025_task-emotionProcessing_echo-3_bold.nii
+        - relation: 74b10e4d7333f58ed1b380af45c84266
+          name: sub-025_task-emotionProcessing_events.tsv.gz
+        - relation: f53925e9fa6a24259e91d0537d5d725b
+          name: sub-025_task-emotionProcessingImagined_echo-1_bold.json
+        - relation: 0577b1e7ea6786bae61031a06220a810
+          name: sub-025_task-emotionProcessingImagined_echo-1_bold.nii
+        - relation: e13ebf196f9e07478266674ac5ead24e
+          name: sub-025_task-emotionProcessingImagined_echo-2_bold.json
+        - relation: a994b10225ee41df351809c9358faf85
+          name: sub-025_task-emotionProcessingImagined_echo-2_bold.nii
+        - relation: c7b24e636a25b4d08c411f949ab0ef5a
+          name: sub-025_task-emotionProcessingImagined_echo-3_bold.json
+        - relation: 15d6eaa340a866de7e64b32cee611a03
+          name: sub-025_task-emotionProcessingImagined_echo-3_bold.nii
+        - relation: 037993522fb30018c40367a704483687
+          name: sub-025_task-emotionProcessingImagined_events.tsv.gz
+        - relation: f2ea0de36ad20fbd34744be2686ef790
+          name: sub-025_task-emotionProcessingImagined_physio.json
+        - relation: 5aeaf61ce59c611def6ca7200925fcad
+          name: sub-025_task-emotionProcessingImagined_physio.tsv.gz
+        - relation: 495e70560c2f494854fc9dcac2abf81b
+          name: sub-025_task-emotionProcessing_physio.json
+        - relation: ca9ef6362d3c02e157aa2b5b31663737
+          name: sub-025_task-emotionProcessing_physio.tsv.gz
+        - relation: 2a4112c592ddeeffa7b0d609eaa48472
+          name: sub-025_task-fingerTapping_echo-1_bold.json
+        - relation: 7a4989302353c2507229aa6e1a36a2d9
+          name: sub-025_task-fingerTapping_echo-1_bold.nii
+        - relation: 049d6292f471d9725b1bb562b3f48b20
+          name: sub-025_task-fingerTapping_echo-2_bold.json
+        - relation: 62d567a6946e8f2f95e45e70b33da544
+          name: sub-025_task-fingerTapping_echo-2_bold.nii
+        - relation: 9b661b4cd4ef743034cfef2427b76d08
+          name: sub-025_task-fingerTapping_echo-3_bold.json
+        - relation: 91b40c8fead0371648bd2b77154f9dd1
+          name: sub-025_task-fingerTapping_echo-3_bold.nii
+        - relation: 575dcf28dc7c1641f5117121b99bfb5b
+          name: sub-025_task-fingerTapping_events.tsv.gz
+        - relation: c2ba2164df29bcb46e163701354cc111
+          name: sub-025_task-fingerTappingImagined_echo-1_bold.json
+        - relation: 065a74091eb867a4b9165209bd271403
+          name: sub-025_task-fingerTappingImagined_echo-1_bold.nii
+        - relation: 45d501c3ef2f6c388b26b5165818aa51
+          name: sub-025_task-fingerTappingImagined_echo-2_bold.json
+        - relation: 18bd02a9fc512830f0a2a0f00f23023a
+          name: sub-025_task-fingerTappingImagined_echo-2_bold.nii
+        - relation: b555c9c1024633c1267d0bb87060f4a5
+          name: sub-025_task-fingerTappingImagined_echo-3_bold.json
+        - relation: 2152b72ca956bf7a8c9ba8392fe4dcf7
+          name: sub-025_task-fingerTappingImagined_echo-3_bold.nii
+        - relation: c3721d501643fa74c63a2849bbe0fc29
+          name: sub-025_task-fingerTappingImagined_events.tsv.gz
+        - relation: bc7ea47540ecc5fd483cea3751596558
+          name: sub-025_task-fingerTappingImagined_physio.json
+        - relation: 2ddca451eda2d8d03218a82b70c566ca
+          name: sub-025_task-fingerTappingImagined_physio.tsv.gz
+        - relation: 8ef8c83c58f8e3b5b6118e0b84e00404
+          name: sub-025_task-fingerTapping_physio.json
+        - relation: ce57f859bfd8c3ce710253e4daa4dd60
+          name: sub-025_task-fingerTapping_physio.tsv.gz
+        - relation: 2c9dcd69ba60afc1907ff85b249312b6
+          name: sub-025_task-rest_run-1_echo-1_bold.json
+        - relation: 60d5dd81c35de9876e0f66908461cbc6
+          name: sub-025_task-rest_run-1_echo-1_bold.nii
+        - relation: c8e33ac93b50f58fa0687b474791e7d3
+          name: sub-025_task-rest_run-1_echo-2_bold.json
+        - relation: 3a646ee3c1b543a56a0f21176be2efdd
+          name: sub-025_task-rest_run-1_echo-2_bold.nii
+        - relation: 8c21a8507b6cb565588c0140180d2772
+          name: sub-025_task-rest_run-1_echo-3_bold.json
+        - relation: a147274fd35661aa0c1fa1d7f0b308b1
+          name: sub-025_task-rest_run-1_echo-3_bold.nii
+        - relation: e53241984863a44ace80f7ae64b587ef
+          name: sub-025_task-rest_run-1_physio.json
+        - relation: 807f681d4fd68b0f5b7bd9a208e0619f
+          name: sub-025_task-rest_run-1_physio.tsv.gz
+        - relation: b2ef37dc700fe8774b2c78aa3033676b
+          name: sub-025_task-rest_run-2_echo-1_bold.json
+        - relation: 86f7de0aab6e037b267cb59be01522e9
+          name: sub-025_task-rest_run-2_echo-1_bold.nii
+        - relation: 77076e6d43c5ef3e1c1fd7bd96098a54
+          name: sub-025_task-rest_run-2_echo-2_bold.json
+        - relation: 27a372721c92ce378d24b66dc45177a2
+          name: sub-025_task-rest_run-2_echo-2_bold.nii
+        - relation: a26b09276b6ebf55dcafcc93a40391a9
+          name: sub-025_task-rest_run-2_echo-3_bold.json
+        - relation: 2c415447bbfe53ac60adf92aad2d998e
+          name: sub-025_task-rest_run-2_echo-3_bold.nii
+        - relation: 7dd438d04b16055b2fd0ae4459538b3a
+          name: sub-025_task-rest_run-2_physio.json
+        - relation: 56668a26291c7bd6af6901f2942bc7ba
+          name: sub-025_task-rest_run-2_physio.tsv.gz
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 240a45381b94d5ca4d4ade6eaaf7c534
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 240a45381b94d5ca4d4ade6eaaf7c534
+      download_url: https://dataverse.nl/api/access/datafile/45351
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 18f17176166efa9151bb8ca293698c6c
+      byte_size: 1042
+      checksum:
+        algorithm: md5
+        digest: 18f17176166efa9151bb8ca293698c6c
+      download_url: https://dataverse.nl/api/access/datafile/45198
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: feca4cabeb9b08cf58eeb4c8ba952f77
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: feca4cabeb9b08cf58eeb4c8ba952f77
+      download_url: https://dataverse.nl/api/access/datafile/46275
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 79a76423364b453c79bee24ab27fddaa
+      byte_size: 1042
+      checksum:
+        algorithm: md5
+        digest: 79a76423364b453c79bee24ab27fddaa
+      download_url: https://dataverse.nl/api/access/datafile/46298
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 9f4e28cd101143505ac5185185124158
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 9f4e28cd101143505ac5185185124158
+      download_url: https://dataverse.nl/api/access/datafile/45341
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 74b10e4d7333f58ed1b380af45c84266
+      byte_size: 1896
+      checksum:
+        algorithm: md5
+        digest: 74b10e4d7333f58ed1b380af45c84266
+      download_url: https://dataverse.nl/api/access/datafile/46576
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f53925e9fa6a24259e91d0537d5d725b
+      byte_size: 1050
+      checksum:
+        algorithm: md5
+        digest: f53925e9fa6a24259e91d0537d5d725b
+      download_url: https://dataverse.nl/api/access/datafile/46037
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 0577b1e7ea6786bae61031a06220a810
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 0577b1e7ea6786bae61031a06220a810
+      download_url: https://dataverse.nl/api/access/datafile/45491
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e13ebf196f9e07478266674ac5ead24e
+      byte_size: 1050
+      checksum:
+        algorithm: md5
+        digest: e13ebf196f9e07478266674ac5ead24e
+      download_url: https://dataverse.nl/api/access/datafile/45898
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a994b10225ee41df351809c9358faf85
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: a994b10225ee41df351809c9358faf85
+      download_url: https://dataverse.nl/api/access/datafile/45929
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c7b24e636a25b4d08c411f949ab0ef5a
+      byte_size: 1050
+      checksum:
+        algorithm: md5
+        digest: c7b24e636a25b4d08c411f949ab0ef5a
+      download_url: https://dataverse.nl/api/access/datafile/45743
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 15d6eaa340a866de7e64b32cee611a03
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 15d6eaa340a866de7e64b32cee611a03
+      download_url: https://dataverse.nl/api/access/datafile/46194
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 037993522fb30018c40367a704483687
+      byte_size: 180
+      checksum:
+        algorithm: md5
+        digest: 037993522fb30018c40367a704483687
+      download_url: https://dataverse.nl/api/access/datafile/46641
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f2ea0de36ad20fbd34744be2686ef790
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: f2ea0de36ad20fbd34744be2686ef790
+      download_url: https://dataverse.nl/api/access/datafile/46062
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5aeaf61ce59c611def6ca7200925fcad
+      byte_size: 450969
+      checksum:
+        algorithm: md5
+        digest: 5aeaf61ce59c611def6ca7200925fcad
+      download_url: https://dataverse.nl/api/access/datafile/45662
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 495e70560c2f494854fc9dcac2abf81b
+      byte_size: 142
+      checksum:
+        algorithm: md5
+        digest: 495e70560c2f494854fc9dcac2abf81b
+      download_url: https://dataverse.nl/api/access/datafile/45584
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ca9ef6362d3c02e157aa2b5b31663737
+      byte_size: 505872
+      checksum:
+        algorithm: md5
+        digest: ca9ef6362d3c02e157aa2b5b31663737
+      download_url: https://dataverse.nl/api/access/datafile/46348
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2a4112c592ddeeffa7b0d609eaa48472
+      byte_size: 1038
+      checksum:
+        algorithm: md5
+        digest: 2a4112c592ddeeffa7b0d609eaa48472
+      download_url: https://dataverse.nl/api/access/datafile/45888
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 7a4989302353c2507229aa6e1a36a2d9
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 7a4989302353c2507229aa6e1a36a2d9
+      download_url: https://dataverse.nl/api/access/datafile/45181
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 049d6292f471d9725b1bb562b3f48b20
+      byte_size: 1038
+      checksum:
+        algorithm: md5
+        digest: 049d6292f471d9725b1bb562b3f48b20
+      download_url: https://dataverse.nl/api/access/datafile/45500
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 62d567a6946e8f2f95e45e70b33da544
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 62d567a6946e8f2f95e45e70b33da544
+      download_url: https://dataverse.nl/api/access/datafile/45463
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 9b661b4cd4ef743034cfef2427b76d08
+      byte_size: 1038
+      checksum:
+        algorithm: md5
+        digest: 9b661b4cd4ef743034cfef2427b76d08
+      download_url: https://dataverse.nl/api/access/datafile/45337
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 91b40c8fead0371648bd2b77154f9dd1
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 91b40c8fead0371648bd2b77154f9dd1
+      download_url: https://dataverse.nl/api/access/datafile/45204
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 575dcf28dc7c1641f5117121b99bfb5b
+      byte_size: 167
+      checksum:
+        algorithm: md5
+        digest: 575dcf28dc7c1641f5117121b99bfb5b
+      download_url: https://dataverse.nl/api/access/datafile/46632
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c2ba2164df29bcb46e163701354cc111
+      byte_size: 1046
+      checksum:
+        algorithm: md5
+        digest: c2ba2164df29bcb46e163701354cc111
+      download_url: https://dataverse.nl/api/access/datafile/45925
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 065a74091eb867a4b9165209bd271403
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 065a74091eb867a4b9165209bd271403
+      download_url: https://dataverse.nl/api/access/datafile/45927
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 45d501c3ef2f6c388b26b5165818aa51
+      byte_size: 1046
+      checksum:
+        algorithm: md5
+        digest: 45d501c3ef2f6c388b26b5165818aa51
+      download_url: https://dataverse.nl/api/access/datafile/45340
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 18bd02a9fc512830f0a2a0f00f23023a
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 18bd02a9fc512830f0a2a0f00f23023a
+      download_url: https://dataverse.nl/api/access/datafile/45567
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b555c9c1024633c1267d0bb87060f4a5
+      byte_size: 1046
+      checksum:
+        algorithm: md5
+        digest: b555c9c1024633c1267d0bb87060f4a5
+      download_url: https://dataverse.nl/api/access/datafile/45978
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2152b72ca956bf7a8c9ba8392fe4dcf7
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 2152b72ca956bf7a8c9ba8392fe4dcf7
+      download_url: https://dataverse.nl/api/access/datafile/45096
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c3721d501643fa74c63a2849bbe0fc29
+      byte_size: 179
+      checksum:
+        algorithm: md5
+        digest: c3721d501643fa74c63a2849bbe0fc29
+      download_url: https://dataverse.nl/api/access/datafile/46555
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: bc7ea47540ecc5fd483cea3751596558
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: bc7ea47540ecc5fd483cea3751596558
+      download_url: https://dataverse.nl/api/access/datafile/45250
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2ddca451eda2d8d03218a82b70c566ca
+      byte_size: 479333
+      checksum:
+        algorithm: md5
+        digest: 2ddca451eda2d8d03218a82b70c566ca
+      download_url: https://dataverse.nl/api/access/datafile/45534
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8ef8c83c58f8e3b5b6118e0b84e00404
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 8ef8c83c58f8e3b5b6118e0b84e00404
+      download_url: https://dataverse.nl/api/access/datafile/45823
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ce57f859bfd8c3ce710253e4daa4dd60
+      byte_size: 496050
+      checksum:
+        algorithm: md5
+        digest: ce57f859bfd8c3ce710253e4daa4dd60
+      download_url: https://dataverse.nl/api/access/datafile/46039
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2c9dcd69ba60afc1907ff85b249312b6
+      byte_size: 1029
+      checksum:
+        algorithm: md5
+        digest: 2c9dcd69ba60afc1907ff85b249312b6
+      download_url: https://dataverse.nl/api/access/datafile/45938
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 60d5dd81c35de9876e0f66908461cbc6
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 60d5dd81c35de9876e0f66908461cbc6
+      download_url: https://dataverse.nl/api/access/datafile/45311
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c8e33ac93b50f58fa0687b474791e7d3
+      byte_size: 1029
+      checksum:
+        algorithm: md5
+        digest: c8e33ac93b50f58fa0687b474791e7d3
+      download_url: https://dataverse.nl/api/access/datafile/45475
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 3a646ee3c1b543a56a0f21176be2efdd
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 3a646ee3c1b543a56a0f21176be2efdd
+      download_url: https://dataverse.nl/api/access/datafile/46370
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8c21a8507b6cb565588c0140180d2772
+      byte_size: 1029
+      checksum:
+        algorithm: md5
+        digest: 8c21a8507b6cb565588c0140180d2772
+      download_url: https://dataverse.nl/api/access/datafile/45753
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a147274fd35661aa0c1fa1d7f0b308b1
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: a147274fd35661aa0c1fa1d7f0b308b1
+      download_url: https://dataverse.nl/api/access/datafile/46272
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e53241984863a44ace80f7ae64b587ef
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: e53241984863a44ace80f7ae64b587ef
+      download_url: https://dataverse.nl/api/access/datafile/45211
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 807f681d4fd68b0f5b7bd9a208e0619f
+      byte_size: 457356
+      checksum:
+        algorithm: md5
+        digest: 807f681d4fd68b0f5b7bd9a208e0619f
+      download_url: https://dataverse.nl/api/access/datafile/46116
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b2ef37dc700fe8774b2c78aa3033676b
+      byte_size: 1029
+      checksum:
+        algorithm: md5
+        digest: b2ef37dc700fe8774b2c78aa3033676b
+      download_url: https://dataverse.nl/api/access/datafile/46521
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 86f7de0aab6e037b267cb59be01522e9
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 86f7de0aab6e037b267cb59be01522e9
+      download_url: https://dataverse.nl/api/access/datafile/45322
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 77076e6d43c5ef3e1c1fd7bd96098a54
+      byte_size: 1029
+      checksum:
+        algorithm: md5
+        digest: 77076e6d43c5ef3e1c1fd7bd96098a54
+      download_url: https://dataverse.nl/api/access/datafile/45656
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 27a372721c92ce378d24b66dc45177a2
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 27a372721c92ce378d24b66dc45177a2
+      download_url: https://dataverse.nl/api/access/datafile/45931
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a26b09276b6ebf55dcafcc93a40391a9
+      byte_size: 1029
+      checksum:
+        algorithm: md5
+        digest: a26b09276b6ebf55dcafcc93a40391a9
+      download_url: https://dataverse.nl/api/access/datafile/46458
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2c415447bbfe53ac60adf92aad2d998e
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 2c415447bbfe53ac60adf92aad2d998e
+      download_url: https://dataverse.nl/api/access/datafile/45113
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 7dd438d04b16055b2fd0ae4459538b3a
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 7dd438d04b16055b2fd0ae4459538b3a
+      download_url: https://dataverse.nl/api/access/datafile/45592
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 56668a26291c7bd6af6901f2942bc7ba
+      byte_size: 448369
+      checksum:
+        algorithm: md5
+        digest: 56668a26291c7bd6af6901f2942bc7ba
+      download_url: https://dataverse.nl/api/access/datafile/45367
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b0393dbc149581f72e5faec4f4010dd1
+      byte_size: 20736352
+      checksum:
+        algorithm: md5
+        digest: b0393dbc149581f72e5faec4f4010dd1
+      download_url: https://dataverse.nl/api/access/datafile/45775
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-026/
+      qualified_part:
+        - relation: sub-026/anat/
+          name: anat
+        - relation: sub-026/func/
+          name: func
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-026/anat/
+      qualified_part:
+        - relation: b0393dbc149581f72e5faec4f4010dd1
+          name: sub-026_T1w.nii
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c3c5a4acf31d2c108256ac46d603f2e0
+      byte_size: 1041
+      checksum:
+        algorithm: md5
+        digest: c3c5a4acf31d2c108256ac46d603f2e0
+      download_url: https://dataverse.nl/api/access/datafile/46180
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-026/func/
+      qualified_part:
+        - relation: c3c5a4acf31d2c108256ac46d603f2e0
+          name: sub-026_task-emotionProcessing_echo-1_bold.json
+        - relation: 770c0aab148ac49b357464c9b08789c1
+          name: sub-026_task-emotionProcessing_echo-1_bold.nii
+        - relation: 22ff64eb37754e5c041c65e50d73e027
+          name: sub-026_task-emotionProcessing_echo-2_bold.json
+        - relation: e0745a6a4926df590506751ab2f87f2f
+          name: sub-026_task-emotionProcessing_echo-2_bold.nii
+        - relation: 61bcc9bddf6122c8bf7713df4eeca7ae
+          name: sub-026_task-emotionProcessing_echo-3_bold.json
+        - relation: 02180f5df7a7e039eb6be0af5fd144b9
+          name: sub-026_task-emotionProcessing_echo-3_bold.nii
+        - relation: ad78412b62e046c2d7f46e70c84f0a35
+          name: sub-026_task-emotionProcessing_events.tsv.gz
+        - relation: 5b9a67934af122a9f8a7046d14aac605
+          name: sub-026_task-emotionProcessingImagined_echo-1_bold.json
+        - relation: 8604e9da34c047ae16fdeaa56782c720
+          name: sub-026_task-emotionProcessingImagined_echo-1_bold.nii
+        - relation: 636b783ce7993c116e8df06a0868f804
+          name: sub-026_task-emotionProcessingImagined_echo-2_bold.json
+        - relation: 1d0165578e7797307cf5b82d6b546298
+          name: sub-026_task-emotionProcessingImagined_echo-2_bold.nii
+        - relation: 51c9f9c4f068f84d0d6fc62daae340dd
+          name: sub-026_task-emotionProcessingImagined_echo-3_bold.json
+        - relation: 40e7a5baf0522ff99a61028781f06564
+          name: sub-026_task-emotionProcessingImagined_echo-3_bold.nii
+        - relation: 66f9c2461d4904750d29717f18771847
+          name: sub-026_task-emotionProcessingImagined_events.tsv.gz
+        - relation: cf612fd13dec932183d848f4b1c211a5
+          name: sub-026_task-emotionProcessingImagined_physio.json
+        - relation: 60bca3447bb980e7b21b9d5d84ac16d0
+          name: sub-026_task-emotionProcessingImagined_physio.tsv.gz
+        - relation: a47ab5b3cf57e4d1dc9923f36acfb62b
+          name: sub-026_task-emotionProcessing_physio.json
+        - relation: bd2ef171a4203d82411f72eddb69bb55
+          name: sub-026_task-emotionProcessing_physio.tsv.gz
+        - relation: 16cd0167b36edbc8355d6eddf70652a0
+          name: sub-026_task-fingerTapping_echo-1_bold.json
+        - relation: 4e8e0e382d40a67f712be2ddf6978c68
+          name: sub-026_task-fingerTapping_echo-1_bold.nii
+        - relation: 1f7fbd1bd9df0d59e61c5a951a193129
+          name: sub-026_task-fingerTapping_echo-2_bold.json
+        - relation: 584623c4e56b1e15ba62c79455eb934c
+          name: sub-026_task-fingerTapping_echo-2_bold.nii
+        - relation: 380c897d6ec1474bc749b4f529ac5648
+          name: sub-026_task-fingerTapping_echo-3_bold.json
+        - relation: 54414da1d6c300555e243927fd85fa04
+          name: sub-026_task-fingerTapping_echo-3_bold.nii
+        - relation: b758cca6a704f1302b8830893618918b
+          name: sub-026_task-fingerTapping_events.tsv.gz
+        - relation: 4d3fdda5ac93b7abaded38f5dcb36a1a
+          name: sub-026_task-fingerTappingImagined_echo-1_bold.json
+        - relation: a2d337bf912bd286970e48b179d1eb67
+          name: sub-026_task-fingerTappingImagined_echo-1_bold.nii
+        - relation: 61aaeafeb068f2e4474db1ddc062709f
+          name: sub-026_task-fingerTappingImagined_echo-2_bold.json
+        - relation: 43469f452f999528b527ddbb5781ca8c
+          name: sub-026_task-fingerTappingImagined_echo-2_bold.nii
+        - relation: ec8247219a8d162e6b41a79edb16b048
+          name: sub-026_task-fingerTappingImagined_echo-3_bold.json
+        - relation: 97553d139ca593353f3a0137b66678e3
+          name: sub-026_task-fingerTappingImagined_echo-3_bold.nii
+        - relation: 4a4be477b2f82edd56c569aef703b1ea
+          name: sub-026_task-fingerTappingImagined_events.tsv.gz
+        - relation: 8ebb24c7fcc1281d2306572f11ab4a82
+          name: sub-026_task-fingerTappingImagined_physio.json
+        - relation: 6950b366743ab0a636aaa9caf8acf961
+          name: sub-026_task-fingerTappingImagined_physio.tsv.gz
+        - relation: 5020aca0469a7eda04d8cf6e4ef3d87d
+          name: sub-026_task-fingerTapping_physio.json
+        - relation: 878f685f595fa9dc696feef4789bb331
+          name: sub-026_task-fingerTapping_physio.tsv.gz
+        - relation: 0fbbcca7138fd1ff8277c69bf9f03938
+          name: sub-026_task-rest_run-1_echo-1_bold.json
+        - relation: fc12d511864f590534b7649311359b6e
+          name: sub-026_task-rest_run-1_echo-1_bold.nii
+        - relation: bf8044e98020ad358d35b4f684a2df61
+          name: sub-026_task-rest_run-1_echo-2_bold.json
+        - relation: d432804d113ad3d24db7c09eb0e4a928
+          name: sub-026_task-rest_run-1_echo-2_bold.nii
+        - relation: 873faf19266364b522c1d6ff010a23f4
+          name: sub-026_task-rest_run-1_echo-3_bold.json
+        - relation: ca995fcfd80b219b2a474a351aa6256b
+          name: sub-026_task-rest_run-1_echo-3_bold.nii
+        - relation: b1d969444e3b2cf6a637e0e401af8ed2
+          name: sub-026_task-rest_run-1_physio.json
+        - relation: c7322b9e688232d8591496c9bacdd07f
+          name: sub-026_task-rest_run-1_physio.tsv.gz
+        - relation: b027df5bf2692e25e4389b3c1d61121f
+          name: sub-026_task-rest_run-2_echo-1_bold.json
+        - relation: cfea757fd830246c0e200499328caa6f
+          name: sub-026_task-rest_run-2_echo-1_bold.nii
+        - relation: 807807cadb2a53b8ab053c87c28dba77
+          name: sub-026_task-rest_run-2_echo-2_bold.json
+        - relation: bf5a83754588b04028a3b542c683c680
+          name: sub-026_task-rest_run-2_echo-2_bold.nii
+        - relation: e2bbb35ec65a1da6ac637993aed9555f
+          name: sub-026_task-rest_run-2_echo-3_bold.json
+        - relation: d4f0ac826307f186692d28d962a4cb33
+          name: sub-026_task-rest_run-2_echo-3_bold.nii
+        - relation: f2ed61b872263d38fa3b3f5c35d46451
+          name: sub-026_task-rest_run-2_physio.json
+        - relation: 08050fddf8b54edcf6e8dd20ed418b49
+          name: sub-026_task-rest_run-2_physio.tsv.gz
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 770c0aab148ac49b357464c9b08789c1
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 770c0aab148ac49b357464c9b08789c1
+      download_url: https://dataverse.nl/api/access/datafile/45720
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 22ff64eb37754e5c041c65e50d73e027
+      byte_size: 1041
+      checksum:
+        algorithm: md5
+        digest: 22ff64eb37754e5c041c65e50d73e027
+      download_url: https://dataverse.nl/api/access/datafile/45124
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e0745a6a4926df590506751ab2f87f2f
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: e0745a6a4926df590506751ab2f87f2f
+      download_url: https://dataverse.nl/api/access/datafile/46126
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 61bcc9bddf6122c8bf7713df4eeca7ae
+      byte_size: 1041
+      checksum:
+        algorithm: md5
+        digest: 61bcc9bddf6122c8bf7713df4eeca7ae
+      download_url: https://dataverse.nl/api/access/datafile/45191
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 02180f5df7a7e039eb6be0af5fd144b9
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 02180f5df7a7e039eb6be0af5fd144b9
+      download_url: https://dataverse.nl/api/access/datafile/45717
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ad78412b62e046c2d7f46e70c84f0a35
+      byte_size: 1902
+      checksum:
+        algorithm: md5
+        digest: ad78412b62e046c2d7f46e70c84f0a35
+      download_url: https://dataverse.nl/api/access/datafile/46627
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5b9a67934af122a9f8a7046d14aac605
+      byte_size: 1049
+      checksum:
+        algorithm: md5
+        digest: 5b9a67934af122a9f8a7046d14aac605
+      download_url: https://dataverse.nl/api/access/datafile/45316
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8604e9da34c047ae16fdeaa56782c720
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 8604e9da34c047ae16fdeaa56782c720
+      download_url: https://dataverse.nl/api/access/datafile/45407
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 636b783ce7993c116e8df06a0868f804
+      byte_size: 1049
+      checksum:
+        algorithm: md5
+        digest: 636b783ce7993c116e8df06a0868f804
+      download_url: https://dataverse.nl/api/access/datafile/45443
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1d0165578e7797307cf5b82d6b546298
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 1d0165578e7797307cf5b82d6b546298
+      download_url: https://dataverse.nl/api/access/datafile/45736
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 51c9f9c4f068f84d0d6fc62daae340dd
+      byte_size: 1049
+      checksum:
+        algorithm: md5
+        digest: 51c9f9c4f068f84d0d6fc62daae340dd
+      download_url: https://dataverse.nl/api/access/datafile/46207
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 40e7a5baf0522ff99a61028781f06564
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 40e7a5baf0522ff99a61028781f06564
+      download_url: https://dataverse.nl/api/access/datafile/45784
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 66f9c2461d4904750d29717f18771847
+      byte_size: 178
+      checksum:
+        algorithm: md5
+        digest: 66f9c2461d4904750d29717f18771847
+      download_url: https://dataverse.nl/api/access/datafile/46572
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: cf612fd13dec932183d848f4b1c211a5
+      byte_size: 142
+      checksum:
+        algorithm: md5
+        digest: cf612fd13dec932183d848f4b1c211a5
+      download_url: https://dataverse.nl/api/access/datafile/45802
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 60bca3447bb980e7b21b9d5d84ac16d0
+      byte_size: 464619
+      checksum:
+        algorithm: md5
+        digest: 60bca3447bb980e7b21b9d5d84ac16d0
+      download_url: https://dataverse.nl/api/access/datafile/45361
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a47ab5b3cf57e4d1dc9923f36acfb62b
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: a47ab5b3cf57e4d1dc9923f36acfb62b
+      download_url: https://dataverse.nl/api/access/datafile/45748
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: bd2ef171a4203d82411f72eddb69bb55
+      byte_size: 476434
+      checksum:
+        algorithm: md5
+        digest: bd2ef171a4203d82411f72eddb69bb55
+      download_url: https://dataverse.nl/api/access/datafile/45752
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 16cd0167b36edbc8355d6eddf70652a0
+      byte_size: 1037
+      checksum:
+        algorithm: md5
+        digest: 16cd0167b36edbc8355d6eddf70652a0
+      download_url: https://dataverse.nl/api/access/datafile/45356
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4e8e0e382d40a67f712be2ddf6978c68
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 4e8e0e382d40a67f712be2ddf6978c68
+      download_url: https://dataverse.nl/api/access/datafile/45358
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1f7fbd1bd9df0d59e61c5a951a193129
+      byte_size: 1037
+      checksum:
+        algorithm: md5
+        digest: 1f7fbd1bd9df0d59e61c5a951a193129
+      download_url: https://dataverse.nl/api/access/datafile/45706
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 584623c4e56b1e15ba62c79455eb934c
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 584623c4e56b1e15ba62c79455eb934c
+      download_url: https://dataverse.nl/api/access/datafile/46203
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 380c897d6ec1474bc749b4f529ac5648
+      byte_size: 1037
+      checksum:
+        algorithm: md5
+        digest: 380c897d6ec1474bc749b4f529ac5648
+      download_url: https://dataverse.nl/api/access/datafile/46197
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 54414da1d6c300555e243927fd85fa04
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 54414da1d6c300555e243927fd85fa04
+      download_url: https://dataverse.nl/api/access/datafile/46500
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b758cca6a704f1302b8830893618918b
+      byte_size: 166
+      checksum:
+        algorithm: md5
+        digest: b758cca6a704f1302b8830893618918b
+      download_url: https://dataverse.nl/api/access/datafile/46657
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4d3fdda5ac93b7abaded38f5dcb36a1a
+      byte_size: 1045
+      checksum:
+        algorithm: md5
+        digest: 4d3fdda5ac93b7abaded38f5dcb36a1a
+      download_url: https://dataverse.nl/api/access/datafile/45863
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a2d337bf912bd286970e48b179d1eb67
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: a2d337bf912bd286970e48b179d1eb67
+      download_url: https://dataverse.nl/api/access/datafile/46003
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 61aaeafeb068f2e4474db1ddc062709f
+      byte_size: 1045
+      checksum:
+        algorithm: md5
+        digest: 61aaeafeb068f2e4474db1ddc062709f
+      download_url: https://dataverse.nl/api/access/datafile/45207
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 43469f452f999528b527ddbb5781ca8c
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 43469f452f999528b527ddbb5781ca8c
+      download_url: https://dataverse.nl/api/access/datafile/45593
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ec8247219a8d162e6b41a79edb16b048
+      byte_size: 1045
+      checksum:
+        algorithm: md5
+        digest: ec8247219a8d162e6b41a79edb16b048
+      download_url: https://dataverse.nl/api/access/datafile/45967
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 97553d139ca593353f3a0137b66678e3
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 97553d139ca593353f3a0137b66678e3
+      download_url: https://dataverse.nl/api/access/datafile/45303
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4a4be477b2f82edd56c569aef703b1ea
+      byte_size: 179
+      checksum:
+        algorithm: md5
+        digest: 4a4be477b2f82edd56c569aef703b1ea
+      download_url: https://dataverse.nl/api/access/datafile/46633
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8ebb24c7fcc1281d2306572f11ab4a82
+      byte_size: 142
+      checksum:
+        algorithm: md5
+        digest: 8ebb24c7fcc1281d2306572f11ab4a82
+      download_url: https://dataverse.nl/api/access/datafile/45470
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6950b366743ab0a636aaa9caf8acf961
+      byte_size: 460022
+      checksum:
+        algorithm: md5
+        digest: 6950b366743ab0a636aaa9caf8acf961
+      download_url: https://dataverse.nl/api/access/datafile/46144
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5020aca0469a7eda04d8cf6e4ef3d87d
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 5020aca0469a7eda04d8cf6e4ef3d87d
+      download_url: https://dataverse.nl/api/access/datafile/45442
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 878f685f595fa9dc696feef4789bb331
+      byte_size: 497401
+      checksum:
+        algorithm: md5
+        digest: 878f685f595fa9dc696feef4789bb331
+      download_url: https://dataverse.nl/api/access/datafile/45266
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 0fbbcca7138fd1ff8277c69bf9f03938
+      byte_size: 1028
+      checksum:
+        algorithm: md5
+        digest: 0fbbcca7138fd1ff8277c69bf9f03938
+      download_url: https://dataverse.nl/api/access/datafile/46218
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: fc12d511864f590534b7649311359b6e
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: fc12d511864f590534b7649311359b6e
+      download_url: https://dataverse.nl/api/access/datafile/45210
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: bf8044e98020ad358d35b4f684a2df61
+      byte_size: 1028
+      checksum:
+        algorithm: md5
+        digest: bf8044e98020ad358d35b4f684a2df61
+      download_url: https://dataverse.nl/api/access/datafile/45201
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d432804d113ad3d24db7c09eb0e4a928
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: d432804d113ad3d24db7c09eb0e4a928
+      download_url: https://dataverse.nl/api/access/datafile/46430
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 873faf19266364b522c1d6ff010a23f4
+      byte_size: 1028
+      checksum:
+        algorithm: md5
+        digest: 873faf19266364b522c1d6ff010a23f4
+      download_url: https://dataverse.nl/api/access/datafile/45730
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ca995fcfd80b219b2a474a351aa6256b
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: ca995fcfd80b219b2a474a351aa6256b
+      download_url: https://dataverse.nl/api/access/datafile/45899
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b1d969444e3b2cf6a637e0e401af8ed2
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: b1d969444e3b2cf6a637e0e401af8ed2
+      download_url: https://dataverse.nl/api/access/datafile/45915
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c7322b9e688232d8591496c9bacdd07f
+      byte_size: 465084
+      checksum:
+        algorithm: md5
+        digest: c7322b9e688232d8591496c9bacdd07f
+      download_url: https://dataverse.nl/api/access/datafile/45221
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b027df5bf2692e25e4389b3c1d61121f
+      byte_size: 1028
+      checksum:
+        algorithm: md5
+        digest: b027df5bf2692e25e4389b3c1d61121f
+      download_url: https://dataverse.nl/api/access/datafile/46115
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: cfea757fd830246c0e200499328caa6f
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: cfea757fd830246c0e200499328caa6f
+      download_url: https://dataverse.nl/api/access/datafile/46346
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 807807cadb2a53b8ab053c87c28dba77
+      byte_size: 1028
+      checksum:
+        algorithm: md5
+        digest: 807807cadb2a53b8ab053c87c28dba77
+      download_url: https://dataverse.nl/api/access/datafile/46495
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: bf5a83754588b04028a3b542c683c680
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: bf5a83754588b04028a3b542c683c680
+      download_url: https://dataverse.nl/api/access/datafile/46255
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e2bbb35ec65a1da6ac637993aed9555f
+      byte_size: 1028
+      checksum:
+        algorithm: md5
+        digest: e2bbb35ec65a1da6ac637993aed9555f
+      download_url: https://dataverse.nl/api/access/datafile/46091
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d4f0ac826307f186692d28d962a4cb33
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: d4f0ac826307f186692d28d962a4cb33
+      download_url: https://dataverse.nl/api/access/datafile/45446
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f2ed61b872263d38fa3b3f5c35d46451
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: f2ed61b872263d38fa3b3f5c35d46451
+      download_url: https://dataverse.nl/api/access/datafile/46504
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 08050fddf8b54edcf6e8dd20ed418b49
+      byte_size: 449037
+      checksum:
+        algorithm: md5
+        digest: 08050fddf8b54edcf6e8dd20ed418b49
+      download_url: https://dataverse.nl/api/access/datafile/46502
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 391360fed2f0ad9f464d4300b04fe8f4
+      byte_size: 20736352
+      checksum:
+        algorithm: md5
+        digest: 391360fed2f0ad9f464d4300b04fe8f4
+      download_url: https://dataverse.nl/api/access/datafile/46196
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-027/
+      qualified_part:
+        - relation: sub-027/anat/
+          name: anat
+        - relation: sub-027/func/
+          name: func
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-027/anat/
+      qualified_part:
+        - relation: 391360fed2f0ad9f464d4300b04fe8f4
+          name: sub-027_T1w.nii
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 9160e7408a54f19cd6943c271a0643bc
+      byte_size: 1040
+      checksum:
+        algorithm: md5
+        digest: 9160e7408a54f19cd6943c271a0643bc
+      download_url: https://dataverse.nl/api/access/datafile/45240
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-027/func/
+      qualified_part:
+        - relation: 9160e7408a54f19cd6943c271a0643bc
+          name: sub-027_task-emotionProcessing_echo-1_bold.json
+        - relation: d741e2a020dc97ad80e6205bdcc1953c
+          name: sub-027_task-emotionProcessing_echo-1_bold.nii
+        - relation: c8397b637fc28c1468f26a8e6fca9854
+          name: sub-027_task-emotionProcessing_echo-2_bold.json
+        - relation: d3d77d1e8d03a761c3d9c1e29113cd46
+          name: sub-027_task-emotionProcessing_echo-2_bold.nii
+        - relation: 2b703cf362406375d6b528f6f8eff65b
+          name: sub-027_task-emotionProcessing_echo-3_bold.json
+        - relation: b27fcc2c413af187edddb0a4d94fae78
+          name: sub-027_task-emotionProcessing_echo-3_bold.nii
+        - relation: 64a1e3bbdc41d6cca658ff58ac0703ce
+          name: sub-027_task-emotionProcessing_events.tsv.gz
+        - relation: b340ada6fbcebfc0999e079125cde231
+          name: sub-027_task-emotionProcessingImagined_echo-1_bold.json
+        - relation: 3a8b601a8da50c346c16721f01f843f3
+          name: sub-027_task-emotionProcessingImagined_echo-1_bold.nii
+        - relation: 10940b21e34c03e91d4f0e3b70388ab7
+          name: sub-027_task-emotionProcessingImagined_echo-2_bold.json
+        - relation: 94e31e6ff6ad8b9212a23835abc46588
+          name: sub-027_task-emotionProcessingImagined_echo-2_bold.nii
+        - relation: 1337be6106cbe1368eb2384d1e0614af
+          name: sub-027_task-emotionProcessingImagined_echo-3_bold.json
+        - relation: 45b90f82c23548d7c07299a03c5a219d
+          name: sub-027_task-emotionProcessingImagined_echo-3_bold.nii
+        - relation: 6edd4c82ceac6be3e069f15c3613ee2e
+          name: sub-027_task-emotionProcessingImagined_events.tsv.gz
+        - relation: 7da3a6096bb9532815b05563ec61bf57
+          name: sub-027_task-emotionProcessingImagined_physio.json
+        - relation: 57b540b40cb1493e98612110fa28c93c
+          name: sub-027_task-emotionProcessingImagined_physio.tsv.gz
+        - relation: ff828f0cbc209f4601b5acb666ec2e61
+          name: sub-027_task-emotionProcessing_physio.json
+        - relation: 5e2a55382b9d1cab3a0d8cee81c57b16
+          name: sub-027_task-emotionProcessing_physio.tsv.gz
+        - relation: e891f95434005225ed9747717d7b5606
+          name: sub-027_task-fingerTapping_echo-1_bold.json
+        - relation: 3608b349357d99e9c57f0bebefdb5dba
+          name: sub-027_task-fingerTapping_echo-1_bold.nii
+        - relation: 88ca6bae797eeef31ab85c72c8f1b83d
+          name: sub-027_task-fingerTapping_echo-2_bold.json
+        - relation: 3e3c6c87080b1b228d590288ed93bf88
+          name: sub-027_task-fingerTapping_echo-2_bold.nii
+        - relation: e674d6920f9c458f9afbb3ce20416156
+          name: sub-027_task-fingerTapping_echo-3_bold.json
+        - relation: ceca9bc881d3d8c2dce5a93323a9bab8
+          name: sub-027_task-fingerTapping_echo-3_bold.nii
+        - relation: 0c8eb59418ffe7b04c69942e22d446fb
+          name: sub-027_task-fingerTapping_events.tsv.gz
+        - relation: a093f58299db4d28fbda66cbc6182c22
+          name: sub-027_task-fingerTappingImagined_echo-1_bold.json
+        - relation: cb6ba5d1cbb04710d9c08597388e22ec
+          name: sub-027_task-fingerTappingImagined_echo-1_bold.nii
+        - relation: 4aff660c764a99132d29bedb2eeaf39c
+          name: sub-027_task-fingerTappingImagined_echo-2_bold.json
+        - relation: 7d1773442a1c6e9a171350de28e8df0d
+          name: sub-027_task-fingerTappingImagined_echo-2_bold.nii
+        - relation: 4722a3d37ecee2451946a7f7897fec2c
+          name: sub-027_task-fingerTappingImagined_echo-3_bold.json
+        - relation: d1ba9ec1cca3971aa85232714599548c
+          name: sub-027_task-fingerTappingImagined_echo-3_bold.nii
+        - relation: 4b8a49c8748a47a811bf90760466590c
+          name: sub-027_task-fingerTappingImagined_events.tsv.gz
+        - relation: 201ea354a8c6c2f9090f93a83c70533f
+          name: sub-027_task-fingerTappingImagined_physio.json
+        - relation: 7ba98152b934f6d16a8e5f3350fe483e
+          name: sub-027_task-fingerTappingImagined_physio.tsv.gz
+        - relation: c0c17e9c4c91d0d05d553dc841d298ed
+          name: sub-027_task-fingerTapping_physio.json
+        - relation: 009b85384195d8104c10f0df6726bb8b
+          name: sub-027_task-fingerTapping_physio.tsv.gz
+        - relation: 253882b38043b647b0541a58a3f82db4
+          name: sub-027_task-rest_run-1_echo-1_bold.json
+        - relation: 8ffcf3f54f89836cae1c0bbc17020b3e
+          name: sub-027_task-rest_run-1_echo-1_bold.nii
+        - relation: 686d54fb051d3f88ea343fcc3c95275b
+          name: sub-027_task-rest_run-1_echo-2_bold.json
+        - relation: 25adaf8e38e816070776d127d853c399
+          name: sub-027_task-rest_run-1_echo-2_bold.nii
+        - relation: e5f7167edc3dfaf10919d8371c6239ed
+          name: sub-027_task-rest_run-1_echo-3_bold.json
+        - relation: 0d67d81e894e7de8301c486e78e91650
+          name: sub-027_task-rest_run-1_echo-3_bold.nii
+        - relation: ad035f41a9d628c3a43837a17ffc50f7
+          name: sub-027_task-rest_run-1_physio.json
+        - relation: cedec6211e60ce688cdb00403a795c16
+          name: sub-027_task-rest_run-1_physio.tsv.gz
+        - relation: 9634dc297777a27ef17e67ff2f31b423
+          name: sub-027_task-rest_run-2_echo-1_bold.json
+        - relation: 839e798f0209fb7dd87cc483ee4f3b78
+          name: sub-027_task-rest_run-2_echo-1_bold.nii
+        - relation: 9f79bf08427dd6445dcc5198eadead64
+          name: sub-027_task-rest_run-2_echo-2_bold.json
+        - relation: 935489062a230bd4231076feba9393cd
+          name: sub-027_task-rest_run-2_echo-2_bold.nii
+        - relation: ce58fa531efd9f62eb4b75982de83e5a
+          name: sub-027_task-rest_run-2_echo-3_bold.json
+        - relation: 7f3c62626662b3d21664314518af4ddc
+          name: sub-027_task-rest_run-2_echo-3_bold.nii
+        - relation: 3a52de0bfc90eef9cd273d188e194ff5
+          name: sub-027_task-rest_run-2_physio.json
+        - relation: e6481ed05c3fa687ffa6f9d8388cde2e
+          name: sub-027_task-rest_run-2_physio.tsv.gz
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d741e2a020dc97ad80e6205bdcc1953c
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: d741e2a020dc97ad80e6205bdcc1953c
+      download_url: https://dataverse.nl/api/access/datafile/46467
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c8397b637fc28c1468f26a8e6fca9854
+      byte_size: 1040
+      checksum:
+        algorithm: md5
+        digest: c8397b637fc28c1468f26a8e6fca9854
+      download_url: https://dataverse.nl/api/access/datafile/46490
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d3d77d1e8d03a761c3d9c1e29113cd46
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: d3d77d1e8d03a761c3d9c1e29113cd46
+      download_url: https://dataverse.nl/api/access/datafile/45728
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2b703cf362406375d6b528f6f8eff65b
+      byte_size: 1040
+      checksum:
+        algorithm: md5
+        digest: 2b703cf362406375d6b528f6f8eff65b
+      download_url: https://dataverse.nl/api/access/datafile/46099
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b27fcc2c413af187edddb0a4d94fae78
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: b27fcc2c413af187edddb0a4d94fae78
+      download_url: https://dataverse.nl/api/access/datafile/46270
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 64a1e3bbdc41d6cca658ff58ac0703ce
+      byte_size: 1886
+      checksum:
+        algorithm: md5
+        digest: 64a1e3bbdc41d6cca658ff58ac0703ce
+      download_url: https://dataverse.nl/api/access/datafile/46643
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b340ada6fbcebfc0999e079125cde231
+      byte_size: 1047
+      checksum:
+        algorithm: md5
+        digest: b340ada6fbcebfc0999e079125cde231
+      download_url: https://dataverse.nl/api/access/datafile/46382
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 3a8b601a8da50c346c16721f01f843f3
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 3a8b601a8da50c346c16721f01f843f3
+      download_url: https://dataverse.nl/api/access/datafile/46132
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 10940b21e34c03e91d4f0e3b70388ab7
+      byte_size: 1047
+      checksum:
+        algorithm: md5
+        digest: 10940b21e34c03e91d4f0e3b70388ab7
+      download_url: https://dataverse.nl/api/access/datafile/46420
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 94e31e6ff6ad8b9212a23835abc46588
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 94e31e6ff6ad8b9212a23835abc46588
+      download_url: https://dataverse.nl/api/access/datafile/46025
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1337be6106cbe1368eb2384d1e0614af
+      byte_size: 1047
+      checksum:
+        algorithm: md5
+        digest: 1337be6106cbe1368eb2384d1e0614af
+      download_url: https://dataverse.nl/api/access/datafile/45551
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 45b90f82c23548d7c07299a03c5a219d
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 45b90f82c23548d7c07299a03c5a219d
+      download_url: https://dataverse.nl/api/access/datafile/45301
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6edd4c82ceac6be3e069f15c3613ee2e
+      byte_size: 178
+      checksum:
+        algorithm: md5
+        digest: 6edd4c82ceac6be3e069f15c3613ee2e
+      download_url: https://dataverse.nl/api/access/datafile/46613
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 7da3a6096bb9532815b05563ec61bf57
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 7da3a6096bb9532815b05563ec61bf57
+      download_url: https://dataverse.nl/api/access/datafile/46179
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 57b540b40cb1493e98612110fa28c93c
+      byte_size: 488218
+      checksum:
+        algorithm: md5
+        digest: 57b540b40cb1493e98612110fa28c93c
+      download_url: https://dataverse.nl/api/access/datafile/46242
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ff828f0cbc209f4601b5acb666ec2e61
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: ff828f0cbc209f4601b5acb666ec2e61
+      download_url: https://dataverse.nl/api/access/datafile/45510
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5e2a55382b9d1cab3a0d8cee81c57b16
+      byte_size: 516529
+      checksum:
+        algorithm: md5
+        digest: 5e2a55382b9d1cab3a0d8cee81c57b16
+      download_url: https://dataverse.nl/api/access/datafile/46489
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e891f95434005225ed9747717d7b5606
+      byte_size: 1036
+      checksum:
+        algorithm: md5
+        digest: e891f95434005225ed9747717d7b5606
+      download_url: https://dataverse.nl/api/access/datafile/45803
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 3608b349357d99e9c57f0bebefdb5dba
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 3608b349357d99e9c57f0bebefdb5dba
+      download_url: https://dataverse.nl/api/access/datafile/45503
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 88ca6bae797eeef31ab85c72c8f1b83d
+      byte_size: 1036
+      checksum:
+        algorithm: md5
+        digest: 88ca6bae797eeef31ab85c72c8f1b83d
+      download_url: https://dataverse.nl/api/access/datafile/46219
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 3e3c6c87080b1b228d590288ed93bf88
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 3e3c6c87080b1b228d590288ed93bf88
+      download_url: https://dataverse.nl/api/access/datafile/45951
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e674d6920f9c458f9afbb3ce20416156
+      byte_size: 1036
+      checksum:
+        algorithm: md5
+        digest: e674d6920f9c458f9afbb3ce20416156
+      download_url: https://dataverse.nl/api/access/datafile/45848
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ceca9bc881d3d8c2dce5a93323a9bab8
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: ceca9bc881d3d8c2dce5a93323a9bab8
+      download_url: https://dataverse.nl/api/access/datafile/46492
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 0c8eb59418ffe7b04c69942e22d446fb
+      byte_size: 167
+      checksum:
+        algorithm: md5
+        digest: 0c8eb59418ffe7b04c69942e22d446fb
+      download_url: https://dataverse.nl/api/access/datafile/46573
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a093f58299db4d28fbda66cbc6182c22
+      byte_size: 1043
+      checksum:
+        algorithm: md5
+        digest: a093f58299db4d28fbda66cbc6182c22
+      download_url: https://dataverse.nl/api/access/datafile/46029
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: cb6ba5d1cbb04710d9c08597388e22ec
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: cb6ba5d1cbb04710d9c08597388e22ec
+      download_url: https://dataverse.nl/api/access/datafile/46480
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4aff660c764a99132d29bedb2eeaf39c
+      byte_size: 1043
+      checksum:
+        algorithm: md5
+        digest: 4aff660c764a99132d29bedb2eeaf39c
+      download_url: https://dataverse.nl/api/access/datafile/46439
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 7d1773442a1c6e9a171350de28e8df0d
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 7d1773442a1c6e9a171350de28e8df0d
+      download_url: https://dataverse.nl/api/access/datafile/46328
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4722a3d37ecee2451946a7f7897fec2c
+      byte_size: 1043
+      checksum:
+        algorithm: md5
+        digest: 4722a3d37ecee2451946a7f7897fec2c
+      download_url: https://dataverse.nl/api/access/datafile/45896
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d1ba9ec1cca3971aa85232714599548c
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: d1ba9ec1cca3971aa85232714599548c
+      download_url: https://dataverse.nl/api/access/datafile/45174
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4b8a49c8748a47a811bf90760466590c
+      byte_size: 179
+      checksum:
+        algorithm: md5
+        digest: 4b8a49c8748a47a811bf90760466590c
+      download_url: https://dataverse.nl/api/access/datafile/46565
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 201ea354a8c6c2f9090f93a83c70533f
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 201ea354a8c6c2f9090f93a83c70533f
+      download_url: https://dataverse.nl/api/access/datafile/45531
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 7ba98152b934f6d16a8e5f3350fe483e
+      byte_size: 493219
+      checksum:
+        algorithm: md5
+        digest: 7ba98152b934f6d16a8e5f3350fe483e
+      download_url: https://dataverse.nl/api/access/datafile/45699
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c0c17e9c4c91d0d05d553dc841d298ed
+      byte_size: 142
+      checksum:
+        algorithm: md5
+        digest: c0c17e9c4c91d0d05d553dc841d298ed
+      download_url: https://dataverse.nl/api/access/datafile/45345
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 009b85384195d8104c10f0df6726bb8b
+      byte_size: 499845
+      checksum:
+        algorithm: md5
+        digest: 009b85384195d8104c10f0df6726bb8b
+      download_url: https://dataverse.nl/api/access/datafile/45659
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 253882b38043b647b0541a58a3f82db4
+      byte_size: 1026
+      checksum:
+        algorithm: md5
+        digest: 253882b38043b647b0541a58a3f82db4
+      download_url: https://dataverse.nl/api/access/datafile/45839
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8ffcf3f54f89836cae1c0bbc17020b3e
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 8ffcf3f54f89836cae1c0bbc17020b3e
+      download_url: https://dataverse.nl/api/access/datafile/46239
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 686d54fb051d3f88ea343fcc3c95275b
+      byte_size: 1026
+      checksum:
+        algorithm: md5
+        digest: 686d54fb051d3f88ea343fcc3c95275b
+      download_url: https://dataverse.nl/api/access/datafile/45876
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 25adaf8e38e816070776d127d853c399
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 25adaf8e38e816070776d127d853c399
+      download_url: https://dataverse.nl/api/access/datafile/45762
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e5f7167edc3dfaf10919d8371c6239ed
+      byte_size: 1026
+      checksum:
+        algorithm: md5
+        digest: e5f7167edc3dfaf10919d8371c6239ed
+      download_url: https://dataverse.nl/api/access/datafile/45856
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 0d67d81e894e7de8301c486e78e91650
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 0d67d81e894e7de8301c486e78e91650
+      download_url: https://dataverse.nl/api/access/datafile/46340
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ad035f41a9d628c3a43837a17ffc50f7
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: ad035f41a9d628c3a43837a17ffc50f7
+      download_url: https://dataverse.nl/api/access/datafile/46462
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: cedec6211e60ce688cdb00403a795c16
+      byte_size: 473633
+      checksum:
+        algorithm: md5
+        digest: cedec6211e60ce688cdb00403a795c16
+      download_url: https://dataverse.nl/api/access/datafile/45296
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 9634dc297777a27ef17e67ff2f31b423
+      byte_size: 1027
+      checksum:
+        algorithm: md5
+        digest: 9634dc297777a27ef17e67ff2f31b423
+      download_url: https://dataverse.nl/api/access/datafile/45555
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 839e798f0209fb7dd87cc483ee4f3b78
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 839e798f0209fb7dd87cc483ee4f3b78
+      download_url: https://dataverse.nl/api/access/datafile/46536
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 9f79bf08427dd6445dcc5198eadead64
+      byte_size: 1027
+      checksum:
+        algorithm: md5
+        digest: 9f79bf08427dd6445dcc5198eadead64
+      download_url: https://dataverse.nl/api/access/datafile/46009
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 935489062a230bd4231076feba9393cd
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 935489062a230bd4231076feba9393cd
+      download_url: https://dataverse.nl/api/access/datafile/46460
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ce58fa531efd9f62eb4b75982de83e5a
+      byte_size: 1027
+      checksum:
+        algorithm: md5
+        digest: ce58fa531efd9f62eb4b75982de83e5a
+      download_url: https://dataverse.nl/api/access/datafile/46526
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 7f3c62626662b3d21664314518af4ddc
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 7f3c62626662b3d21664314518af4ddc
+      download_url: https://dataverse.nl/api/access/datafile/45789
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 3a52de0bfc90eef9cd273d188e194ff5
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 3a52de0bfc90eef9cd273d188e194ff5
+      download_url: https://dataverse.nl/api/access/datafile/45150
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e6481ed05c3fa687ffa6f9d8388cde2e
+      byte_size: 487715
+      checksum:
+        algorithm: md5
+        digest: e6481ed05c3fa687ffa6f9d8388cde2e
+      download_url: https://dataverse.nl/api/access/datafile/46046
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 06483989167b850081d0eab5e4e9d75f
+      byte_size: 20736352
+      checksum:
+        algorithm: md5
+        digest: 06483989167b850081d0eab5e4e9d75f
+      download_url: https://dataverse.nl/api/access/datafile/45117
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-029/
+      qualified_part:
+        - relation: sub-029/anat/
+          name: anat
+        - relation: sub-029/func/
+          name: func
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-029/anat/
+      qualified_part:
+        - relation: 06483989167b850081d0eab5e4e9d75f
+          name: sub-029_T1w.nii
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8ca710b33f86c36e67dab5765f551546
+      byte_size: 1041
+      checksum:
+        algorithm: md5
+        digest: 8ca710b33f86c36e67dab5765f551546
+      download_url: https://dataverse.nl/api/access/datafile/46096
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-029/func/
+      qualified_part:
+        - relation: 8ca710b33f86c36e67dab5765f551546
+          name: sub-029_task-emotionProcessing_echo-1_bold.json
+        - relation: 2ea82caf66be69b706e8da251f3db1d0
+          name: sub-029_task-emotionProcessing_echo-1_bold.nii
+        - relation: c642a1f2033af0aa25af0f8106ea516e
+          name: sub-029_task-emotionProcessing_echo-2_bold.json
+        - relation: 98f88deb44a64198f93800a8c567fe7c
+          name: sub-029_task-emotionProcessing_echo-2_bold.nii
+        - relation: aef317b5b3098ea2d40de1ce8b9cfc53
+          name: sub-029_task-emotionProcessing_echo-3_bold.json
+        - relation: 86949512bb0e3dc1ccb8f6881b62c9e9
+          name: sub-029_task-emotionProcessing_echo-3_bold.nii
+        - relation: d363bda5a57ca4e2a170fb7db38fb98a
+          name: sub-029_task-emotionProcessing_events.tsv.gz
+        - relation: 4b5ebeecc9bfc412bbb6e6207e2ed6d5
+          name: sub-029_task-emotionProcessingImagined_echo-1_bold.json
+        - relation: dc9b6f33e0ae0b074310728fdd5fe572
+          name: sub-029_task-emotionProcessingImagined_echo-1_bold.nii
+        - relation: 0e9ef021458d12f51f4e91f110661ff9
+          name: sub-029_task-emotionProcessingImagined_echo-2_bold.json
+        - relation: 6f3194817a8e84239182251ad1fd57c8
+          name: sub-029_task-emotionProcessingImagined_echo-2_bold.nii
+        - relation: c1fca06fbd4937b40f45ab3c82e20e69
+          name: sub-029_task-emotionProcessingImagined_echo-3_bold.json
+        - relation: 6a8b3989f7b59fb6989d366b27e6ec00
+          name: sub-029_task-emotionProcessingImagined_echo-3_bold.nii
+        - relation: 3dd04e9279353a82d5fc7e98460a239f
+          name: sub-029_task-emotionProcessingImagined_events.tsv.gz
+        - relation: 72c92178962a931773723d1358fca1bc
+          name: sub-029_task-emotionProcessingImagined_physio.json
+        - relation: ab3c13026db0130f0f23bcdbf62a9e6f
+          name: sub-029_task-emotionProcessingImagined_physio.tsv.gz
+        - relation: f3bb13d436264f3d9b208761a7af1463
+          name: sub-029_task-emotionProcessing_physio.json
+        - relation: 6cdf0fecde4d7226e248dc44fcb1836c
+          name: sub-029_task-emotionProcessing_physio.tsv.gz
+        - relation: cc0ff9e49a4e54f8654e4ccfd3aaa3f1
+          name: sub-029_task-fingerTapping_echo-1_bold.json
+        - relation: daa2747d5a5ab3547278063606409baf
+          name: sub-029_task-fingerTapping_echo-1_bold.nii
+        - relation: 9a52040f6152d9f9b714816a1a601a9e
+          name: sub-029_task-fingerTapping_echo-2_bold.json
+        - relation: d77cb3cddfca2a2523a46553d9d6fb2c
+          name: sub-029_task-fingerTapping_echo-2_bold.nii
+        - relation: e9b328f4103fc80bbb330d963750caa2
+          name: sub-029_task-fingerTapping_echo-3_bold.json
+        - relation: 5da88cf257ba32d596e009edb8574ef8
+          name: sub-029_task-fingerTapping_echo-3_bold.nii
+        - relation: fd56c77f281c86a9ffb0ddfb09edad97
+          name: sub-029_task-fingerTapping_events.tsv.gz
+        - relation: dc98a0fa52e322063b98f2f45fd9fba6
+          name: sub-029_task-fingerTappingImagined_echo-1_bold.json
+        - relation: a40d4b6f350974a9298ac88ddaa3d84b
+          name: sub-029_task-fingerTappingImagined_echo-1_bold.nii
+        - relation: 759d73ec6bb1a2c407609dc8dddbb704
+          name: sub-029_task-fingerTappingImagined_echo-2_bold.json
+        - relation: abe0243354e2355bdf1786b8e6bcae36
+          name: sub-029_task-fingerTappingImagined_echo-2_bold.nii
+        - relation: d6934052b107e29a3db3e7fc8fba735a
+          name: sub-029_task-fingerTappingImagined_echo-3_bold.json
+        - relation: e056ceee63a8590f083810062f4c34a6
+          name: sub-029_task-fingerTappingImagined_echo-3_bold.nii
+        - relation: 85c94ae6f5fc3b8115d2d419476970cf
+          name: sub-029_task-fingerTappingImagined_events.tsv.gz
+        - relation: 672a4fffbdb16d51499b7930064e1859
+          name: sub-029_task-fingerTappingImagined_physio.json
+        - relation: f71826f74749fe71b7800028c9db1673
+          name: sub-029_task-fingerTappingImagined_physio.tsv.gz
+        - relation: 8be2efff90b216f6acd2809951cf8be6
+          name: sub-029_task-fingerTapping_physio.json
+        - relation: a54c4190dc3c0ecc5beb2b8c9e14735d
+          name: sub-029_task-fingerTapping_physio.tsv.gz
+        - relation: 2872c86e9bacbf82a565dd634ea72386
+          name: sub-029_task-rest_run-1_echo-1_bold.json
+        - relation: 0402d0c1b534383c18c909cc1ad31274
+          name: sub-029_task-rest_run-1_echo-1_bold.nii
+        - relation: ebde01f4f6faf37078c2ff7590b5d256
+          name: sub-029_task-rest_run-1_echo-2_bold.json
+        - relation: 666119314daf509245b75a6254078361
+          name: sub-029_task-rest_run-1_echo-2_bold.nii
+        - relation: 638328d8f9a7083428279da196b3e8c4
+          name: sub-029_task-rest_run-1_echo-3_bold.json
+        - relation: 55aa6d4913b1d6be0e2fcf1c9bbb4333
+          name: sub-029_task-rest_run-1_echo-3_bold.nii
+        - relation: 605ad92271ca46ea0eb86d118616eea9
+          name: sub-029_task-rest_run-1_physio.json
+        - relation: 0dd5ef126996587d16cbce6bd84c2171
+          name: sub-029_task-rest_run-1_physio.tsv.gz
+        - relation: e5533ef3787593680c32ca4c1f6c846a
+          name: sub-029_task-rest_run-2_echo-1_bold.json
+        - relation: a1803f1a402f76f74b955542462d8955
+          name: sub-029_task-rest_run-2_echo-1_bold.nii
+        - relation: f66d20f3812cf38f3e58aec4c2920f9b
+          name: sub-029_task-rest_run-2_echo-2_bold.json
+        - relation: 287aff701204899813a052aae55231e3
+          name: sub-029_task-rest_run-2_echo-2_bold.nii
+        - relation: 31c3bd8364753cc3a49b352afb2a040a
+          name: sub-029_task-rest_run-2_echo-3_bold.json
+        - relation: d274d9901dba8b51a96692e93beef094
+          name: sub-029_task-rest_run-2_echo-3_bold.nii
+        - relation: dcf2960a303745514d4365f102d11dca
+          name: sub-029_task-rest_run-2_physio.json
+        - relation: b9e8a26a359147c508c9aacaad33c4b4
+          name: sub-029_task-rest_run-2_physio.tsv.gz
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2ea82caf66be69b706e8da251f3db1d0
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 2ea82caf66be69b706e8da251f3db1d0
+      download_url: https://dataverse.nl/api/access/datafile/46345
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c642a1f2033af0aa25af0f8106ea516e
+      byte_size: 1041
+      checksum:
+        algorithm: md5
+        digest: c642a1f2033af0aa25af0f8106ea516e
+      download_url: https://dataverse.nl/api/access/datafile/45707
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 98f88deb44a64198f93800a8c567fe7c
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 98f88deb44a64198f93800a8c567fe7c
+      download_url: https://dataverse.nl/api/access/datafile/45348
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: aef317b5b3098ea2d40de1ce8b9cfc53
+      byte_size: 1041
+      checksum:
+        algorithm: md5
+        digest: aef317b5b3098ea2d40de1ce8b9cfc53
+      download_url: https://dataverse.nl/api/access/datafile/46391
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 86949512bb0e3dc1ccb8f6881b62c9e9
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 86949512bb0e3dc1ccb8f6881b62c9e9
+      download_url: https://dataverse.nl/api/access/datafile/46488
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d363bda5a57ca4e2a170fb7db38fb98a
+      byte_size: 1947
+      checksum:
+        algorithm: md5
+        digest: d363bda5a57ca4e2a170fb7db38fb98a
+      download_url: https://dataverse.nl/api/access/datafile/46611
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4b5ebeecc9bfc412bbb6e6207e2ed6d5
+      byte_size: 1049
+      checksum:
+        algorithm: md5
+        digest: 4b5ebeecc9bfc412bbb6e6207e2ed6d5
+      download_url: https://dataverse.nl/api/access/datafile/45357
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: dc9b6f33e0ae0b074310728fdd5fe572
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: dc9b6f33e0ae0b074310728fdd5fe572
+      download_url: https://dataverse.nl/api/access/datafile/45972
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 0e9ef021458d12f51f4e91f110661ff9
+      byte_size: 1049
+      checksum:
+        algorithm: md5
+        digest: 0e9ef021458d12f51f4e91f110661ff9
+      download_url: https://dataverse.nl/api/access/datafile/45760
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6f3194817a8e84239182251ad1fd57c8
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 6f3194817a8e84239182251ad1fd57c8
+      download_url: https://dataverse.nl/api/access/datafile/46102
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c1fca06fbd4937b40f45ab3c82e20e69
+      byte_size: 1049
+      checksum:
+        algorithm: md5
+        digest: c1fca06fbd4937b40f45ab3c82e20e69
+      download_url: https://dataverse.nl/api/access/datafile/46330
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6a8b3989f7b59fb6989d366b27e6ec00
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 6a8b3989f7b59fb6989d366b27e6ec00
+      download_url: https://dataverse.nl/api/access/datafile/45886
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 3dd04e9279353a82d5fc7e98460a239f
+      byte_size: 178
+      checksum:
+        algorithm: md5
+        digest: 3dd04e9279353a82d5fc7e98460a239f
+      download_url: https://dataverse.nl/api/access/datafile/46630
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 72c92178962a931773723d1358fca1bc
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 72c92178962a931773723d1358fca1bc
+      download_url: https://dataverse.nl/api/access/datafile/45563
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ab3c13026db0130f0f23bcdbf62a9e6f
+      byte_size: 509090
+      checksum:
+        algorithm: md5
+        digest: ab3c13026db0130f0f23bcdbf62a9e6f
+      download_url: https://dataverse.nl/api/access/datafile/45919
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f3bb13d436264f3d9b208761a7af1463
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: f3bb13d436264f3d9b208761a7af1463
+      download_url: https://dataverse.nl/api/access/datafile/46198
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6cdf0fecde4d7226e248dc44fcb1836c
+      byte_size: 614680
+      checksum:
+        algorithm: md5
+        digest: 6cdf0fecde4d7226e248dc44fcb1836c
+      download_url: https://dataverse.nl/api/access/datafile/45976
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: cc0ff9e49a4e54f8654e4ccfd3aaa3f1
+      byte_size: 1037
+      checksum:
+        algorithm: md5
+        digest: cc0ff9e49a4e54f8654e4ccfd3aaa3f1
+      download_url: https://dataverse.nl/api/access/datafile/46484
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: daa2747d5a5ab3547278063606409baf
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: daa2747d5a5ab3547278063606409baf
+      download_url: https://dataverse.nl/api/access/datafile/46123
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 9a52040f6152d9f9b714816a1a601a9e
+      byte_size: 1037
+      checksum:
+        algorithm: md5
+        digest: 9a52040f6152d9f9b714816a1a601a9e
+      download_url: https://dataverse.nl/api/access/datafile/46381
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d77cb3cddfca2a2523a46553d9d6fb2c
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: d77cb3cddfca2a2523a46553d9d6fb2c
+      download_url: https://dataverse.nl/api/access/datafile/45759
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e9b328f4103fc80bbb330d963750caa2
+      byte_size: 1037
+      checksum:
+        algorithm: md5
+        digest: e9b328f4103fc80bbb330d963750caa2
+      download_url: https://dataverse.nl/api/access/datafile/45651
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5da88cf257ba32d596e009edb8574ef8
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 5da88cf257ba32d596e009edb8574ef8
+      download_url: https://dataverse.nl/api/access/datafile/45220
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: fd56c77f281c86a9ffb0ddfb09edad97
+      byte_size: 168
+      checksum:
+        algorithm: md5
+        digest: fd56c77f281c86a9ffb0ddfb09edad97
+      download_url: https://dataverse.nl/api/access/datafile/46566
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: dc98a0fa52e322063b98f2f45fd9fba6
+      byte_size: 1044
+      checksum:
+        algorithm: md5
+        digest: dc98a0fa52e322063b98f2f45fd9fba6
+      download_url: https://dataverse.nl/api/access/datafile/45974
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a40d4b6f350974a9298ac88ddaa3d84b
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: a40d4b6f350974a9298ac88ddaa3d84b
+      download_url: https://dataverse.nl/api/access/datafile/45477
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 759d73ec6bb1a2c407609dc8dddbb704
+      byte_size: 1044
+      checksum:
+        algorithm: md5
+        digest: 759d73ec6bb1a2c407609dc8dddbb704
+      download_url: https://dataverse.nl/api/access/datafile/46077
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: abe0243354e2355bdf1786b8e6bcae36
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: abe0243354e2355bdf1786b8e6bcae36
+      download_url: https://dataverse.nl/api/access/datafile/45973
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d6934052b107e29a3db3e7fc8fba735a
+      byte_size: 1044
+      checksum:
+        algorithm: md5
+        digest: d6934052b107e29a3db3e7fc8fba735a
+      download_url: https://dataverse.nl/api/access/datafile/46173
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e056ceee63a8590f083810062f4c34a6
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: e056ceee63a8590f083810062f4c34a6
+      download_url: https://dataverse.nl/api/access/datafile/46260
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 85c94ae6f5fc3b8115d2d419476970cf
+      byte_size: 179
+      checksum:
+        algorithm: md5
+        digest: 85c94ae6f5fc3b8115d2d419476970cf
+      download_url: https://dataverse.nl/api/access/datafile/46642
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 672a4fffbdb16d51499b7930064e1859
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 672a4fffbdb16d51499b7930064e1859
+      download_url: https://dataverse.nl/api/access/datafile/45801
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f71826f74749fe71b7800028c9db1673
+      byte_size: 526633
+      checksum:
+        algorithm: md5
+        digest: f71826f74749fe71b7800028c9db1673
+      download_url: https://dataverse.nl/api/access/datafile/45434
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8be2efff90b216f6acd2809951cf8be6
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 8be2efff90b216f6acd2809951cf8be6
+      download_url: https://dataverse.nl/api/access/datafile/45128
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a54c4190dc3c0ecc5beb2b8c9e14735d
+      byte_size: 602444
+      checksum:
+        algorithm: md5
+        digest: a54c4190dc3c0ecc5beb2b8c9e14735d
+      download_url: https://dataverse.nl/api/access/datafile/46271
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2872c86e9bacbf82a565dd634ea72386
+      byte_size: 1028
+      checksum:
+        algorithm: md5
+        digest: 2872c86e9bacbf82a565dd634ea72386
+      download_url: https://dataverse.nl/api/access/datafile/45838
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 0402d0c1b534383c18c909cc1ad31274
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 0402d0c1b534383c18c909cc1ad31274
+      download_url: https://dataverse.nl/api/access/datafile/45854
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ebde01f4f6faf37078c2ff7590b5d256
+      byte_size: 1028
+      checksum:
+        algorithm: md5
+        digest: ebde01f4f6faf37078c2ff7590b5d256
+      download_url: https://dataverse.nl/api/access/datafile/46175
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 666119314daf509245b75a6254078361
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 666119314daf509245b75a6254078361
+      download_url: https://dataverse.nl/api/access/datafile/45329
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 638328d8f9a7083428279da196b3e8c4
+      byte_size: 1028
+      checksum:
+        algorithm: md5
+        digest: 638328d8f9a7083428279da196b3e8c4
+      download_url: https://dataverse.nl/api/access/datafile/45864
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 55aa6d4913b1d6be0e2fcf1c9bbb4333
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 55aa6d4913b1d6be0e2fcf1c9bbb4333
+      download_url: https://dataverse.nl/api/access/datafile/46055
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 605ad92271ca46ea0eb86d118616eea9
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 605ad92271ca46ea0eb86d118616eea9
+      download_url: https://dataverse.nl/api/access/datafile/45263
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 0dd5ef126996587d16cbce6bd84c2171
+      byte_size: 453530
+      checksum:
+        algorithm: md5
+        digest: 0dd5ef126996587d16cbce6bd84c2171
+      download_url: https://dataverse.nl/api/access/datafile/45671
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e5533ef3787593680c32ca4c1f6c846a
+      byte_size: 1028
+      checksum:
+        algorithm: md5
+        digest: e5533ef3787593680c32ca4c1f6c846a
+      download_url: https://dataverse.nl/api/access/datafile/46040
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a1803f1a402f76f74b955542462d8955
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: a1803f1a402f76f74b955542462d8955
+      download_url: https://dataverse.nl/api/access/datafile/45749
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f66d20f3812cf38f3e58aec4c2920f9b
+      byte_size: 1028
+      checksum:
+        algorithm: md5
+        digest: f66d20f3812cf38f3e58aec4c2920f9b
+      download_url: https://dataverse.nl/api/access/datafile/45829
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 287aff701204899813a052aae55231e3
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 287aff701204899813a052aae55231e3
+      download_url: https://dataverse.nl/api/access/datafile/46335
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 31c3bd8364753cc3a49b352afb2a040a
+      byte_size: 1028
+      checksum:
+        algorithm: md5
+        digest: 31c3bd8364753cc3a49b352afb2a040a
+      download_url: https://dataverse.nl/api/access/datafile/45613
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d274d9901dba8b51a96692e93beef094
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: d274d9901dba8b51a96692e93beef094
+      download_url: https://dataverse.nl/api/access/datafile/46059
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: dcf2960a303745514d4365f102d11dca
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: dcf2960a303745514d4365f102d11dca
+      download_url: https://dataverse.nl/api/access/datafile/46013
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b9e8a26a359147c508c9aacaad33c4b4
+      byte_size: 493637
+      checksum:
+        algorithm: md5
+        digest: b9e8a26a359147c508c9aacaad33c4b4
+      download_url: https://dataverse.nl/api/access/datafile/45135
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 7d49af0678a253f050888f0d5c5b9a7c
+      byte_size: 20736352
+      checksum:
+        algorithm: md5
+        digest: 7d49af0678a253f050888f0d5c5b9a7c
+      download_url: https://dataverse.nl/api/access/datafile/45964
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-030/
+      qualified_part:
+        - relation: sub-030/anat/
+          name: anat
+        - relation: sub-030/func/
+          name: func
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-030/anat/
+      qualified_part:
+        - relation: 7d49af0678a253f050888f0d5c5b9a7c
+          name: sub-030_T1w.nii
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6284fd8caa795a3542e92047539225bb
+      byte_size: 1042
+      checksum:
+        algorithm: md5
+        digest: 6284fd8caa795a3542e92047539225bb
+      download_url: https://dataverse.nl/api/access/datafile/45716
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-030/func/
+      qualified_part:
+        - relation: 6284fd8caa795a3542e92047539225bb
+          name: sub-030_task-emotionProcessing_echo-1_bold.json
+        - relation: 5153f6c8dda335e5e4afdd07b49d3d16
+          name: sub-030_task-emotionProcessing_echo-1_bold.nii
+        - relation: 5f346e95cfacb71285559c08ffa801e0
+          name: sub-030_task-emotionProcessing_echo-2_bold.json
+        - relation: 27e5d2456721906e1515d9da26871f8e
+          name: sub-030_task-emotionProcessing_echo-2_bold.nii
+        - relation: 5c0a009bb87d5dee80253bcccc3ba026
+          name: sub-030_task-emotionProcessing_echo-3_bold.json
+        - relation: 61294fe08c7d78a6cb629dc8786deb4c
+          name: sub-030_task-emotionProcessing_echo-3_bold.nii
+        - relation: cdf3ae06fc8eb4745cf011b0817fbc32
+          name: sub-030_task-emotionProcessing_events.tsv.gz
+        - relation: a947de9eba6d81991eed24943542c2c7
+          name: sub-030_task-emotionProcessingImagined_echo-1_bold.json
+        - relation: 249dd14e1e023cf98361813e8fe2c8ce
+          name: sub-030_task-emotionProcessingImagined_echo-1_bold.nii
+        - relation: 3bf5e0d06f4c0b44684708016ead2384
+          name: sub-030_task-emotionProcessingImagined_echo-2_bold.json
+        - relation: 1545d6a2710463db6f31a9b18522b4f2
+          name: sub-030_task-emotionProcessingImagined_echo-2_bold.nii
+        - relation: dde2c167088d531a025f0a0e94388f5a
+          name: sub-030_task-emotionProcessingImagined_echo-3_bold.json
+        - relation: 5a8bb9ec0d6adb579068cab4e90878c2
+          name: sub-030_task-emotionProcessingImagined_echo-3_bold.nii
+        - relation: 16fb8a49a30a04a40eb1d884275bff57
+          name: sub-030_task-emotionProcessingImagined_events.tsv.gz
+        - relation: 33dc5896a50bc63493bab3f0743b3465
+          name: sub-030_task-emotionProcessingImagined_physio.json
+        - relation: fd5ee5ea81e0249b03683f0d656d4c70
+          name: sub-030_task-emotionProcessingImagined_physio.tsv.gz
+        - relation: ad740656f44d82f4bd7b9cd85cfa75b6
+          name: sub-030_task-emotionProcessing_physio.json
+        - relation: e0560ed1d249cadf942ed068312f4074
+          name: sub-030_task-emotionProcessing_physio.tsv.gz
+        - relation: 87b01272f0d3aec042a70c89cb64c610
+          name: sub-030_task-fingerTapping_echo-1_bold.json
+        - relation: 70c2c565c57410becebcb81c2743b366
+          name: sub-030_task-fingerTapping_echo-1_bold.nii
+        - relation: d2ad0551f289c82c784c0311cbda5868
+          name: sub-030_task-fingerTapping_echo-2_bold.json
+        - relation: 0a985477a760a6866461a8503d29841f
+          name: sub-030_task-fingerTapping_echo-2_bold.nii
+        - relation: 5d7912fb3c00c49ab445f37d023fabde
+          name: sub-030_task-fingerTapping_echo-3_bold.json
+        - relation: 8d8f176db5374b8f5312c07b3868f190
+          name: sub-030_task-fingerTapping_echo-3_bold.nii
+        - relation: 10274748238e4edb1cacbc5ff8c4efb4
+          name: sub-030_task-fingerTapping_events.tsv.gz
+        - relation: 6deb98259db82a9bb337c44e78e221fe
+          name: sub-030_task-fingerTappingImagined_echo-1_bold.json
+        - relation: 9206830373a50d76fa9be72699a45be2
+          name: sub-030_task-fingerTappingImagined_echo-1_bold.nii
+        - relation: 1e119f9dea2d0f2266fdba2f09099eba
+          name: sub-030_task-fingerTappingImagined_echo-2_bold.json
+        - relation: 3b8d8099ff221a24e6f8c2c6e4b5570c
+          name: sub-030_task-fingerTappingImagined_echo-2_bold.nii
+        - relation: ca1f88e3755c369289b2c59316feabd1
+          name: sub-030_task-fingerTappingImagined_echo-3_bold.json
+        - relation: 54ab340987d511300097fd979ba2500a
+          name: sub-030_task-fingerTappingImagined_echo-3_bold.nii
+        - relation: aed4fce2a1c6cef0f89684bbf389f48a
+          name: sub-030_task-fingerTappingImagined_events.tsv.gz
+        - relation: ed88005c127d5f5aef4342a0dee22e4a
+          name: sub-030_task-fingerTappingImagined_physio.json
+        - relation: 803e662ede5ba87711a0e764a4dc5e00
+          name: sub-030_task-fingerTappingImagined_physio.tsv.gz
+        - relation: bcd7d4cca00199ced81ffacc4c34ec31
+          name: sub-030_task-fingerTapping_physio.json
+        - relation: 50fbda51cbb53ef16f3fb3597d76d674
+          name: sub-030_task-fingerTapping_physio.tsv.gz
+        - relation: 0e9ab4d23523465646ff1a1fff65dc25
+          name: sub-030_task-rest_run-1_echo-1_bold.json
+        - relation: 7b7d78156f700cae33926db5aa2f0d04
+          name: sub-030_task-rest_run-1_echo-1_bold.nii
+        - relation: 7e85df7221171f6b2372643486c02bcb
+          name: sub-030_task-rest_run-1_echo-2_bold.json
+        - relation: 122692ec73aa0497ec013677ce2cb7e0
+          name: sub-030_task-rest_run-1_echo-2_bold.nii
+        - relation: 43e86c28283bc8009c9d97276c233295
+          name: sub-030_task-rest_run-1_echo-3_bold.json
+        - relation: d91741896d318dc2ed2b04cb0d9278c5
+          name: sub-030_task-rest_run-1_echo-3_bold.nii
+        - relation: 51211fa4e8939015647398b0c8c7e679
+          name: sub-030_task-rest_run-1_physio.json
+        - relation: e68ffa789f92076c93d66148afd5cd89
+          name: sub-030_task-rest_run-1_physio.tsv.gz
+        - relation: 956ae391decb81c3c0b4696c2f95ac4b
+          name: sub-030_task-rest_run-2_echo-1_bold.json
+        - relation: 747a22e06891ce5b95226b442fead6f6
+          name: sub-030_task-rest_run-2_echo-1_bold.nii
+        - relation: 04d3584fb830f7a8ef784728c17e630e
+          name: sub-030_task-rest_run-2_echo-2_bold.json
+        - relation: 1597ff009b5f28a228d4dfd9ebc0e93e
+          name: sub-030_task-rest_run-2_echo-2_bold.nii
+        - relation: 7c4457b85550d91fae95d072a4cc570b
+          name: sub-030_task-rest_run-2_echo-3_bold.json
+        - relation: 62d1d1ee187bcf3bb58bf391bf188b32
+          name: sub-030_task-rest_run-2_echo-3_bold.nii
+        - relation: a652f7b56ad758609c5310ef0fab2937
+          name: sub-030_task-rest_run-2_physio.json
+        - relation: 4cf99739f118bfd9a0997fe0ae604bcc
+          name: sub-030_task-rest_run-2_physio.tsv.gz
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5153f6c8dda335e5e4afdd07b49d3d16
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 5153f6c8dda335e5e4afdd07b49d3d16
+      download_url: https://dataverse.nl/api/access/datafile/45675
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5f346e95cfacb71285559c08ffa801e0
+      byte_size: 1042
+      checksum:
+        algorithm: md5
+        digest: 5f346e95cfacb71285559c08ffa801e0
+      download_url: https://dataverse.nl/api/access/datafile/46140
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 27e5d2456721906e1515d9da26871f8e
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 27e5d2456721906e1515d9da26871f8e
+      download_url: https://dataverse.nl/api/access/datafile/45997
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5c0a009bb87d5dee80253bcccc3ba026
+      byte_size: 1042
+      checksum:
+        algorithm: md5
+        digest: 5c0a009bb87d5dee80253bcccc3ba026
+      download_url: https://dataverse.nl/api/access/datafile/45514
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 61294fe08c7d78a6cb629dc8786deb4c
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 61294fe08c7d78a6cb629dc8786deb4c
+      download_url: https://dataverse.nl/api/access/datafile/45648
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: cdf3ae06fc8eb4745cf011b0817fbc32
+      byte_size: 1887
+      checksum:
+        algorithm: md5
+        digest: cdf3ae06fc8eb4745cf011b0817fbc32
+      download_url: https://dataverse.nl/api/access/datafile/46648
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a947de9eba6d81991eed24943542c2c7
+      byte_size: 1052
+      checksum:
+        algorithm: md5
+        digest: a947de9eba6d81991eed24943542c2c7
+      download_url: https://dataverse.nl/api/access/datafile/46410
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 249dd14e1e023cf98361813e8fe2c8ce
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 249dd14e1e023cf98361813e8fe2c8ce
+      download_url: https://dataverse.nl/api/access/datafile/45682
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 3bf5e0d06f4c0b44684708016ead2384
+      byte_size: 1052
+      checksum:
+        algorithm: md5
+        digest: 3bf5e0d06f4c0b44684708016ead2384
+      download_url: https://dataverse.nl/api/access/datafile/45957
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1545d6a2710463db6f31a9b18522b4f2
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 1545d6a2710463db6f31a9b18522b4f2
+      download_url: https://dataverse.nl/api/access/datafile/45196
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: dde2c167088d531a025f0a0e94388f5a
+      byte_size: 1052
+      checksum:
+        algorithm: md5
+        digest: dde2c167088d531a025f0a0e94388f5a
+      download_url: https://dataverse.nl/api/access/datafile/45772
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5a8bb9ec0d6adb579068cab4e90878c2
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 5a8bb9ec0d6adb579068cab4e90878c2
+      download_url: https://dataverse.nl/api/access/datafile/45129
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 16fb8a49a30a04a40eb1d884275bff57
+      byte_size: 180
+      checksum:
+        algorithm: md5
+        digest: 16fb8a49a30a04a40eb1d884275bff57
+      download_url: https://dataverse.nl/api/access/datafile/46588
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 33dc5896a50bc63493bab3f0743b3465
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 33dc5896a50bc63493bab3f0743b3465
+      download_url: https://dataverse.nl/api/access/datafile/45620
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: fd5ee5ea81e0249b03683f0d656d4c70
+      byte_size: 495292
+      checksum:
+        algorithm: md5
+        digest: fd5ee5ea81e0249b03683f0d656d4c70
+      download_url: https://dataverse.nl/api/access/datafile/45121
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ad740656f44d82f4bd7b9cd85cfa75b6
+      byte_size: 142
+      checksum:
+        algorithm: md5
+        digest: ad740656f44d82f4bd7b9cd85cfa75b6
+      download_url: https://dataverse.nl/api/access/datafile/45771
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e0560ed1d249cadf942ed068312f4074
+      byte_size: 491529
+      checksum:
+        algorithm: md5
+        digest: e0560ed1d249cadf942ed068312f4074
+      download_url: https://dataverse.nl/api/access/datafile/45718
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 87b01272f0d3aec042a70c89cb64c610
+      byte_size: 1040
+      checksum:
+        algorithm: md5
+        digest: 87b01272f0d3aec042a70c89cb64c610
+      download_url: https://dataverse.nl/api/access/datafile/46349
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 70c2c565c57410becebcb81c2743b366
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 70c2c565c57410becebcb81c2743b366
+      download_url: https://dataverse.nl/api/access/datafile/45483
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d2ad0551f289c82c784c0311cbda5868
+      byte_size: 1040
+      checksum:
+        algorithm: md5
+        digest: d2ad0551f289c82c784c0311cbda5868
+      download_url: https://dataverse.nl/api/access/datafile/45429
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 0a985477a760a6866461a8503d29841f
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 0a985477a760a6866461a8503d29841f
+      download_url: https://dataverse.nl/api/access/datafile/45395
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5d7912fb3c00c49ab445f37d023fabde
+      byte_size: 1040
+      checksum:
+        algorithm: md5
+        digest: 5d7912fb3c00c49ab445f37d023fabde
+      download_url: https://dataverse.nl/api/access/datafile/45733
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8d8f176db5374b8f5312c07b3868f190
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 8d8f176db5374b8f5312c07b3868f190
+      download_url: https://dataverse.nl/api/access/datafile/45466
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 10274748238e4edb1cacbc5ff8c4efb4
+      byte_size: 167
+      checksum:
+        algorithm: md5
+        digest: 10274748238e4edb1cacbc5ff8c4efb4
+      download_url: https://dataverse.nl/api/access/datafile/46581
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6deb98259db82a9bb337c44e78e221fe
+      byte_size: 1046
+      checksum:
+        algorithm: md5
+        digest: 6deb98259db82a9bb337c44e78e221fe
+      download_url: https://dataverse.nl/api/access/datafile/46463
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 9206830373a50d76fa9be72699a45be2
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 9206830373a50d76fa9be72699a45be2
+      download_url: https://dataverse.nl/api/access/datafile/45985
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1e119f9dea2d0f2266fdba2f09099eba
+      byte_size: 1046
+      checksum:
+        algorithm: md5
+        digest: 1e119f9dea2d0f2266fdba2f09099eba
+      download_url: https://dataverse.nl/api/access/datafile/46334
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 3b8d8099ff221a24e6f8c2c6e4b5570c
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 3b8d8099ff221a24e6f8c2c6e4b5570c
+      download_url: https://dataverse.nl/api/access/datafile/45532
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ca1f88e3755c369289b2c59316feabd1
+      byte_size: 1046
+      checksum:
+        algorithm: md5
+        digest: ca1f88e3755c369289b2c59316feabd1
+      download_url: https://dataverse.nl/api/access/datafile/45545
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 54ab340987d511300097fd979ba2500a
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 54ab340987d511300097fd979ba2500a
+      download_url: https://dataverse.nl/api/access/datafile/45934
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: aed4fce2a1c6cef0f89684bbf389f48a
+      byte_size: 179
+      checksum:
+        algorithm: md5
+        digest: aed4fce2a1c6cef0f89684bbf389f48a
+      download_url: https://dataverse.nl/api/access/datafile/46600
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ed88005c127d5f5aef4342a0dee22e4a
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: ed88005c127d5f5aef4342a0dee22e4a
+      download_url: https://dataverse.nl/api/access/datafile/46468
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 803e662ede5ba87711a0e764a4dc5e00
+      byte_size: 476319
+      checksum:
+        algorithm: md5
+        digest: 803e662ede5ba87711a0e764a4dc5e00
+      download_url: https://dataverse.nl/api/access/datafile/45108
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: bcd7d4cca00199ced81ffacc4c34ec31
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: bcd7d4cca00199ced81ffacc4c34ec31
+      download_url: https://dataverse.nl/api/access/datafile/45489
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 50fbda51cbb53ef16f3fb3597d76d674
+      byte_size: 476107
+      checksum:
+        algorithm: md5
+        digest: 50fbda51cbb53ef16f3fb3597d76d674
+      download_url: https://dataverse.nl/api/access/datafile/46465
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 0e9ab4d23523465646ff1a1fff65dc25
+      byte_size: 1030
+      checksum:
+        algorithm: md5
+        digest: 0e9ab4d23523465646ff1a1fff65dc25
+      download_url: https://dataverse.nl/api/access/datafile/46403
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 7b7d78156f700cae33926db5aa2f0d04
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 7b7d78156f700cae33926db5aa2f0d04
+      download_url: https://dataverse.nl/api/access/datafile/46414
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 7e85df7221171f6b2372643486c02bcb
+      byte_size: 1030
+      checksum:
+        algorithm: md5
+        digest: 7e85df7221171f6b2372643486c02bcb
+      download_url: https://dataverse.nl/api/access/datafile/45541
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 122692ec73aa0497ec013677ce2cb7e0
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 122692ec73aa0497ec013677ce2cb7e0
+      download_url: https://dataverse.nl/api/access/datafile/45377
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 43e86c28283bc8009c9d97276c233295
+      byte_size: 1030
+      checksum:
+        algorithm: md5
+        digest: 43e86c28283bc8009c9d97276c233295
+      download_url: https://dataverse.nl/api/access/datafile/45564
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d91741896d318dc2ed2b04cb0d9278c5
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: d91741896d318dc2ed2b04cb0d9278c5
+      download_url: https://dataverse.nl/api/access/datafile/46280
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 51211fa4e8939015647398b0c8c7e679
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 51211fa4e8939015647398b0c8c7e679
+      download_url: https://dataverse.nl/api/access/datafile/45408
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e68ffa789f92076c93d66148afd5cd89
+      byte_size: 462755
+      checksum:
+        algorithm: md5
+        digest: e68ffa789f92076c93d66148afd5cd89
+      download_url: https://dataverse.nl/api/access/datafile/45321
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 956ae391decb81c3c0b4696c2f95ac4b
+      byte_size: 1031
+      checksum:
+        algorithm: md5
+        digest: 956ae391decb81c3c0b4696c2f95ac4b
+      download_url: https://dataverse.nl/api/access/datafile/45596
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 747a22e06891ce5b95226b442fead6f6
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 747a22e06891ce5b95226b442fead6f6
+      download_url: https://dataverse.nl/api/access/datafile/46211
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 04d3584fb830f7a8ef784728c17e630e
+      byte_size: 1031
+      checksum:
+        algorithm: md5
+        digest: 04d3584fb830f7a8ef784728c17e630e
+      download_url: https://dataverse.nl/api/access/datafile/45133
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1597ff009b5f28a228d4dfd9ebc0e93e
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 1597ff009b5f28a228d4dfd9ebc0e93e
+      download_url: https://dataverse.nl/api/access/datafile/45715
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 7c4457b85550d91fae95d072a4cc570b
+      byte_size: 1031
+      checksum:
+        algorithm: md5
+        digest: 7c4457b85550d91fae95d072a4cc570b
+      download_url: https://dataverse.nl/api/access/datafile/45131
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 62d1d1ee187bcf3bb58bf391bf188b32
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 62d1d1ee187bcf3bb58bf391bf188b32
+      download_url: https://dataverse.nl/api/access/datafile/46137
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a652f7b56ad758609c5310ef0fab2937
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: a652f7b56ad758609c5310ef0fab2937
+      download_url: https://dataverse.nl/api/access/datafile/46122
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4cf99739f118bfd9a0997fe0ae604bcc
+      byte_size: 476195
+      checksum:
+        algorithm: md5
+        digest: 4cf99739f118bfd9a0997fe0ae604bcc
+      download_url: https://dataverse.nl/api/access/datafile/46286
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: eb385669721030b98836830b7000b0b5
+      byte_size: 20736352
+      checksum:
+        algorithm: md5
+        digest: eb385669721030b98836830b7000b0b5
+      download_url: https://dataverse.nl/api/access/datafile/45544
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-031/
+      qualified_part:
+        - relation: sub-031/anat/
+          name: anat
+        - relation: sub-031/func/
+          name: func
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-031/anat/
+      qualified_part:
+        - relation: eb385669721030b98836830b7000b0b5
+          name: sub-031_T1w.nii
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 42a0650f24e5e4d1ceef8d63789c07e0
+      byte_size: 1037
+      checksum:
+        algorithm: md5
+        digest: 42a0650f24e5e4d1ceef8d63789c07e0
+      download_url: https://dataverse.nl/api/access/datafile/45851
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-031/func/
+      qualified_part:
+        - relation: 42a0650f24e5e4d1ceef8d63789c07e0
+          name: sub-031_task-emotionProcessing_echo-1_bold.json
+        - relation: a2d2a978cab262ecef9ec66c647675ab
+          name: sub-031_task-emotionProcessing_echo-1_bold.nii
+        - relation: 4e1fca6683a7845b0eabcf07a9a7fc73
+          name: sub-031_task-emotionProcessing_echo-2_bold.json
+        - relation: 0fec398f1ec3542a99bf6970f7926670
+          name: sub-031_task-emotionProcessing_echo-2_bold.nii
+        - relation: 2fae64eda1ad8304bc639b6399a6ac21
+          name: sub-031_task-emotionProcessing_echo-3_bold.json
+        - relation: edd04104a9525374da16af5ac8444a6e
+          name: sub-031_task-emotionProcessing_echo-3_bold.nii
+        - relation: 5277d970321107e4ff62110a5efa36b2
+          name: sub-031_task-emotionProcessing_events.tsv.gz
+        - relation: 8217cc3d23c0c41e5e906b5425eef056
+          name: sub-031_task-emotionProcessingImagined_echo-1_bold.json
+        - relation: ec54f11a2ea08dcb739e1882ed99ff43
+          name: sub-031_task-emotionProcessingImagined_echo-1_bold.nii
+        - relation: 08a4ef57345695af6df33685c7d16c1f
+          name: sub-031_task-emotionProcessingImagined_echo-2_bold.json
+        - relation: 6b3e0bc231406bf13779757fd84ea449
+          name: sub-031_task-emotionProcessingImagined_echo-2_bold.nii
+        - relation: d12cf12c33775533eddb629c61308042
+          name: sub-031_task-emotionProcessingImagined_echo-3_bold.json
+        - relation: b886908aeaa472357d3c9b59bcf37a34
+          name: sub-031_task-emotionProcessingImagined_echo-3_bold.nii
+        - relation: 880d5e26a7c1025b0f921cf8c4ee76d2
+          name: sub-031_task-emotionProcessingImagined_events.tsv.gz
+        - relation: 99890ebb90e3ff583aaae8a7c96dd4c6
+          name: sub-031_task-emotionProcessingImagined_physio.json
+        - relation: 80331e9333eae550dbfac06eecaff7f7
+          name: sub-031_task-emotionProcessingImagined_physio.tsv.gz
+        - relation: a9ec1300d617c185be53ecc4378dd2a9
+          name: sub-031_task-emotionProcessing_physio.json
+        - relation: b76ec0da0d71f3fcc24208db6c777034
+          name: sub-031_task-emotionProcessing_physio.tsv.gz
+        - relation: 3719f2d5fb9e27010773993f60836e39
+          name: sub-031_task-fingerTapping_echo-1_bold.json
+        - relation: 16236c6dd29c2d773c5fe63d9b5733fa
+          name: sub-031_task-fingerTapping_echo-1_bold.nii
+        - relation: 0db5e7ae1cb6627feeb54be3ba822b84
+          name: sub-031_task-fingerTapping_echo-2_bold.json
+        - relation: bd54aedb7810b5b36460e00d483aedbe
+          name: sub-031_task-fingerTapping_echo-2_bold.nii
+        - relation: d4c69055b292ca4302ca0f04c7169c8b
+          name: sub-031_task-fingerTapping_echo-3_bold.json
+        - relation: e72425e7c2aee7afe5d96859729f9fb7
+          name: sub-031_task-fingerTapping_echo-3_bold.nii
+        - relation: fc88d5449bdfef5f0eb7a528f33b27bb
+          name: sub-031_task-fingerTapping_events.tsv.gz
+        - relation: 5e7da551bf765343ced4a55abc97db70
+          name: sub-031_task-fingerTappingImagined_echo-1_bold.json
+        - relation: ee7c5e607a7a996daf5935a1234fdb37
+          name: sub-031_task-fingerTappingImagined_echo-1_bold.nii
+        - relation: 17ac41ef430199c10cae34b9edfca197
+          name: sub-031_task-fingerTappingImagined_echo-2_bold.json
+        - relation: a501d0464c22f726e6f5f1faad45ed5d
+          name: sub-031_task-fingerTappingImagined_echo-2_bold.nii
+        - relation: 4cb2a766010ebf0ca6721331b9529591
+          name: sub-031_task-fingerTappingImagined_echo-3_bold.json
+        - relation: 5df5194d728d639ebd1029b09f1f0411
+          name: sub-031_task-fingerTappingImagined_echo-3_bold.nii
+        - relation: 6691789fd6206ed061aa23750b11b927
+          name: sub-031_task-fingerTappingImagined_events.tsv.gz
+        - relation: c623115320f634efcaefb2b0a5d75288
+          name: sub-031_task-fingerTappingImagined_physio.json
+        - relation: 4a16ec80d015060631add147e0a6fd74
+          name: sub-031_task-fingerTappingImagined_physio.tsv.gz
+        - relation: 31b4170baec18b2be5621e9f2d3bf577
+          name: sub-031_task-fingerTapping_physio.json
+        - relation: 66a719fb58313de8f23285c9e364d41b
+          name: sub-031_task-fingerTapping_physio.tsv.gz
+        - relation: 881dda2fa595fb1e83732f6baa916c6d
+          name: sub-031_task-rest_run-1_echo-1_bold.json
+        - relation: 586bfe19d96be1d7ffb8235acee74d5c
+          name: sub-031_task-rest_run-1_echo-1_bold.nii
+        - relation: fa4292ec53aa27a9950dd945ad649149
+          name: sub-031_task-rest_run-1_echo-2_bold.json
+        - relation: afba70a659537be0515ef3c082820c98
+          name: sub-031_task-rest_run-1_echo-2_bold.nii
+        - relation: c284b2a35f671ff7526c69854c2bb564
+          name: sub-031_task-rest_run-1_echo-3_bold.json
+        - relation: 3f3c28f7447a7cd0f183073bbe401b13
+          name: sub-031_task-rest_run-1_echo-3_bold.nii
+        - relation: b676a72f00b1dc65fc19563863766991
+          name: sub-031_task-rest_run-1_physio.json
+        - relation: e50bd35a460c3654ea0d49fe55028b06
+          name: sub-031_task-rest_run-1_physio.tsv.gz
+        - relation: bc778928ec86b0b101244f24aaa164bd
+          name: sub-031_task-rest_run-2_echo-1_bold.json
+        - relation: 1d1746b3ff6e6a7a056c7649e7a440a7
+          name: sub-031_task-rest_run-2_echo-1_bold.nii
+        - relation: 1ea98acf6dc9275f88d7f22b4c723adc
+          name: sub-031_task-rest_run-2_echo-2_bold.json
+        - relation: 706ff57f1edd078131e4ce97ad5bb0cd
+          name: sub-031_task-rest_run-2_echo-2_bold.nii
+        - relation: 5d4b834cc7ba0ac83167972984bed1f6
+          name: sub-031_task-rest_run-2_echo-3_bold.json
+        - relation: bea921c5cb404c38ee939c51b8c586a8
+          name: sub-031_task-rest_run-2_echo-3_bold.nii
+        - relation: a5d69e35f3340276d6be92b975f206d9
+          name: sub-031_task-rest_run-2_physio.json
+        - relation: 184f7866445f619c0c067be193c1e215
+          name: sub-031_task-rest_run-2_physio.tsv.gz
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a2d2a978cab262ecef9ec66c647675ab
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: a2d2a978cab262ecef9ec66c647675ab
+      download_url: https://dataverse.nl/api/access/datafile/46256
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4e1fca6683a7845b0eabcf07a9a7fc73
+      byte_size: 1037
+      checksum:
+        algorithm: md5
+        digest: 4e1fca6683a7845b0eabcf07a9a7fc73
+      download_url: https://dataverse.nl/api/access/datafile/45639
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 0fec398f1ec3542a99bf6970f7926670
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 0fec398f1ec3542a99bf6970f7926670
+      download_url: https://dataverse.nl/api/access/datafile/45812
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2fae64eda1ad8304bc639b6399a6ac21
+      byte_size: 1037
+      checksum:
+        algorithm: md5
+        digest: 2fae64eda1ad8304bc639b6399a6ac21
+      download_url: https://dataverse.nl/api/access/datafile/46538
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: edd04104a9525374da16af5ac8444a6e
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: edd04104a9525374da16af5ac8444a6e
+      download_url: https://dataverse.nl/api/access/datafile/45486
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5277d970321107e4ff62110a5efa36b2
+      byte_size: 1854
+      checksum:
+        algorithm: md5
+        digest: 5277d970321107e4ff62110a5efa36b2
+      download_url: https://dataverse.nl/api/access/datafile/46628
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8217cc3d23c0c41e5e906b5425eef056
+      byte_size: 1045
+      checksum:
+        algorithm: md5
+        digest: 8217cc3d23c0c41e5e906b5425eef056
+      download_url: https://dataverse.nl/api/access/datafile/45355
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ec54f11a2ea08dcb739e1882ed99ff43
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: ec54f11a2ea08dcb739e1882ed99ff43
+      download_url: https://dataverse.nl/api/access/datafile/46380
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 08a4ef57345695af6df33685c7d16c1f
+      byte_size: 1045
+      checksum:
+        algorithm: md5
+        digest: 08a4ef57345695af6df33685c7d16c1f
+      download_url: https://dataverse.nl/api/access/datafile/45918
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6b3e0bc231406bf13779757fd84ea449
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 6b3e0bc231406bf13779757fd84ea449
+      download_url: https://dataverse.nl/api/access/datafile/45373
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d12cf12c33775533eddb629c61308042
+      byte_size: 1045
+      checksum:
+        algorithm: md5
+        digest: d12cf12c33775533eddb629c61308042
+      download_url: https://dataverse.nl/api/access/datafile/46363
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b886908aeaa472357d3c9b59bcf37a34
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: b886908aeaa472357d3c9b59bcf37a34
+      download_url: https://dataverse.nl/api/access/datafile/45194
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 880d5e26a7c1025b0f921cf8c4ee76d2
+      byte_size: 178
+      checksum:
+        algorithm: md5
+        digest: 880d5e26a7c1025b0f921cf8c4ee76d2
+      download_url: https://dataverse.nl/api/access/datafile/46614
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 99890ebb90e3ff583aaae8a7c96dd4c6
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 99890ebb90e3ff583aaae8a7c96dd4c6
+      download_url: https://dataverse.nl/api/access/datafile/46092
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 80331e9333eae550dbfac06eecaff7f7
+      byte_size: 474191
+      checksum:
+        algorithm: md5
+        digest: 80331e9333eae550dbfac06eecaff7f7
+      download_url: https://dataverse.nl/api/access/datafile/45397
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a9ec1300d617c185be53ecc4378dd2a9
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: a9ec1300d617c185be53ecc4378dd2a9
+      download_url: https://dataverse.nl/api/access/datafile/45831
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b76ec0da0d71f3fcc24208db6c777034
+      byte_size: 486789
+      checksum:
+        algorithm: md5
+        digest: b76ec0da0d71f3fcc24208db6c777034
+      download_url: https://dataverse.nl/api/access/datafile/45874
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 3719f2d5fb9e27010773993f60836e39
+      byte_size: 1033
+      checksum:
+        algorithm: md5
+        digest: 3719f2d5fb9e27010773993f60836e39
+      download_url: https://dataverse.nl/api/access/datafile/46449
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 16236c6dd29c2d773c5fe63d9b5733fa
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 16236c6dd29c2d773c5fe63d9b5733fa
+      download_url: https://dataverse.nl/api/access/datafile/46236
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 0db5e7ae1cb6627feeb54be3ba822b84
+      byte_size: 1033
+      checksum:
+        algorithm: md5
+        digest: 0db5e7ae1cb6627feeb54be3ba822b84
+      download_url: https://dataverse.nl/api/access/datafile/45259
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: bd54aedb7810b5b36460e00d483aedbe
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: bd54aedb7810b5b36460e00d483aedbe
+      download_url: https://dataverse.nl/api/access/datafile/45452
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d4c69055b292ca4302ca0f04c7169c8b
+      byte_size: 1033
+      checksum:
+        algorithm: md5
+        digest: d4c69055b292ca4302ca0f04c7169c8b
+      download_url: https://dataverse.nl/api/access/datafile/45908
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e72425e7c2aee7afe5d96859729f9fb7
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: e72425e7c2aee7afe5d96859729f9fb7
+      download_url: https://dataverse.nl/api/access/datafile/45721
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: fc88d5449bdfef5f0eb7a528f33b27bb
+      byte_size: 167
+      checksum:
+        algorithm: md5
+        digest: fc88d5449bdfef5f0eb7a528f33b27bb
+      download_url: https://dataverse.nl/api/access/datafile/46618
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5e7da551bf765343ced4a55abc97db70
+      byte_size: 1041
+      checksum:
+        algorithm: md5
+        digest: 5e7da551bf765343ced4a55abc97db70
+      download_url: https://dataverse.nl/api/access/datafile/45506
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ee7c5e607a7a996daf5935a1234fdb37
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: ee7c5e607a7a996daf5935a1234fdb37
+      download_url: https://dataverse.nl/api/access/datafile/45279
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 17ac41ef430199c10cae34b9edfca197
+      byte_size: 1041
+      checksum:
+        algorithm: md5
+        digest: 17ac41ef430199c10cae34b9edfca197
+      download_url: https://dataverse.nl/api/access/datafile/46103
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a501d0464c22f726e6f5f1faad45ed5d
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: a501d0464c22f726e6f5f1faad45ed5d
+      download_url: https://dataverse.nl/api/access/datafile/45542
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4cb2a766010ebf0ca6721331b9529591
+      byte_size: 1041
+      checksum:
+        algorithm: md5
+        digest: 4cb2a766010ebf0ca6721331b9529591
+      download_url: https://dataverse.nl/api/access/datafile/45130
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5df5194d728d639ebd1029b09f1f0411
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 5df5194d728d639ebd1029b09f1f0411
+      download_url: https://dataverse.nl/api/access/datafile/45152
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6691789fd6206ed061aa23750b11b927
+      byte_size: 179
+      checksum:
+        algorithm: md5
+        digest: 6691789fd6206ed061aa23750b11b927
+      download_url: https://dataverse.nl/api/access/datafile/46598
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c623115320f634efcaefb2b0a5d75288
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: c623115320f634efcaefb2b0a5d75288
+      download_url: https://dataverse.nl/api/access/datafile/45821
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4a16ec80d015060631add147e0a6fd74
+      byte_size: 468033
+      checksum:
+        algorithm: md5
+        digest: 4a16ec80d015060631add147e0a6fd74
+      download_url: https://dataverse.nl/api/access/datafile/46024
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 31b4170baec18b2be5621e9f2d3bf577
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 31b4170baec18b2be5621e9f2d3bf577
+      download_url: https://dataverse.nl/api/access/datafile/45770
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 66a719fb58313de8f23285c9e364d41b
+      byte_size: 499366
+      checksum:
+        algorithm: md5
+        digest: 66a719fb58313de8f23285c9e364d41b
+      download_url: https://dataverse.nl/api/access/datafile/45176
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 881dda2fa595fb1e83732f6baa916c6d
+      byte_size: 1024
+      checksum:
+        algorithm: md5
+        digest: 881dda2fa595fb1e83732f6baa916c6d
+      download_url: https://dataverse.nl/api/access/datafile/45871
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 586bfe19d96be1d7ffb8235acee74d5c
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 586bfe19d96be1d7ffb8235acee74d5c
+      download_url: https://dataverse.nl/api/access/datafile/45833
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: fa4292ec53aa27a9950dd945ad649149
+      byte_size: 1024
+      checksum:
+        algorithm: md5
+        digest: fa4292ec53aa27a9950dd945ad649149
+      download_url: https://dataverse.nl/api/access/datafile/45328
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: afba70a659537be0515ef3c082820c98
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: afba70a659537be0515ef3c082820c98
+      download_url: https://dataverse.nl/api/access/datafile/45178
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c284b2a35f671ff7526c69854c2bb564
+      byte_size: 1024
+      checksum:
+        algorithm: md5
+        digest: c284b2a35f671ff7526c69854c2bb564
+      download_url: https://dataverse.nl/api/access/datafile/46433
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 3f3c28f7447a7cd0f183073bbe401b13
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 3f3c28f7447a7cd0f183073bbe401b13
+      download_url: https://dataverse.nl/api/access/datafile/45751
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b676a72f00b1dc65fc19563863766991
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: b676a72f00b1dc65fc19563863766991
+      download_url: https://dataverse.nl/api/access/datafile/45806
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: e50bd35a460c3654ea0d49fe55028b06
+      byte_size: 466931
+      checksum:
+        algorithm: md5
+        digest: e50bd35a460c3654ea0d49fe55028b06
+      download_url: https://dataverse.nl/api/access/datafile/45912
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: bc778928ec86b0b101244f24aaa164bd
+      byte_size: 1024
+      checksum:
+        algorithm: md5
+        digest: bc778928ec86b0b101244f24aaa164bd
+      download_url: https://dataverse.nl/api/access/datafile/45635
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1d1746b3ff6e6a7a056c7649e7a440a7
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 1d1746b3ff6e6a7a056c7649e7a440a7
+      download_url: https://dataverse.nl/api/access/datafile/46364
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1ea98acf6dc9275f88d7f22b4c723adc
+      byte_size: 1024
+      checksum:
+        algorithm: md5
+        digest: 1ea98acf6dc9275f88d7f22b4c723adc
+      download_url: https://dataverse.nl/api/access/datafile/46291
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 706ff57f1edd078131e4ce97ad5bb0cd
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 706ff57f1edd078131e4ce97ad5bb0cd
+      download_url: https://dataverse.nl/api/access/datafile/45144
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5d4b834cc7ba0ac83167972984bed1f6
+      byte_size: 1024
+      checksum:
+        algorithm: md5
+        digest: 5d4b834cc7ba0ac83167972984bed1f6
+      download_url: https://dataverse.nl/api/access/datafile/45998
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: bea921c5cb404c38ee939c51b8c586a8
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: bea921c5cb404c38ee939c51b8c586a8
+      download_url: https://dataverse.nl/api/access/datafile/45186
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a5d69e35f3340276d6be92b975f206d9
+      byte_size: 142
+      checksum:
+        algorithm: md5
+        digest: a5d69e35f3340276d6be92b975f206d9
+      download_url: https://dataverse.nl/api/access/datafile/46319
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 184f7866445f619c0c067be193c1e215
+      byte_size: 464210
+      checksum:
+        algorithm: md5
+        digest: 184f7866445f619c0c067be193c1e215
+      download_url: https://dataverse.nl/api/access/datafile/46204
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 48e60100ea298d4d4c8c8d3cbfd04b0e
+      byte_size: 20736352
+      checksum:
+        algorithm: md5
+        digest: 48e60100ea298d4d4c8c8d3cbfd04b0e
+      download_url: https://dataverse.nl/api/access/datafile/46200
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-032/
+      qualified_part:
+        - relation: sub-032/anat/
+          name: anat
+        - relation: sub-032/func/
+          name: func
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-032/anat/
+      qualified_part:
+        - relation: 48e60100ea298d4d4c8c8d3cbfd04b0e
+          name: sub-032_T1w.nii
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 06416007e86d197a6940d678e8136bca
+      byte_size: 1041
+      checksum:
+        algorithm: md5
+        digest: 06416007e86d197a6940d678e8136bca
+      download_url: https://dataverse.nl/api/access/datafile/45609
+    - meta_type: dlco:FileContainerObject
+      meta_code: sub-032/func/
+      qualified_part:
+        - relation: 06416007e86d197a6940d678e8136bca
+          name: sub-032_task-emotionProcessing_echo-1_bold.json
+        - relation: 1b89791e8c1aee44164213034f192b63
+          name: sub-032_task-emotionProcessing_echo-1_bold.nii
+        - relation: 2b3b3996277ade762410715cfd47431a
+          name: sub-032_task-emotionProcessing_echo-2_bold.json
+        - relation: 65365545508eabb82cc566e36be4ac34
+          name: sub-032_task-emotionProcessing_echo-2_bold.nii
+        - relation: ed07bf52a32bd33053c0bb04e686972a
+          name: sub-032_task-emotionProcessing_echo-3_bold.json
+        - relation: b1e6f7903c2a3150438d9a23616504af
+          name: sub-032_task-emotionProcessing_echo-3_bold.nii
+        - relation: 8e174c8a66696c7906ba1dcf98d2cc68
+          name: sub-032_task-emotionProcessing_events.tsv.gz
+        - relation: 61c5e521e58b82e36d53844980c06b63
+          name: sub-032_task-emotionProcessingImagined_echo-1_bold.json
+        - relation: 1bf02155e4fcab9c3684175c291dcb3f
+          name: sub-032_task-emotionProcessingImagined_echo-1_bold.nii
+        - relation: 0eefb1536ee550ab938735426c2eef11
+          name: sub-032_task-emotionProcessingImagined_echo-2_bold.json
+        - relation: 4c609570fd448c9b71abec081fa6d7b4
+          name: sub-032_task-emotionProcessingImagined_echo-2_bold.nii
+        - relation: 02b818204856fea23ce0f54e4dc1dd19
+          name: sub-032_task-emotionProcessingImagined_echo-3_bold.json
+        - relation: 80eba72ec6b10e3cf388f9ca45f341f3
+          name: sub-032_task-emotionProcessingImagined_echo-3_bold.nii
+        - relation: ecf9cf82ebb51b7bf4b02c480273f2a4
+          name: sub-032_task-emotionProcessingImagined_events.tsv.gz
+        - relation: a608105dd96eab86ce9ec6496e59f96b
+          name: sub-032_task-emotionProcessingImagined_physio.json
+        - relation: fdf331a186d1c0bcf29afe86797af8aa
+          name: sub-032_task-emotionProcessingImagined_physio.tsv.gz
+        - relation: a980a7103affd6f65d96e06212a0a3b0
+          name: sub-032_task-emotionProcessing_physio.json
+        - relation: 679f51d4a7e2989403d6b807fad9e7d2
+          name: sub-032_task-emotionProcessing_physio.tsv.gz
+        - relation: ce389476e87c994f77aaa2158f41ea8d
+          name: sub-032_task-fingerTapping_echo-1_bold.json
+        - relation: aa3c6b2b266c7d0f9231892fb30c232c
+          name: sub-032_task-fingerTapping_echo-1_bold.nii
+        - relation: b49a4da3a7f7bd6888b4ff407e5833b2
+          name: sub-032_task-fingerTapping_echo-2_bold.json
+        - relation: 75bba51d82aee031e427861b16236775
+          name: sub-032_task-fingerTapping_echo-2_bold.nii
+        - relation: da255b4cbc9064e4d00bdd80bfef8e94
+          name: sub-032_task-fingerTapping_echo-3_bold.json
+        - relation: 04aabb3917920bbea046ca597b0c3614
+          name: sub-032_task-fingerTapping_echo-3_bold.nii
+        - relation: 01dd8f6f5e013c54c0627beb86752f57
+          name: sub-032_task-fingerTapping_events.tsv.gz
+        - relation: a3ecabae2ffc13e0a501f7f66763f221
+          name: sub-032_task-fingerTappingImagined_echo-1_bold.json
+        - relation: ee6dae06d74b9429018c5e223ba18e1b
+          name: sub-032_task-fingerTappingImagined_echo-1_bold.nii
+        - relation: feb865a25268a697bba12a00e056e9e8
+          name: sub-032_task-fingerTappingImagined_echo-2_bold.json
+        - relation: bf036104b3012772a84b6beef452198e
+          name: sub-032_task-fingerTappingImagined_echo-2_bold.nii
+        - relation: 5a6937a8c9385dd4b229505d0e0eb9b3
+          name: sub-032_task-fingerTappingImagined_echo-3_bold.json
+        - relation: 422b513db148567d68380c9cc0a07a96
+          name: sub-032_task-fingerTappingImagined_echo-3_bold.nii
+        - relation: 70c2dff6db9c2aa45696781343789c5e
+          name: sub-032_task-fingerTappingImagined_events.tsv.gz
+        - relation: ba316c86b3fd667eefdebfd6b430e537
+          name: sub-032_task-fingerTappingImagined_physio.json
+        - relation: 86bb10881e3538db6a45adf4d62f2de9
+          name: sub-032_task-fingerTappingImagined_physio.tsv.gz
+        - relation: 47c7b8a95b772ed4e9ab4579964acd98
+          name: sub-032_task-fingerTapping_physio.json
+        - relation: 60e6c6803435ca34b8285788e22f12b6
+          name: sub-032_task-fingerTapping_physio.tsv.gz
+        - relation: 19f46f4e86b559bcff24b380d5602814
+          name: sub-032_task-rest_run-1_echo-1_bold.json
+        - relation: f35d8a4022fa2399322f299689275089
+          name: sub-032_task-rest_run-1_echo-1_bold.nii
+        - relation: 7390ff359ffb6e5e7218be387777ddb5
+          name: sub-032_task-rest_run-1_echo-2_bold.json
+        - relation: af3cf6a31f6988965a963fa03adb82e4
+          name: sub-032_task-rest_run-1_echo-2_bold.nii
+        - relation: 9f4b1c3710f156c61b00783ef6e254fd
+          name: sub-032_task-rest_run-1_echo-3_bold.json
+        - relation: 94572c16591270cc44701ad2af98d235
+          name: sub-032_task-rest_run-1_echo-3_bold.nii
+        - relation: 601450400ed297074b76412ce41f391a
+          name: sub-032_task-rest_run-1_physio.json
+        - relation: a29a480738f5ed9341c3a8cb2c35b0ce
+          name: sub-032_task-rest_run-1_physio.tsv.gz
+        - relation: 634a31cb6dddc913d0b5b2f36b7d7f55
+          name: sub-032_task-rest_run-2_echo-1_bold.json
+        - relation: 00e335fb2c52c789ddbbd47fa8577494
+          name: sub-032_task-rest_run-2_echo-1_bold.nii
+        - relation: 961828cb3e667183d08bc8c50b44841e
+          name: sub-032_task-rest_run-2_echo-2_bold.json
+        - relation: 53fa854d499812d7cd2e0c4c0bce4268
+          name: sub-032_task-rest_run-2_echo-2_bold.nii
+        - relation: f78b6a8c5bfccaefccdb712c53398c85
+          name: sub-032_task-rest_run-2_echo-3_bold.json
+        - relation: 95d20042772759ef8f1eae8342912238
+          name: sub-032_task-rest_run-2_echo-3_bold.nii
+        - relation: c2bc90d9766475106f49a8e071e31794
+          name: sub-032_task-rest_run-2_physio.json
+        - relation: 6e52d0eed2038d116afc2504ea53551c
+          name: sub-032_task-rest_run-2_physio.tsv.gz
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1b89791e8c1aee44164213034f192b63
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 1b89791e8c1aee44164213034f192b63
+      download_url: https://dataverse.nl/api/access/datafile/46352
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 2b3b3996277ade762410715cfd47431a
+      byte_size: 1041
+      checksum:
+        algorithm: md5
+        digest: 2b3b3996277ade762410715cfd47431a
+      download_url: https://dataverse.nl/api/access/datafile/45817
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 65365545508eabb82cc566e36be4ac34
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 65365545508eabb82cc566e36be4ac34
+      download_url: https://dataverse.nl/api/access/datafile/46478
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ed07bf52a32bd33053c0bb04e686972a
+      byte_size: 1041
+      checksum:
+        algorithm: md5
+        digest: ed07bf52a32bd33053c0bb04e686972a
+      download_url: https://dataverse.nl/api/access/datafile/45529
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b1e6f7903c2a3150438d9a23616504af
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: b1e6f7903c2a3150438d9a23616504af
+      download_url: https://dataverse.nl/api/access/datafile/45522
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 8e174c8a66696c7906ba1dcf98d2cc68
+      byte_size: 1873
+      checksum:
+        algorithm: md5
+        digest: 8e174c8a66696c7906ba1dcf98d2cc68
+      download_url: https://dataverse.nl/api/access/datafile/46638
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 61c5e521e58b82e36d53844980c06b63
+      byte_size: 1049
+      checksum:
+        algorithm: md5
+        digest: 61c5e521e58b82e36d53844980c06b63
+      download_url: https://dataverse.nl/api/access/datafile/46238
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 1bf02155e4fcab9c3684175c291dcb3f
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 1bf02155e4fcab9c3684175c291dcb3f
+      download_url: https://dataverse.nl/api/access/datafile/45335
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 0eefb1536ee550ab938735426c2eef11
+      byte_size: 1049
+      checksum:
+        algorithm: md5
+        digest: 0eefb1536ee550ab938735426c2eef11
+      download_url: https://dataverse.nl/api/access/datafile/45203
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 4c609570fd448c9b71abec081fa6d7b4
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 4c609570fd448c9b71abec081fa6d7b4
+      download_url: https://dataverse.nl/api/access/datafile/46106
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 02b818204856fea23ce0f54e4dc1dd19
+      byte_size: 1049
+      checksum:
+        algorithm: md5
+        digest: 02b818204856fea23ce0f54e4dc1dd19
+      download_url: https://dataverse.nl/api/access/datafile/45223
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 80eba72ec6b10e3cf388f9ca45f341f3
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 80eba72ec6b10e3cf388f9ca45f341f3
+      download_url: https://dataverse.nl/api/access/datafile/45526
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ecf9cf82ebb51b7bf4b02c480273f2a4
+      byte_size: 178
+      checksum:
+        algorithm: md5
+        digest: ecf9cf82ebb51b7bf4b02c480273f2a4
+      download_url: https://dataverse.nl/api/access/datafile/46634
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a608105dd96eab86ce9ec6496e59f96b
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: a608105dd96eab86ce9ec6496e59f96b
+      download_url: https://dataverse.nl/api/access/datafile/46401
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: fdf331a186d1c0bcf29afe86797af8aa
+      byte_size: 466464
+      checksum:
+        algorithm: md5
+        digest: fdf331a186d1c0bcf29afe86797af8aa
+      download_url: https://dataverse.nl/api/access/datafile/45291
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a980a7103affd6f65d96e06212a0a3b0
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: a980a7103affd6f65d96e06212a0a3b0
+      download_url: https://dataverse.nl/api/access/datafile/45756
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 679f51d4a7e2989403d6b807fad9e7d2
+      byte_size: 493060
+      checksum:
+        algorithm: md5
+        digest: 679f51d4a7e2989403d6b807fad9e7d2
+      download_url: https://dataverse.nl/api/access/datafile/46248
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ce389476e87c994f77aaa2158f41ea8d
+      byte_size: 1037
+      checksum:
+        algorithm: md5
+        digest: ce389476e87c994f77aaa2158f41ea8d
+      download_url: https://dataverse.nl/api/access/datafile/46405
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: aa3c6b2b266c7d0f9231892fb30c232c
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: aa3c6b2b266c7d0f9231892fb30c232c
+      download_url: https://dataverse.nl/api/access/datafile/46318
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: b49a4da3a7f7bd6888b4ff407e5833b2
+      byte_size: 1037
+      checksum:
+        algorithm: md5
+        digest: b49a4da3a7f7bd6888b4ff407e5833b2
+      download_url: https://dataverse.nl/api/access/datafile/46446
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 75bba51d82aee031e427861b16236775
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 75bba51d82aee031e427861b16236775
+      download_url: https://dataverse.nl/api/access/datafile/45773
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: da255b4cbc9064e4d00bdd80bfef8e94
+      byte_size: 1037
+      checksum:
+        algorithm: md5
+        digest: da255b4cbc9064e4d00bdd80bfef8e94
+      download_url: https://dataverse.nl/api/access/datafile/45576
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 04aabb3917920bbea046ca597b0c3614
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 04aabb3917920bbea046ca597b0c3614
+      download_url: https://dataverse.nl/api/access/datafile/46273
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 01dd8f6f5e013c54c0627beb86752f57
+      byte_size: 167
+      checksum:
+        algorithm: md5
+        digest: 01dd8f6f5e013c54c0627beb86752f57
+      download_url: https://dataverse.nl/api/access/datafile/46605
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a3ecabae2ffc13e0a501f7f66763f221
+      byte_size: 1045
+      checksum:
+        algorithm: md5
+        digest: a3ecabae2ffc13e0a501f7f66763f221
+      download_url: https://dataverse.nl/api/access/datafile/45944
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ee6dae06d74b9429018c5e223ba18e1b
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: ee6dae06d74b9429018c5e223ba18e1b
+      download_url: https://dataverse.nl/api/access/datafile/45399
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: feb865a25268a697bba12a00e056e9e8
+      byte_size: 1045
+      checksum:
+        algorithm: md5
+        digest: feb865a25268a697bba12a00e056e9e8
+      download_url: https://dataverse.nl/api/access/datafile/46258
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: bf036104b3012772a84b6beef452198e
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: bf036104b3012772a84b6beef452198e
+      download_url: https://dataverse.nl/api/access/datafile/45458
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 5a6937a8c9385dd4b229505d0e0eb9b3
+      byte_size: 1045
+      checksum:
+        algorithm: md5
+        digest: 5a6937a8c9385dd4b229505d0e0eb9b3
+      download_url: https://dataverse.nl/api/access/datafile/46353
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 422b513db148567d68380c9cc0a07a96
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 422b513db148567d68380c9cc0a07a96
+      download_url: https://dataverse.nl/api/access/datafile/45401
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 70c2dff6db9c2aa45696781343789c5e
+      byte_size: 179
+      checksum:
+        algorithm: md5
+        digest: 70c2dff6db9c2aa45696781343789c5e
+      download_url: https://dataverse.nl/api/access/datafile/46610
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ba316c86b3fd667eefdebfd6b430e537
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: ba316c86b3fd667eefdebfd6b430e537
+      download_url: https://dataverse.nl/api/access/datafile/45630
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 86bb10881e3538db6a45adf4d62f2de9
+      byte_size: 467483
+      checksum:
+        algorithm: md5
+        digest: 86bb10881e3538db6a45adf4d62f2de9
+      download_url: https://dataverse.nl/api/access/datafile/45724
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 47c7b8a95b772ed4e9ab4579964acd98
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 47c7b8a95b772ed4e9ab4579964acd98
+      download_url: https://dataverse.nl/api/access/datafile/45464
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 60e6c6803435ca34b8285788e22f12b6
+      byte_size: 471716
+      checksum:
+        algorithm: md5
+        digest: 60e6c6803435ca34b8285788e22f12b6
+      download_url: https://dataverse.nl/api/access/datafile/46193
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 19f46f4e86b559bcff24b380d5602814
+      byte_size: 1028
+      checksum:
+        algorithm: md5
+        digest: 19f46f4e86b559bcff24b380d5602814
+      download_url: https://dataverse.nl/api/access/datafile/46520
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f35d8a4022fa2399322f299689275089
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: f35d8a4022fa2399322f299689275089
+      download_url: https://dataverse.nl/api/access/datafile/46065
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 7390ff359ffb6e5e7218be387777ddb5
+      byte_size: 1028
+      checksum:
+        algorithm: md5
+        digest: 7390ff359ffb6e5e7218be387777ddb5
+      download_url: https://dataverse.nl/api/access/datafile/46408
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: af3cf6a31f6988965a963fa03adb82e4
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: af3cf6a31f6988965a963fa03adb82e4
+      download_url: https://dataverse.nl/api/access/datafile/45652
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 9f4b1c3710f156c61b00783ef6e254fd
+      byte_size: 1028
+      checksum:
+        algorithm: md5
+        digest: 9f4b1c3710f156c61b00783ef6e254fd
+      download_url: https://dataverse.nl/api/access/datafile/45315
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 94572c16591270cc44701ad2af98d235
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 94572c16591270cc44701ad2af98d235
+      download_url: https://dataverse.nl/api/access/datafile/46171
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 601450400ed297074b76412ce41f391a
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: 601450400ed297074b76412ce41f391a
+      download_url: https://dataverse.nl/api/access/datafile/46240
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: a29a480738f5ed9341c3a8cb2c35b0ce
+      byte_size: 462207
+      checksum:
+        algorithm: md5
+        digest: a29a480738f5ed9341c3a8cb2c35b0ce
+      download_url: https://dataverse.nl/api/access/datafile/46529
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 634a31cb6dddc913d0b5b2f36b7d7f55
+      byte_size: 1028
+      checksum:
+        algorithm: md5
+        digest: 634a31cb6dddc913d0b5b2f36b7d7f55
+      download_url: https://dataverse.nl/api/access/datafile/46111
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 00e335fb2c52c789ddbbd47fa8577494
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 00e335fb2c52c789ddbbd47fa8577494
+      download_url: https://dataverse.nl/api/access/datafile/45606
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 961828cb3e667183d08bc8c50b44841e
+      byte_size: 1028
+      checksum:
+        algorithm: md5
+        digest: 961828cb3e667183d08bc8c50b44841e
+      download_url: https://dataverse.nl/api/access/datafile/46290
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 53fa854d499812d7cd2e0c4c0bce4268
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 53fa854d499812d7cd2e0c4c0bce4268
+      download_url: https://dataverse.nl/api/access/datafile/45917
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: f78b6a8c5bfccaefccdb712c53398c85
+      byte_size: 1028
+      checksum:
+        algorithm: md5
+        digest: f78b6a8c5bfccaefccdb712c53398c85
+      download_url: https://dataverse.nl/api/access/datafile/46369
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 95d20042772759ef8f1eae8342912238
+      byte_size: 58491232
+      checksum:
+        algorithm: md5
+        digest: 95d20042772759ef8f1eae8342912238
+      download_url: https://dataverse.nl/api/access/datafile/45217
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: c2bc90d9766475106f49a8e071e31794
+      byte_size: 143
+      checksum:
+        algorithm: md5
+        digest: c2bc90d9766475106f49a8e071e31794
+      download_url: https://dataverse.nl/api/access/datafile/46336
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 6e52d0eed2038d116afc2504ea53551c
+      byte_size: 456867
+      checksum:
+        algorithm: md5
+        digest: 6e52d0eed2038d116afc2504ea53551c
+      download_url: https://dataverse.nl/api/access/datafile/46434
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: eac027a2545fd2b8ee12e495d2ee6499
+      byte_size: 1893
+      checksum:
+        algorithm: md5
+        digest: eac027a2545fd2b8ee12e495d2ee6499
+      download_url: https://dataverse.nl/api/access/datafile/46665
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: d80166992bd6e82f2ccc13aea8537542
+      byte_size: 821
+      checksum:
+        algorithm: md5
+        digest: d80166992bd6e82f2ccc13aea8537542
+      download_url: https://dataverse.nl/api/access/datafile/46667
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: ab572625ab03f4175842af1c3d52370d
+      byte_size: 872
+      checksum:
+        algorithm: md5
+        digest: ab572625ab03f4175842af1c3d52370d
+      download_url: https://dataverse.nl/api/access/datafile/46666
+    - meta_type: dlco:DigitalDocumentObject
+      meta_code: 3b708d003000956e0562d0c8f39b1786
+      byte_size: 808
+      checksum:
+        algorithm: md5
+        digest: 3b708d003000956e0562d0c8f39b1786
+      download_url: https://dataverse.nl/api/access/datafile/46668
+  qualified_part:
+    - relation: 7d63a6dd379b3b81574e31240433e008
+      name: dataset_description.json
+    - relation: derivatives/
+      name: derivatives
+    - relation: 0a25e5c0225e9bd18c62a560df470980
+      name: participants.tsv
+    - relation: 1abb42c68887b4c075e710f0ae8ce855
+      name: README.md
+    - relation: sub-001/
+      name: sub-001
+    - relation: sub-002/
+      name: sub-002
+    - relation: sub-003/
+      name: sub-003
+    - relation: sub-004/
+      name: sub-004
+    - relation: sub-005/
+      name: sub-005
+    - relation: sub-006/
+      name: sub-006
+    - relation: sub-007/
+      name: sub-007
+    - relation: sub-010/
+      name: sub-010
+    - relation: sub-011/
+      name: sub-011
+    - relation: sub-012/
+      name: sub-012
+    - relation: sub-013/
+      name: sub-013
+    - relation: sub-015/
+      name: sub-015
+    - relation: sub-016/
+      name: sub-016
+    - relation: sub-017/
+      name: sub-017
+    - relation: sub-018/
+      name: sub-018
+    - relation: sub-019/
+      name: sub-019
+    - relation: sub-020/
+      name: sub-020
+    - relation: sub-021/
+      name: sub-021
+    - relation: sub-022/
+      name: sub-022
+    - relation: sub-023/
+      name: sub-023
+    - relation: sub-024/
+      name: sub-024
+    - relation: sub-025/
+      name: sub-025
+    - relation: sub-026/
+      name: sub-026
+    - relation: sub-027/
+      name: sub-027
+    - relation: sub-029/
+      name: sub-029
+    - relation: sub-030/
+      name: sub-030
+    - relation: sub-031/
+      name: sub-031
+    - relation: sub-032/
+      name: sub-032
+    - relation: eac027a2545fd2b8ee12e495d2ee6499
+      name: task-emotionProcessing_events.json
+    - relation: d80166992bd6e82f2ccc13aea8537542
+      name: task-emotionProcessingImagined_events.json
+    - relation: ab572625ab03f4175842af1c3d52370d
+      name: task-fingerTapping_events.json
+    - relation: 3b708d003000956e0562d0c8f39b1786
+      name: task-fingerTappingImagined_events.json


### PR DESCRIPTION
With this example data, exported dataverse metadata records were converted to be compliant with the dataset-version schema. The dataset described by the dataverse records can be viewed at https://doi.org/10.34894/R1TNL8. A custom script was developed to help with the conversion: https://github.com/jsheunis/datalad-concepts/blob/tools/tools/dataverse_to_datasetversion.py

The example files are quite big because the dataset contains many files.

One thing I am still unsure of is whether I should account for the fact that files will only be accessible by a user once access is granted based on signing a Data use agreement. The use of `qualified_access` seems like it might be appropriate, but I couldn't yet figure out the correct way to use it from examples and the existing ontology classes.