### PR TITLE
Explore possibilities re influence classes

### DIFF
--- a/src/examples/data-distribution/AgentInfluence-std.json
+++ b/src/examples/data-distribution/AgentInfluence-std.json
@@ -1,0 +1,7 @@
+{
+  "had_role": [
+    "marcrel:aut"
+  ],
+  "agent": "https://orcid.org/0000-0001-6398-6370",
+  "@type": "AgentInfluence"
+}

--- a/src/examples/data-distribution/AgentInfluence-std.yaml
+++ b/src/examples/data-distribution/AgentInfluence-std.yaml
@@ -1,0 +1,4 @@
+# Declare a person identified by an ORCID to have had the role of an author
+agent: https://orcid.org/0000-0001-6398-6370
+had_role:
+  - marcrel:aut

--- a/src/examples/data-distribution/EntityInfluence-std.json
+++ b/src/examples/data-distribution/EntityInfluence-std.json
@@ -1,0 +1,7 @@
+{
+  "had_role": [
+    "dlco:is_about"
+  ],
+  "entity": "https://en.wikipedia.org/wiki/Vulcan_(Star_Trek)#Mind_melds",
+  "@type": "EntityInfluence"
+}

--- a/src/examples/data-distribution/EntityInfluence-std.yaml
+++ b/src/examples/data-distribution/EntityInfluence-std.yaml
@@ -1,0 +1,4 @@
+# Declare the topic of a subject to be Vulcan mind melds
+entity: https://en.wikipedia.org/wiki/Vulcan_(Star_Trek)#Mind_melds
+had_role:
+  - dlco:is_about

--- a/src/linkml/schemas/data-distribution.yaml
+++ b/src/linkml/schemas/data-distribution.yaml
@@ -89,6 +89,7 @@ slots:
 
   agent:
     slot_uri: dlco:agent
+    is_a: influencer
     description: >-
       References an agent which influenced an entity.
     range: Agent
@@ -218,6 +219,7 @@ slots:
 
   entity:
     slot_uri: dlco:entity
+    is_a: influencer
     description: >-
       References an entity which influenced an entity.
     range: Entity
@@ -441,8 +443,6 @@ slots:
     range: string
 
   type:
-    #slot_uri: dlco:type
-    #slot_uri: http://www.w3.org/1999/02/22-rdf-syntax-ns#type
     slot_uri: RDF:type
     designates_type: true
     description: >-
@@ -740,6 +740,12 @@ classes:
     slot_usage:
       had_role:
         multivalued: true
+        required: true
+      influencer:
+        # we cannot make it required. The equals_expression of,
+        # e.g. `AgentInfluence` does not kick in for value inference
+        # before validation errors out
+        #required: true
     exact_mappings:
       - prov:Influence
 
@@ -753,6 +759,7 @@ classes:
       - agent
     slot_usage:
       agent:
+        required: true
         equals_expression: "{influencer}"
         todos:
           - Ideally this would be a structured_alias to `influencer`. However, this does not seem to work at all in the way that it is described.
@@ -780,6 +787,7 @@ classes:
       - entity
     slot_usage:
       entity:
+        required: true
         equals_expression: "{influencer}"
         todos:
           - Ideally this would be a structured_alias to `influencer`. However, this does not seem to work at all in the way that it is described.

--- a/tests/data-distribution-schema/validation/AgentInfluence.valid.cfg.yaml
+++ b/tests/data-distribution-schema/validation/AgentInfluence.valid.cfg.yaml
@@ -1,0 +1,9 @@
+schema: src/linkml/schemas/data-distribution.yaml
+target_class: AgentInfluence
+data_sources:
+  - src/examples/data-distribution/AgentInfluence-std.yaml
+plugins:
+  JsonschemaValidationPlugin:
+    closed: true
+    include_range_class_descendants: false
+  RecommendedSlotsPlugin:

--- a/tests/data-distribution-schema/validation/EntityInfluence.valid.cfg.yaml
+++ b/tests/data-distribution-schema/validation/EntityInfluence.valid.cfg.yaml
@@ -1,0 +1,9 @@
+schema: src/linkml/schemas/data-distribution.yaml
+target_class: EntityInfluence
+data_sources:
+  - src/examples/data-distribution/EntityInfluence-std.yaml
+plugins:
+  JsonschemaValidationPlugin:
+    closed: true
+    include_range_class_descendants: false
+  RecommendedSlotsPlugin:


### PR DESCRIPTION
- make `agent` and `entity` derive from `influencer` (all three are slots)
- add slot requirements: this is not really satisfactory, because linkml cannot populate slots from `equals_expression` before validation.
- add dedicated examples, and also validate them