### PR TITLE
Enhance enough to capture the penguins example

### DIFF
--- a/src/examples/data-distribution/Distribution-basic.json
+++ b/src/examples/data-distribution/Distribution-basic.json
@@ -14,6 +14,6 @@
     }
   ],
   "license": "licenses:CC0-1.0",
-  "modified": "2024-03-21",
+  "date_modified": "2024-03-21",
   "@type": "Distribution"
 }

--- a/src/examples/data-distribution/Distribution-basic.yaml
+++ b/src/examples/data-distribution/Distribution-basic.yaml
@@ -7,7 +7,7 @@
 id: thisdsver:./some/name.ext
 byte_size: 123456789
 license: licenses:CC0-1.0
-modified: "2024-03-21"
+date_modified: "2024-03-21"
 name: name.ext
 #
 # Checksum information is inlined, because additional linkage

--- a/src/examples/data-distribution/Distribution-penguins.json
+++ b/src/examples/data-distribution/Distribution-penguins.json
@@ -1,0 +1,307 @@
+{
+  "id": "thisdsver:.",
+  "type": "dlco:Distribution",
+  "was_attributed_to": [
+    {
+      "id": "thisds:#ahorst",
+      "identifier": [
+        {
+          "notation": "0000-0002-6047-5564",
+          "schema_agency": "https://orcid.org"
+        }
+      ],
+      "name": "Allison Horst",
+      "same_as": [
+        "https://orcid.org/0000-0002-6047-5564"
+      ],
+      "type": "dlco:ResearchContributor",
+      "email": "ahorst@example.com",
+      "affiliation": "thisds:#UCSB"
+    },
+    {
+      "id": "thisds:#ahill",
+      "identifier": [
+        {
+          "notation": "0000-0002-8082-1890",
+          "schema_agency": "https://orcid.org"
+        }
+      ],
+      "name": "Allison Hill",
+      "type": "dlco:ResearchContributor",
+      "email": "ahill@example.com",
+      "affiliation": "thisds:#Rstudio"
+    },
+    {
+      "id": "thisds:#kgorman",
+      "identifier": [
+        {
+          "notation": "0000-0002-0258-9264",
+          "schema_agency": "https://orcid.org"
+        }
+      ],
+      "name": "Kirsten Gorman",
+      "type": "dlco:ResearchContributor",
+      "email": "kgorman@example.com",
+      "affiliation": "https://ror.org/01j7nq853"
+    },
+    {
+      "id": "thisds:#UCSB",
+      "name": "UC Santa Barbara: Santa Barbara, CA, US",
+      "type": "dlco:Organization"
+    },
+    {
+      "id": "thisds:#RStudio",
+      "name": "RStudio: Boston, MA, US",
+      "type": "dlco:Organization"
+    },
+    {
+      "id": "https://ror.org/01j7nq853",
+      "identifier": [
+        {
+          "notation": "01j7nq853",
+          "schema_agency": "https://ror.org"
+        }
+      ],
+      "name": "University of Alaska Fairbanks: Fairbanks, AK, US",
+      "type": "dlco:Organization"
+    },
+    {
+      "id": "https://ror.org/05nwjp114",
+      "identifier": [
+        {
+          "notation": "05nwjp114",
+          "schema_agency": "https://ror.org"
+        }
+      ],
+      "name": "NSF Office of Polar Programs",
+      "type": "dlco:Agent"
+    },
+    {
+      "id": "https://ror.org/021nxhr62",
+      "identifier": [
+        {
+          "notation": "021nxhr62",
+          "schema_agency": "https://ror.org"
+        }
+      ],
+      "name": "US National Science Foundation",
+      "same_as": [
+        "https://www.nsf.org"
+      ],
+      "type": "dlco:Agent"
+    }
+  ],
+  "has_part": [
+    {
+      "id": "thisdsver:./adelie.csv",
+      "type": "dlco:Distribution",
+      "byte_size": 23755,
+      "checksum": [
+        {
+          "algorithm": "md5",
+          "digest": "e7e2be6b203a221949f05e02fcefd853"
+        }
+      ],
+      "download_url": "https://portal.edirepository.org/nis/dataviewer?packageid=knb-lter-pal.219.3&entityid=002f3893385f710df69eeebe893144ff"
+    },
+    {
+      "id": "thisdsver:./gentoo.csv",
+      "type": "dlco:Distribution",
+      "byte_size": 11263,
+      "checksum": [
+        {
+          "algorithm": "md5",
+          "digest": "1549566fb97afa879dc9446edcf2015f"
+        }
+      ],
+      "download_url": "https://portal.edirepository.org/nis/dataviewer?packageid=knb-lter-pal.220.3&entityid=e03b43c924f226486f2f0ab6709d2381"
+    },
+    {
+      "id": "thisdsver:./chinstrap.csv",
+      "type": "dlco:Distribution",
+      "byte_size": 18872,
+      "checksum": [
+        {
+          "algorithm": "md5",
+          "digest": "e4b0710c69297031d63866ce8b888f25"
+        }
+      ],
+      "download_url": "https://portal.edirepository.org/nis/dataviewer?packageid=knb-lter-pal.221.2&entityid=fe853aa8f7a59aa84cdd3197619ef462"
+    }
+  ],
+  "is_distribution_of": "thisdsver:#",
+  "license": "licenses:CC0-1.0",
+  "relation": [
+    {
+      "id": "thisdsver:#",
+      "description": "The goal of palmerpenguins is to provide a great dataset for data exploration and visualization, as an alternative to iris. Data were collected and made available by Dr. Kristen Gorman and the Palmer Station, Antarctica LTER, a member of the Long Term Ecological Research Network.",
+      "identifier": [
+        {
+          "notation": "10.5281/zenodo.3960218",
+          "schema_agency": "https://doi.org"
+        }
+      ],
+      "name": "penguins",
+      "same_as": [
+        "https://doi.org/10.5281/zenodo.3960218"
+      ],
+      "title": "Palmer Penguins",
+      "type": "dlco:Resource",
+      "qualified_attribution": [
+        {
+          "had_role": [
+            "marcrel:aut",
+            "dpv:DataController"
+          ],
+          "agent": "thisds:#ahorst"
+        },
+        {
+          "had_role": [
+            "marcrel:aut"
+          ],
+          "agent": "thisds:#ahill"
+        },
+        {
+          "had_role": [
+            "marcrel:aut",
+            "marcrel:cre"
+          ],
+          "agent": "thisds:#kgorman"
+        },
+        {
+          "had_role": [
+            "marcrel:sht"
+          ],
+          "agent": "thisds:#UCSB"
+        },
+        {
+          "had_role": [
+            "marcrel:sht"
+          ],
+          "agent": "thisds:#RStudio"
+        },
+        {
+          "had_role": [
+            "marcrel:sht"
+          ],
+          "agent": "https://ror.org/01j7nq853"
+        }
+      ],
+      "date_modified": "2020-07-16",
+      "is_version_of": "thisds:#",
+      "keyword": [
+        "penguins",
+        "sea ice",
+        "foraging",
+        "ecological niches",
+        "islands",
+        "antarctica",
+        "animal sexual behavior",
+        "isotopes"
+      ],
+      "landing_page": "https://github.com/allisonhorst/palmerpenguins",
+      "qualified_relation": [
+        {
+          "had_role": [
+            "schema:funding"
+          ],
+          "entity": "thisds:#nsf0217282"
+        },
+        {
+          "had_role": [
+            "schema:funding"
+          ],
+          "entity": "thisds:#nsf0823101"
+        },
+        {
+          "had_role": [
+            "schema:funding"
+          ],
+          "entity": "thisds:#nsf0741351"
+        },
+        {
+          "had_role": [
+            "CiTO:citesAsAuthority",
+            "CiTO:isCitedAsDataSourceBy"
+          ],
+          "entity": "thisds:#gormanetal"
+        }
+      ],
+      "version": "0.1.0"
+    },
+    {
+      "id": "thisds:#nsf0217282",
+      "identifier": [
+        {
+          "notation": "0217282",
+          "schema_agency": "https://ror.org/021nxhr62"
+        }
+      ],
+      "name": "LTER: PALMER, ANTARCTICA LTER: Climate Change, Ecosystem Migration and Teleconnections in an Ice-Dominated Environment",
+      "type": "dlco:Grant",
+      "sponsor": "https://ror.org/05nwjp114",
+      "cites_as_authority": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=0217282"
+    },
+    {
+      "id": "thisds:#nsf0823101",
+      "identifier": [
+        {
+          "notation": "0823101",
+          "schema_agency": "https://ror.org/021nxhr62"
+        }
+      ],
+      "name": "Palmer, Antarctica Long Term Ecological Research Project",
+      "type": "dlco:Grant",
+      "sponsor": "https://ror.org/05nwjp114",
+      "cites_as_authority": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=0823101"
+    },
+    {
+      "id": "thisds:#nsf0741351",
+      "identifier": [
+        {
+          "notation": "0741351",
+          "schema_agency": "https://ror.org/021nxhr62"
+        }
+      ],
+      "name": "Collaborative Research: Possible Climate-induced Change in the Distribution of Pleuragramma Antarcticum on the Western Antarctic Peninsula Shelf",
+      "type": "dlco:Grant",
+      "sponsor": "https://ror.org/05nwjp114",
+      "cites_as_authority": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=0741351"
+    },
+    {
+      "id": "thisds:#gormanetal",
+      "identifier": [
+        {
+          "notation": "10.1371/journal.pone.0090081",
+          "schema_agency": "https://doi.org"
+        }
+      ],
+      "type": "dlco:Publication",
+      "qualified_attribution": [
+        {
+          "had_role": [
+            "marcrel:aut"
+          ],
+          "agent": "thisds:#kgorman"
+        }
+      ],
+      "citation": "'Gorman KB, Williams TD, Fraser WR (2014) Ecological Sexual Dimorphism and Environmental Variability within a Community of Antarctic Penguins (Genus Pygoscelis). PLoS ONE 9(3): e90081.'",
+      "date_published": "2014-03-05"
+    }
+  ],
+  "qualified_part": [
+    {
+      "name": "adelie.csv",
+      "entity": "thisdsver:./adelie.csv"
+    },
+    {
+      "name": "gentoo.csv",
+      "entity": "thisdsver:./gentoo.csv"
+    },
+    {
+      "name": "chinstrap.csv",
+      "entity": "thisdsver:./chinstrap.csv"
+    }
+  ],
+  "@type": "Distribution"
+}

--- a/src/examples/data-distribution/Distribution-penguins.yaml
+++ b/src/examples/data-distribution/Distribution-penguins.yaml
@@ -1,0 +1,204 @@
+# we identify the dataset distribution (incl. its parts) as the main data entity
+# of this dataset version. However, this is arbitrary. It could also be an
+# archive or directory in a larger distribution context.
+id: thisdsver:.
+license: licenses:CC0-1.0
+# we describe the full penguin dataset distribution here. However, this is an
+# arbitrary choice. We could also have a near-identical record that is focused
+# on a single file in the dataset -- while also contextual relationships
+has_part:
+  - id: thisdsver:./adelie.csv
+    byte_size: 23755
+    checksum:
+      - algorithm: md5
+        digest: e7e2be6b203a221949f05e02fcefd853
+    download_url: https://portal.edirepository.org/nis/dataviewer?packageid=knb-lter-pal.219.3&entityid=002f3893385f710df69eeebe893144ff
+  - id: thisdsver:./gentoo.csv
+    byte_size: 11263
+    checksum:
+      - algorithm: md5
+        digest: 1549566fb97afa879dc9446edcf2015f
+    download_url: https://portal.edirepository.org/nis/dataviewer?packageid=knb-lter-pal.220.3&entityid=e03b43c924f226486f2f0ab6709d2381
+  - id: thisdsver:./chinstrap.csv
+    byte_size: 18872
+    checksum:
+      - algorithm: md5
+        digest: e4b0710c69297031d63866ce8b888f25
+    download_url: https://portal.edirepository.org/nis/dataviewer?packageid=knb-lter-pal.221.2&entityid=fe853aa8f7a59aa84cdd3197619ef462
+qualified_part:
+  - name: adelie.csv
+    entity: thisdsver:./adelie.csv
+  - name: gentoo.csv
+    entity: thisdsver:./gentoo.csv
+  - name: chinstrap.csv
+    entity: thisdsver:./chinstrap.csv
+#
+# relation to contextual entities
+is_distribution_of: thisdsver:#
+relation:
+  - id: thisdsver:#
+    type: dlco:Resource
+    date_modified: "2020-07-16"
+    description: >-
+      The goal of palmerpenguins is to provide a great dataset for data
+      exploration and visualization, as an alternative to iris. Data were
+      collected and made available by Dr. Kristen Gorman and the Palmer
+      Station, Antarctica LTER, a member of the Long Term Ecological
+      Research Network.
+    is_version_of: thisds:#
+    keyword:
+      - penguins
+      - sea ice
+      - foraging
+      - ecological niches
+      - islands
+      - antarctica
+      - animal sexual behavior
+      - isotopes
+    landing_page: https://github.com/allisonhorst/palmerpenguins
+    name: penguins
+    identifier:
+      - notation: 10.5281/zenodo.3960218
+        schema_agency: https://doi.org
+    qualified_attribution:
+      - agent: thisds:#ahorst
+        had_role:
+          - marcrel:aut
+          - dpv:DataController
+      - agent: thisds:#ahill
+        had_role:
+          - marcrel:aut
+      - agent: thisds:#kgorman
+        had_role:
+          - marcrel:aut
+          - marcrel:cre
+      - agent: thisds:#UCSB
+        had_role:
+          # Supporting host
+          - marcrel:sht
+      - agent: thisds:#RStudio
+        had_role:
+          - marcrel:sht
+      - agent: https://ror.org/01j7nq853
+        had_role:
+          - marcrel:sht
+    qualified_relation:
+      - had_role:
+          - schema:funding
+        entity: thisds:#nsf0217282
+      - had_role:
+          - schema:funding
+        entity: thisds:#nsf0823101
+      - had_role:
+          - schema:funding
+        entity: thisds:#nsf0741351
+      - had_role:
+          - CiTO:citesAsAuthority
+          - CiTO:isCitedAsDataSourceBy
+        entity: thisds:#gormanetal
+    same_as:
+      - https://doi.org/10.5281/zenodo.3960218
+    title: Palmer Penguins
+    version: "0.1.0"
+
+  - id: thisds:#nsf0217282
+    type: dlco:Grant
+    name: "LTER: PALMER, ANTARCTICA LTER: Climate Change, Ecosystem Migration and Teleconnections in an Ice-Dominated Environment"
+    identifier:
+      - notation: "0217282"
+        schema_agency: https://ror.org/021nxhr62
+    sponsor: https://ror.org/05nwjp114
+    cites_as_authority: https://www.nsf.gov/awardsearch/showAward?AWD_ID=0217282
+  - id: thisds:#nsf0823101
+    type: dlco:Grant
+    name: Palmer, Antarctica Long Term Ecological Research Project
+    identifier:
+      - notation: "0823101"
+        schema_agency: https://ror.org/021nxhr62
+    sponsor: https://ror.org/05nwjp114
+    cites_as_authority: https://www.nsf.gov/awardsearch/showAward?AWD_ID=0823101
+  - id: thisds:#nsf0741351
+    type: dlco:Grant
+    name: "Collaborative Research: Possible Climate-induced Change in the Distribution of Pleuragramma Antarcticum on the Western Antarctic Peninsula Shelf"
+    identifier:
+      - notation: "0741351"
+        schema_agency: https://ror.org/021nxhr62
+    sponsor: https://ror.org/05nwjp114
+    cites_as_authority: https://www.nsf.gov/awardsearch/showAward?AWD_ID=0741351
+  # the following publication ID could also be the DOI, but having a global ID is not
+  # a requirement (although almost unconditionally advantageous)
+  - id: thisds:#gormanetal
+    type: dlco:Publication
+    citation: >-
+      'Gorman KB, Williams TD, Fraser WR (2014) Ecological Sexual Dimorphism
+      and Environmental Variability within a Community of Antarctic Penguins (Genus
+      Pygoscelis). PLoS ONE 9(3): e90081.'
+    date_published: '2014-03-05'
+    identifier:
+      - notation: 10.1371/journal.pone.0090081
+        schema_agency: https://doi.org
+    qualified_attribution:
+      - agent: thisds:#kgorman
+        had_role:
+          - marcrel:aut
+
+# Relevant agents.
+# There definition in the scope of the Distribution is arbitrary.
+# They could also be defined inlined at the Resource level, or
+# even not at all in this document (assuming a definition using
+# the exact same identifier would be available elsewhere).
+# We use the `thisds` prefix based on the assumption that no
+# namespace conflict would ever happen across dataset versions.
+was_attributed_to:
+  - id: thisds:#ahorst
+    type: dlco:ResearchContributor
+    name: Allison Horst
+    email: ahorst@example.com
+    identifier:
+      - notation: 0000-0002-6047-5564
+        schema_agency: https://orcid.org
+    affiliation: thisds:#UCSB
+    # we can also use the ORCID as an equivalence statement, and web resource
+    # to link to
+    same_as:
+      - https://orcid.org/0000-0002-6047-5564
+  - id: thisds:#ahill
+    type: dlco:ResearchContributor
+    name: Allison Hill
+    email: ahill@example.com
+    identifier:
+      - notation: 0000-0002-8082-1890
+        schema_agency: https://orcid.org
+    affiliation: thisds:#Rstudio
+  - id: thisds:#kgorman
+    type: dlco:ResearchContributor
+    name: Kirsten Gorman
+    email: kgorman@example.com
+    identifier:
+      - notation: 0000-0002-0258-9264
+        schema_agency: https://orcid.org
+    affiliation: https://ror.org/01j7nq853
+  - id: thisds:#UCSB
+    type: dlco:Organization
+    name: 'UC Santa Barbara: Santa Barbara, CA, US'
+  - id: thisds:#RStudio
+    type: dlco:Organization
+    name: 'RStudio: Boston, MA, US'
+  - id: https://ror.org/01j7nq853
+    type: dlco:Organization
+    name: 'University of Alaska Fairbanks: Fairbanks, AK, US'
+    identifier:
+      - notation: 01j7nq853
+        schema_agency: https://ror.org
+  - id: https://ror.org/05nwjp114
+    name: NSF Office of Polar Programs
+    identifier:
+      - notation: 05nwjp114
+        schema_agency: https://ror.org
+  - id: https://ror.org/021nxhr62
+    name: US National Science Foundation
+    identifier:
+      - notation: 021nxhr62
+        schema_agency: https://ror.org
+    same_as:
+      - https://www.nsf.org

--- a/src/examples/data-distribution/Distribution-resource.json
+++ b/src/examples/data-distribution/Distribution-resource.json
@@ -1,22 +1,22 @@
 {
   "id": "thisdsver:./some/path.ext",
   "type": "dlco:Distribution",
-  "is_distribution_of": "thisdsver:./some/path",
+  "is_distribution_of": "thisdsver:#some/path",
   "relation": [
     {
-      "id": "thisdsver:./some/path",
+      "id": "thisdsver:#some/path",
       "description": "Some tabular data",
       "type": "dlco:Resource",
-      "is_part_of": "thisdsver:."
+      "is_part_of": "thisdsver:#"
     },
     {
-      "id": "thisdsver:.",
+      "id": "thisdsver:#",
       "description": "A version of a collection of some data",
       "type": "dlco:Resource",
-      "is_version_of": "thisds:."
+      "is_version_of": "thisds:#"
     },
     {
-      "id": "thisds:.",
+      "id": "thisds:#",
       "description": "A collection of some data",
       "type": "dlco:Resource"
     }

--- a/src/examples/data-distribution/Distribution-resource.yaml
+++ b/src/examples/data-distribution/Distribution-resource.yaml
@@ -8,16 +8,16 @@
 # of the same resource exist. The resource object only has to be
 # defined once in a `relation` property
 id: thisdsver:./some/path.ext
-is_distribution_of: thisdsver:./some/path
+is_distribution_of: thisdsver:#some/path
 relation:
-  - id: thisdsver:./some/path
+  - id: thisdsver:#some/path
     type: dlco:Resource
     description: Some tabular data
-    is_part_of: thisdsver:.
-  - id: thisdsver:.
+    is_part_of: thisdsver:#
+  - id: thisdsver:#
     type: dlco:Resource
     description: A version of a collection of some data
-    is_version_of: thisds:.
-  - id: thisds:.
+    is_version_of: thisds:#
+  - id: thisds:#
     type: dlco:Resource
     description: A collection of some data

--- a/src/examples/data-distribution/Resource-funding.json
+++ b/src/examples/data-distribution/Resource-funding.json
@@ -1,6 +1,13 @@
 {
   "id": "thisdsver:#",
   "type": "dlco:Resource",
+  "was_attributed_to": [
+    {
+      "id": "https://ror.org/018mejw64",
+      "name": "Deutsche Forschungsgemeinschaft",
+      "type": "dlco:Organization"
+    }
+  ],
   "qualified_relation": [
     {
       "had_role": [
@@ -15,13 +22,6 @@
       "name": "SFB1451",
       "type": "dlco:Grant",
       "sponsor": "https://ror.org/018mejw64"
-    }
-  ],
-  "was_attributed_to": [
-    {
-      "id": "https://ror.org/018mejw64",
-      "name": "Deutsche Forschungsgemeinschaft",
-      "type": "dlco:Organization"
     }
   ],
   "@type": "Resource"

--- a/src/linkml/schemas/data-distribution.yaml
+++ b/src/linkml/schemas/data-distribution.yaml
@@ -26,6 +26,7 @@ comments:
 license: MIT
 
 prefixes:
+  ADMS: http://www.w3.org/ns/adms#
   bibo: http://purl.org/ontology/bibo/
   CiTO: http://purl.org/spar/cito/
   DCAT: http://www.w3.org/ns/dcat#
@@ -36,10 +37,14 @@ prefixes:
   foaf: http://xmlns.com/foaf/0.1/
   linkml: https://w3id.org/linkml/
   obo: http://purl.obolibrary.org/obo/
+  owl: http://www.w3.org/2002/07/owl#
+  pav: http://purl.org/pav/
   prov: http://www.w3.org/ns/prov#
   RDF: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   RDFS: http://www.w3.org/2000/01/rdf-schema#
   schema: http://schema.org/
+  skos: http://www.w3.org/2004/02/skos/core#
+  sio: http://semanticscience.org/resource/
   spdx: http://spdx.org/rdf/terms#
   licenses: http://spdx.org/licenses/
   marcrel: http://id.loc.gov/vocabulary/relators/
@@ -74,6 +79,25 @@ imports:
 
 
 slots:
+  affiliation:
+    slot_uri: dlco:affiliation
+    description: >-
+      An organization that an agent is affiliated with.
+    range: Organization
+    exact_mappings:
+      - schema:affiliation
+
+  agent:
+    slot_uri: dlco:agent
+    description: >-
+      References an agent which influenced an entity.
+    range: Agent
+    domain: AgentInfluence
+    exact_mappings:
+      - prov:agent
+    broad_mappings:
+      - prov:influencer
+
   algorithm:
     description: >-
       The algorithm or rules to follow to compute a score, an effective method
@@ -100,6 +124,14 @@ slots:
     range: Checksum
     exact_mappings:
       - spdx:checksum
+
+  citation:
+    slot_uri: dlco:citation
+    description: >-
+      TODO
+    range: string
+    exact_mappings:
+      - schema:citation
 
   cites_as_authority:
     slot_uri: dlco:cites_as_authority
@@ -135,6 +167,22 @@ slots:
     comments:
       - Unlike `DCAT:distribution`, this property does not restrict its domain to
         a dataset.
+
+  download_url:
+    slot_uri: dlco:download_url
+    description: >-
+      URL of downloadable resourcefile in a given format.
+    range: uri
+    exact_mappings:
+      - DCAT:downloadURL
+
+  email:
+    slot_uri: dlco:email
+    description: Email address associated with an entity.
+    exact_mappings:
+      - schema:email
+      - obo:IAO_0000429
+    range: EmailAddress
 
   entity:
     slot_uri: dlco:entity
@@ -178,6 +226,16 @@ slots:
       - dcterms:identifier
       - schema:identifier
 
+  identifier:
+    slot_uri: dlco:identifier
+    description: An unambiguous reference to the subject within a given context.
+    exact_mappings:
+      - dcterms:identifier
+      - schema:identifier
+      - ADMS:identifier
+    range: Identifier
+    multivalued: true
+
   influencer:
     slot_uri: dlco:influencer
     description: >-
@@ -216,6 +274,30 @@ slots:
     exact_mappings:
       - DCAT:isVersionOf
 
+  keyword:
+    slot_uri: dlco:keyword
+    description: >-
+      One or more keywords or tags describing the resource.
+    range: string
+    multivalued: true
+    exact_mappings:
+      - dcat:keyword
+      - schema:keywords
+
+  landing_page:
+    slot_uri: dlco:landing_page
+    description: >-
+      A Web page that can be navigated to in a Web browser to gain access
+      to a resource, its distributions and/or additional information.
+    range: uri
+    exact_mappings:
+      - DCAT:landingPage
+      - foaf:page
+    comments:
+      - If the distribution(s) are accessible only through a landing page (i.e., direct download URLs are not known), then the landing page link SHOULD be duplicated as `dlco:access_url` on a distribution.
+    see_also:
+      - https://www.w3.org/TR/vocab-dcat-3/#example-landing-page
+
   license:
     slot_uri: dlco:license
     description: A legal document under which the resource is made available.
@@ -233,13 +315,24 @@ slots:
     exact_mappings:
       - spdx:extractedText
 
-  modified:
-    slot_uri: dlco:modified
+  date_modified:
+    slot_uri: dlco:date_modified
     description: >-
       Date on which the resource was (last) changed, updated or modified.
     range: W3CISO8601
     exact_mappings:
       - dcterms:modified
+    notes:
+      - successful validation with `datetime` as a range and linkml-jsonschema-validate` depends on a patched linkml, see https://github.com/linkml/linkml/issues/1806
+      - a related problem also exists for `linkml-validate`, we cannot have a more specific range right now
+
+  date_published:
+    slot_uri: dlco:date_published
+    description: >-
+      Date on which the resource was (last) changed, updated or modified.
+    range: W3CISO8601
+    exact_mappings:
+      - schema:datePublished
     notes:
       - successful validation with `datetime` as a range and linkml-jsonschema-validate` depends on a patched linkml, see https://github.com/linkml/linkml/issues/1806
       - a related problem also exists for `linkml-validate`, we cannot have a more specific range right now
@@ -253,6 +346,15 @@ slots:
       - foaf:name
     range: string
 
+  notation:
+    slot_uri: dlco:notation
+    description: >-
+      String of characters such as "T58.5" or "303.4833" used to uniquely
+      identify a concept within the scope of a given concept scheme.
+    range: string
+    exact_mappings:
+      - skos:notation
+
   relation:
     slot_uri: dlco:relation
     description: >-
@@ -260,6 +362,26 @@ slots:
     relational_role: OBJECT
     exact_mappings:
       - dcterms:relation
+
+  same_as:
+    slot_uri: dlco:same_as
+    description: >-
+      Property that determines that subject and object are equal.
+      Can be used to indicate a URL of a reference Web page that unambiguously
+      indicates the subjects's identity. For example, the URL of the subjects's
+      Wikipedia page, Wikidata entry, or official website.
+    exact_mappings:
+      - owl:sameAs
+    close_mappings:
+      - schema:sameAs
+
+  schema_agency:
+    slot_uri: dlco:schema_agency
+    description: >-
+      Name of the agency that issued an identifier.
+    range: Agent
+    exact_mappings:
+      - ADMS:schemaAgency
 
   sponsor:
     slot_uri: dlco:sponsor
@@ -269,6 +391,19 @@ slots:
     range: Agent
     exact_mappings:
       - schema:sponsor
+
+  title:
+    slot_uri: dlco:title
+    description: >-
+      A summarily description of a item or entity. It is closely related to
+      a name, but often less compact and more descriptive. Typically used for
+      documents.
+    exact_mappings:
+      - dcterms:title
+      - sio:SIO_000185
+    related_mappings:
+      - schema:name
+    range: string
 
   type:
     #slot_uri: dlco:type
@@ -280,6 +415,14 @@ slots:
     range: uriorcurie
     exact_mappings:
       - dcterms:type
+
+  qualified_attribution:
+    slot_uri: dlco:qualified_attribution
+    description: >-
+      Attribution is the ascribing of an entity to an agent.
+    exact_mappings:
+      - prov:qualifiedAttribution
+    range: Attribution
 
   qualified_part:
     slot_uri: dlco:qualified_part
@@ -296,6 +439,15 @@ slots:
       - DCAT:qualifiedRelation
     range: EntityInfluence
     multivalued: true
+
+  version:
+    slot_uri: dlco:version
+    description: >-
+      Version indicator (name or identifier) of a resource.
+    range: string
+    exact_mappings:
+      - DCAT:version
+      - pav:version
 
   was_attributed_to:
     slot_uri: dlco:was_attributed_to
@@ -316,11 +468,19 @@ classes:
     slots:
       - id
       - description
-      #- identifier
+      - identifier
       #- is_about
       - name
-      #- title
+      - same_as
+      - title
       - type
+    slot_usage:
+      identifier:
+        inlined: true
+        inlined_as_list: true
+      same_as:
+        multivalued: true
+        range: uriorcurie
     narrow_mappings:
       - prov:Activity
       - prov:Agent
@@ -345,18 +505,6 @@ classes:
 
 
   #
-  # entities
-  #
-  Entity:
-    class_uri: dlco:Entity
-    is_a: ProvConcept
-    description: >-
-      A physical, digital, conceptual, or other kind of thing with some
-      fixed aspects; entities may be real or imaginary.
-    exact_mappings:
-      - prov:Entity
-
-  #
   # agents
   #
   Agent:
@@ -370,6 +518,17 @@ classes:
       - foaf:Agent
       - prov:Agent
 
+  Person:
+    class_uri: dlco:Person
+    is_a: Agent
+    description: >-
+      Person agents are people.
+    slots:
+      - email
+    exact_mappings:
+      - foaf:Person
+      - prov:Person
+
   Organization:
     class_uri: dlco:Organization
     is_a: Agent
@@ -379,6 +538,40 @@ classes:
     exact_mappings:
       - foaf:Organization
       - prov:Organization
+
+  ResearchContributor:
+    class_uri: dlco:ResearchContributor
+    is_a: Person
+    description: >-
+      A person that has or could contribute to some research in any capacity.
+    slots:
+      - affiliation
+
+  #
+  # entities
+  #
+  Entity:
+    class_uri: dlco:Entity
+    is_a: ProvConcept
+    description: >-
+      A physical, digital, conceptual, or other kind of thing with some
+      fixed aspects; entities may be real or imaginary.
+    slots:
+      - qualified_attribution
+      - was_attributed_to
+    slot_usage:
+      qualified_attribution:
+        range: Attribution
+        multivalued: true
+        inlined: true
+        inlined_as_list: true
+      was_attributed_to:
+        multivalued: true
+        inlined: true
+        inlined_as_list: true
+        range: Agent
+    exact_mappings:
+      - prov:Entity
 
   Distribution:
     class_uri: dlco:Distribution
@@ -391,10 +584,13 @@ classes:
     slots:
       - byte_size
       - checksum
+      # TODO multivalued?
+      - download_url
       - has_part
       - is_distribution_of
       - license
-      - modified
+      - date_modified
+      - date_published
       - relation
       - qualified_part
     slot_usage:
@@ -416,7 +612,7 @@ classes:
         multivalued: true
         inlined: true
         inlined_as_list: true
-        range: QualifiedPart
+        range: DistributionPart
     exact_mappings:
       - DCAT:Distribution
 
@@ -428,17 +624,15 @@ classes:
     notes:
       - Try to make having specific subtypes of this class unnecessary
     slots:
+      - date_modified
+      - date_published
       - is_part_of
       - is_version_of
-      #- landing_page
-      #- modified
-      #- name
-      #- qualified_attribution
+      - keyword
+      - landing_page
       - qualified_relation
-      #- qualified_part
       - relation
-      #- title
-      - was_attributed_to
+      - version
       #- was_generated_by
     slot_usage:
       is_part_of:
@@ -455,13 +649,44 @@ classes:
         multivalued: true
         inlined: true
         inlined_as_list: true
-      was_attributed_to:
-        multivalued: true
-        inlined: true
-        inlined_as_list: true
-        range: Agent
     exact_mappings:
       - DCAT:Resource
+
+  Publication:
+    class_uri: dlco:Publication
+    is_a: Entity
+    description: >-
+      TODO
+    slots:
+      - citation
+      - date_published
+      #- url
+
+  LicenseDocument:
+    class_uri: dlco:LicenseDocument
+    is_a: Entity
+    description: >-
+      A legal document giving official permission to do something with a resource.
+    slots:
+      - license_text
+    exact_mappings:
+      - dcterms:LicenseDocument
+      - spdx:License
+    todos:
+      - spdx vocab has a needed pieces to express a any custom license
+
+  Grant:
+    class_uri: dlco:Grant
+    is_a: Entity
+    description: >-
+      A grant, typically financial or otherwise quantifiable, of resources.
+    slots:
+      - sponsor
+      - cites_as_authority
+    exact_mappings:
+      - schema:Grant
+    todos:
+      - We might also want to support `citation` here to support funder-recommended or funder-required citation forms.
 
   #
   # basic relations
@@ -478,6 +703,33 @@ classes:
       had_role:
         multivalued: true
     exact_mappings:
+      - prov:Influence
+
+  AgentInfluence:
+    class_uri: dlco:AgentInfluence
+    is_a: Influence
+    description: >-
+      Capacity of an agent to have an effect on the character, development,
+      or behavior of another Entity, Agent, or Activity
+    slots:
+      - agent
+    slot_usage:
+      agent:
+        equals_expression: "{influencer}"
+        todos:
+          - Ideally this would be a structured_alias to `influencer`. However, this does not seem to work at all in the way that it is described.
+    exact_mappings:
+      - prov:AgentInfluence
+
+  Attribution:
+    class_uri: dlco:Attribution
+    is_a: AgentInfluence
+    description: >-
+      Attribution is the ascribing of an entity to an agent.
+    exact_mappings:
+      - prov:Attribution
+    broad_mappings:
+      - prov:AgentInfluence
       - prov:Influence
 
   EntityInfluence:
@@ -498,6 +750,25 @@ classes:
     broad_mappings:
       - prov:Influence
 
+  DistributionPart:
+    class_uri: dlco:DistributionPart
+    description: >-
+      An association class for attaching additional information to a
+      hasPart relationship.
+    broad_mappings:
+      - DCAT:Relationship
+    slots:
+      - name
+      - entity
+    slot_usage:
+      name:
+        description: >-
+          The name of the part within the containing entity.
+    comments:
+      - This class is a key element of the data model. It enables referencing
+        a particular resource (e.g., a file's content, or versioned directory
+        tree in multiple contexts, such as different versions of a dataset).
+
   Role:
     class_uri: dlco:Role
     description: >-
@@ -510,19 +781,9 @@ classes:
       - prov:Role
       - DCAT:Role
 
-  LicenseDocument:
-    class_uri: dlco:LicenseDocument
-    is_a: Entity
-    description: >-
-      A legal document giving official permission to do something with a resource.
-    slots:
-      - license_text
-    exact_mappings:
-      - dcterms:LicenseDocument
-      - spdx:License
-    todos:
-      - spdx vocab has a needed pieces to express a any custom license
-
+  #
+  # utilities
+  #
   Checksum:
     class_uri: dlco:Checksum
     description: >-
@@ -541,34 +802,14 @@ classes:
     exact_mappings:
       - spdx:Checksum
 
-  QualifiedPart:
-    class_uri: dlco:QualifiedPart
+  Identifier:
+    class_uri: dlco:Identifier
     description: >-
-      An association class for attaching additional information to a
-      hasPart relationship.
-    broad_mappings:
-      - DCAT:Relationship
+       Identifier.
     slots:
-      - name
-      - entity
-    slot_usage:
-      name:
-        description: >-
-          The name of the part within the containing entity.
-    comments:
-      - This class is a key element of the data model. It enables referencing
-        a particular resource (e.g., a file's content, or versioned directory
-        tree in multiple contexts, such as different versions of a dataset).
-
-  Grant:
-    class_uri: dlco:Grant
-    is_a: Entity
-    description: >-
-      A grant, typically financial or otherwise quantifiable, of resources.
-    slots:
-      - sponsor
-      - cites_as_authority
+      - notation
+      - schema_agency
     exact_mappings:
-      - schema:Grant
-    todos:
-      - We might also want to support `citation` here to support funder-recommended or funder-required citation forms.
+      - ADMS:Identifier
+    see_also:
+      - https://semiceu.github.io/ADMS/releases/2.00/#Identifier

--- a/tests/data-distribution-schema/validation/Distribution.valid.cfg.yaml
+++ b/tests/data-distribution-schema/validation/Distribution.valid.cfg.yaml
@@ -5,6 +5,7 @@ data_sources:
   - src/examples/data-distribution/Distribution-customlicense.yaml
   - src/examples/data-distribution/Distribution-resource.yaml
   - src/examples/data-distribution/Distribution-parts.yaml
+  - src/examples/data-distribution/Distribution-penguins.yaml
 plugins:
   JsonschemaValidationPlugin:
     closed: true


### PR DESCRIPTION
In particular settle on a system to capture arbitrary identifiers with sufficient clarity, without having to introduce a dedicated property for each of them. Shown here on the examples of ORCID, ROR, and DOI.

This example now also shows better how it is possible to mix and match local and global identifiers.