### PR TITLE
Rich publication records

### DIFF
--- a/src/examples/data-distribution/Distribution-basic.json
+++ b/src/examples/data-distribution/Distribution-basic.json
@@ -1,7 +1,7 @@
 {
   "id": "thisdsver:./some/name.ext",
+  "meta_type": "dlco:Distribution",
   "name": "name.ext",
-  "type": "dlco:Distribution",
   "byte_size": 123456789,
   "checksum": [
     {

--- a/src/examples/data-distribution/Distribution-customlicense.json
+++ b/src/examples/data-distribution/Distribution-customlicense.json
@@ -1,10 +1,10 @@
 {
   "id": "thisdsver:./some/path.ext",
-  "type": "dlco:Distribution",
+  "meta_type": "dlco:Distribution",
   "relation": [
     {
       "id": "thisds:#customlicense",
-      "type": "dlco:LicenseDocument",
+      "meta_type": "dlco:LicenseDocument",
       "license_text": "Highly custom terms, never seen before."
     }
   ],

--- a/src/examples/data-distribution/Distribution-customlicense.json
+++ b/src/examples/data-distribution/Distribution-customlicense.json
@@ -1,7 +1,6 @@
 {
   "id": "thisdsver:./some/path.ext",
   "type": "dlco:Distribution",
-  "license": "thisds:#customlicense",
   "relation": [
     {
       "id": "thisds:#customlicense",
@@ -9,5 +8,6 @@
       "license_text": "Highly custom terms, never seen before."
     }
   ],
+  "license": "thisds:#customlicense",
   "@type": "Distribution"
 }

--- a/src/examples/data-distribution/Distribution-customlicense.yaml
+++ b/src/examples/data-distribution/Distribution-customlicense.yaml
@@ -1,7 +1,7 @@
 id: thisdsver:./some/path.ext
 relation:
   - id: thisds:#customlicense
-    type: dlco:LicenseDocument
+    meta_type: dlco:LicenseDocument
     license_text: >-
       Highly custom terms, never seen before.
 license: thisds:#customlicense

--- a/src/examples/data-distribution/Distribution-formats.json
+++ b/src/examples/data-distribution/Distribution-formats.json
@@ -1,16 +1,16 @@
 {
   "id": "thisdsver:.",
-  "type": "dlco:Distribution",
+  "meta_type": "dlco:Distribution",
   "conforms_to": "https://bids-specification.readthedocs.io/en/v1.4.0",
   "has_part": [
     {
       "id": "thisdsver:./dataset_description.json",
-      "type": "dlco:Distribution",
+      "meta_type": "dlco:Distribution",
       "media_type": "application/json"
     },
     {
       "id": "thisdsver:./participants.tsv",
-      "type": "dlco:Distribution",
+      "meta_type": "dlco:Distribution",
       "format": "http://edamontology.org/format_3475"
     }
   ],

--- a/src/examples/data-distribution/Distribution-parts.json
+++ b/src/examples/data-distribution/Distribution-parts.json
@@ -1,16 +1,16 @@
 {
   "id": "thisdsver:./archive.zip",
-  "type": "dlco:Distribution",
+  "meta_type": "dlco:Distribution",
   "has_part": [
     {
       "id": "thisdsver:./archive.zip/subdir",
       "description": "A subdirectory",
-      "type": "dlco:Distribution",
+      "meta_type": "dlco:Distribution",
       "has_part": [
         {
           "id": "thisdsver:./archive.zip/subdir/file.txt",
           "description": "A file",
-          "type": "dlco:Distribution"
+          "meta_type": "dlco:Distribution"
         }
       ],
       "qualified_part": [

--- a/src/examples/data-distribution/Distribution-penguins.json
+++ b/src/examples/data-distribution/Distribution-penguins.json
@@ -1,6 +1,164 @@
 {
   "id": "thisdsver:.",
   "type": "dlco:Distribution",
+  "relation": [
+    {
+      "id": "thisdsver:#",
+      "description": "The goal of palmerpenguins is to provide a great dataset for data exploration and visualization, as an alternative to iris. Data were collected and made available by Dr. Kristen Gorman and the Palmer Station, Antarctica LTER, a member of the Long Term Ecological Research Network.",
+      "identifier": [
+        {
+          "notation": "10.5281/zenodo.3960218",
+          "schema_agency": "https://doi.org"
+        }
+      ],
+      "name": "penguins",
+      "same_as": [
+        "https://doi.org/10.5281/zenodo.3960218"
+      ],
+      "title": "Palmer Penguins",
+      "type": "dlco:Resource",
+      "qualified_attribution": [
+        {
+          "had_role": [
+            "marcrel:aut",
+            "dpv:DataController"
+          ],
+          "agent": "thisds:#ahorst"
+        },
+        {
+          "had_role": [
+            "marcrel:aut"
+          ],
+          "agent": "thisds:#ahill"
+        },
+        {
+          "had_role": [
+            "marcrel:aut",
+            "marcrel:cre"
+          ],
+          "agent": "thisds:#kgorman"
+        },
+        {
+          "had_role": [
+            "marcrel:sht"
+          ],
+          "agent": "thisds:#UCSB"
+        },
+        {
+          "had_role": [
+            "marcrel:sht"
+          ],
+          "agent": "thisds:#RStudio"
+        },
+        {
+          "had_role": [
+            "marcrel:sht"
+          ],
+          "agent": "https://ror.org/01j7nq853"
+        }
+      ],
+      "qualified_relation": [
+        {
+          "had_role": [
+            "schema:funding"
+          ],
+          "entity": "thisds:#nsf0217282"
+        },
+        {
+          "had_role": [
+            "schema:funding"
+          ],
+          "entity": "thisds:#nsf0823101"
+        },
+        {
+          "had_role": [
+            "schema:funding"
+          ],
+          "entity": "thisds:#nsf0741351"
+        },
+        {
+          "had_role": [
+            "CiTO:citesAsAuthority",
+            "CiTO:isCitedAsDataSourceBy"
+          ],
+          "entity": "thisds:#gormanetal"
+        }
+      ],
+      "date_modified": "2020-07-16",
+      "is_version_of": "thisds:#",
+      "keyword": [
+        "penguins",
+        "sea ice",
+        "foraging",
+        "ecological niches",
+        "islands",
+        "antarctica",
+        "animal sexual behavior",
+        "isotopes"
+      ],
+      "landing_page": "https://github.com/allisonhorst/palmerpenguins",
+      "version": "0.1.0"
+    },
+    {
+      "id": "thisds:#nsf0217282",
+      "identifier": [
+        {
+          "notation": "0217282",
+          "schema_agency": "https://ror.org/021nxhr62"
+        }
+      ],
+      "name": "LTER: PALMER, ANTARCTICA LTER: Climate Change, Ecosystem Migration and Teleconnections in an Ice-Dominated Environment",
+      "type": "dlco:Grant",
+      "sponsor": "https://ror.org/05nwjp114",
+      "cites_as_authority": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=0217282"
+    },
+    {
+      "id": "thisds:#nsf0823101",
+      "identifier": [
+        {
+          "notation": "0823101",
+          "schema_agency": "https://ror.org/021nxhr62"
+        }
+      ],
+      "name": "Palmer, Antarctica Long Term Ecological Research Project",
+      "type": "dlco:Grant",
+      "sponsor": "https://ror.org/05nwjp114",
+      "cites_as_authority": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=0823101"
+    },
+    {
+      "id": "thisds:#nsf0741351",
+      "identifier": [
+        {
+          "notation": "0741351",
+          "schema_agency": "https://ror.org/021nxhr62"
+        }
+      ],
+      "name": "Collaborative Research: Possible Climate-induced Change in the Distribution of Pleuragramma Antarcticum on the Western Antarctic Peninsula Shelf",
+      "type": "dlco:Grant",
+      "sponsor": "https://ror.org/05nwjp114",
+      "cites_as_authority": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=0741351"
+    },
+    {
+      "id": "thisds:#gormanetal",
+      "identifier": [
+        {
+          "notation": "10.1371/journal.pone.0090081",
+          "schema_agency": "https://doi.org"
+        }
+      ],
+      "type": "dlco:Publication",
+      "qualified_attribution": [
+        {
+          "had_role": [
+            "marcrel:aut"
+          ],
+          "agent": "thisds:#kgorman"
+        }
+      ],
+      "date_published": "2014-03-05",
+      "notation": "'Gorman KB, Williams TD, Fraser WR (2014) Ecological Sexual Dimorphism and Environmental Variability within a Community of Antarctic Penguins (Genus Pygoscelis). PLoS ONE 9(3): e90081.'"
+    }
+  ],
   "was_attributed_to": [
     {
       "id": "thisds:#ahorst",
@@ -16,7 +174,9 @@
       ],
       "type": "dlco:ResearchContributor",
       "email": "ahorst@example.com",
-      "affiliation": "thisds:#UCSB"
+      "affiliation": [
+        "thisds:#UCSB"
+      ]
     },
     {
       "id": "thisds:#ahill",
@@ -29,7 +189,9 @@
       "name": "Allison Hill",
       "type": "dlco:ResearchContributor",
       "email": "ahill@example.com",
-      "affiliation": "thisds:#Rstudio"
+      "affiliation": [
+        "thisds:#Rstudio"
+      ]
     },
     {
       "id": "thisds:#kgorman",
@@ -42,7 +204,9 @@
       "name": "Kirsten Gorman",
       "type": "dlco:ResearchContributor",
       "email": "kgorman@example.com",
-      "affiliation": "https://ror.org/01j7nq853"
+      "affiliation": [
+        "https://ror.org/01j7nq853"
+      ]
     },
     {
       "id": "thisds:#UCSB",
@@ -134,164 +298,6 @@
   ],
   "is_distribution_of": "thisdsver:#",
   "license": "licenses:CC0-1.0",
-  "relation": [
-    {
-      "id": "thisdsver:#",
-      "description": "The goal of palmerpenguins is to provide a great dataset for data exploration and visualization, as an alternative to iris. Data were collected and made available by Dr. Kristen Gorman and the Palmer Station, Antarctica LTER, a member of the Long Term Ecological Research Network.",
-      "identifier": [
-        {
-          "notation": "10.5281/zenodo.3960218",
-          "schema_agency": "https://doi.org"
-        }
-      ],
-      "name": "penguins",
-      "same_as": [
-        "https://doi.org/10.5281/zenodo.3960218"
-      ],
-      "title": "Palmer Penguins",
-      "type": "dlco:Resource",
-      "qualified_attribution": [
-        {
-          "had_role": [
-            "marcrel:aut",
-            "dpv:DataController"
-          ],
-          "agent": "thisds:#ahorst"
-        },
-        {
-          "had_role": [
-            "marcrel:aut"
-          ],
-          "agent": "thisds:#ahill"
-        },
-        {
-          "had_role": [
-            "marcrel:aut",
-            "marcrel:cre"
-          ],
-          "agent": "thisds:#kgorman"
-        },
-        {
-          "had_role": [
-            "marcrel:sht"
-          ],
-          "agent": "thisds:#UCSB"
-        },
-        {
-          "had_role": [
-            "marcrel:sht"
-          ],
-          "agent": "thisds:#RStudio"
-        },
-        {
-          "had_role": [
-            "marcrel:sht"
-          ],
-          "agent": "https://ror.org/01j7nq853"
-        }
-      ],
-      "date_modified": "2020-07-16",
-      "is_version_of": "thisds:#",
-      "keyword": [
-        "penguins",
-        "sea ice",
-        "foraging",
-        "ecological niches",
-        "islands",
-        "antarctica",
-        "animal sexual behavior",
-        "isotopes"
-      ],
-      "landing_page": "https://github.com/allisonhorst/palmerpenguins",
-      "qualified_relation": [
-        {
-          "had_role": [
-            "schema:funding"
-          ],
-          "entity": "thisds:#nsf0217282"
-        },
-        {
-          "had_role": [
-            "schema:funding"
-          ],
-          "entity": "thisds:#nsf0823101"
-        },
-        {
-          "had_role": [
-            "schema:funding"
-          ],
-          "entity": "thisds:#nsf0741351"
-        },
-        {
-          "had_role": [
-            "CiTO:citesAsAuthority",
-            "CiTO:isCitedAsDataSourceBy"
-          ],
-          "entity": "thisds:#gormanetal"
-        }
-      ],
-      "version": "0.1.0"
-    },
-    {
-      "id": "thisds:#nsf0217282",
-      "identifier": [
-        {
-          "notation": "0217282",
-          "schema_agency": "https://ror.org/021nxhr62"
-        }
-      ],
-      "name": "LTER: PALMER, ANTARCTICA LTER: Climate Change, Ecosystem Migration and Teleconnections in an Ice-Dominated Environment",
-      "type": "dlco:Grant",
-      "sponsor": "https://ror.org/05nwjp114",
-      "cites_as_authority": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=0217282"
-    },
-    {
-      "id": "thisds:#nsf0823101",
-      "identifier": [
-        {
-          "notation": "0823101",
-          "schema_agency": "https://ror.org/021nxhr62"
-        }
-      ],
-      "name": "Palmer, Antarctica Long Term Ecological Research Project",
-      "type": "dlco:Grant",
-      "sponsor": "https://ror.org/05nwjp114",
-      "cites_as_authority": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=0823101"
-    },
-    {
-      "id": "thisds:#nsf0741351",
-      "identifier": [
-        {
-          "notation": "0741351",
-          "schema_agency": "https://ror.org/021nxhr62"
-        }
-      ],
-      "name": "Collaborative Research: Possible Climate-induced Change in the Distribution of Pleuragramma Antarcticum on the Western Antarctic Peninsula Shelf",
-      "type": "dlco:Grant",
-      "sponsor": "https://ror.org/05nwjp114",
-      "cites_as_authority": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=0741351"
-    },
-    {
-      "id": "thisds:#gormanetal",
-      "identifier": [
-        {
-          "notation": "10.1371/journal.pone.0090081",
-          "schema_agency": "https://doi.org"
-        }
-      ],
-      "type": "dlco:Publication",
-      "qualified_attribution": [
-        {
-          "had_role": [
-            "marcrel:aut"
-          ],
-          "agent": "thisds:#kgorman"
-        }
-      ],
-      "citation": "'Gorman KB, Williams TD, Fraser WR (2014) Ecological Sexual Dimorphism and Environmental Variability within a Community of Antarctic Penguins (Genus Pygoscelis). PLoS ONE 9(3): e90081.'",
-      "date_published": "2014-03-05"
-    }
-  ],
   "qualified_part": [
     {
       "name": "adelie.csv",

--- a/src/examples/data-distribution/Distribution-penguins.json
+++ b/src/examples/data-distribution/Distribution-penguins.json
@@ -1,6 +1,6 @@
 {
   "id": "thisdsver:.",
-  "type": "dlco:Distribution",
+  "meta_type": "dlco:Distribution",
   "relation": [
     {
       "id": "thisdsver:#",
@@ -11,12 +11,12 @@
           "schema_agency": "https://doi.org"
         }
       ],
+      "meta_type": "dlco:Resource",
       "name": "penguins",
       "same_as": [
         "https://doi.org/10.5281/zenodo.3960218"
       ],
       "title": "Palmer Penguins",
-      "type": "dlco:Resource",
       "qualified_attribution": [
         {
           "had_role": [
@@ -107,8 +107,8 @@
           "schema_agency": "https://ror.org/021nxhr62"
         }
       ],
+      "meta_type": "dlco:Grant",
       "name": "LTER: PALMER, ANTARCTICA LTER: Climate Change, Ecosystem Migration and Teleconnections in an Ice-Dominated Environment",
-      "type": "dlco:Grant",
       "sponsor": "https://ror.org/05nwjp114",
       "cites_as_authority": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=0217282"
     },
@@ -120,8 +120,8 @@
           "schema_agency": "https://ror.org/021nxhr62"
         }
       ],
+      "meta_type": "dlco:Grant",
       "name": "Palmer, Antarctica Long Term Ecological Research Project",
-      "type": "dlco:Grant",
       "sponsor": "https://ror.org/05nwjp114",
       "cites_as_authority": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=0823101"
     },
@@ -133,8 +133,8 @@
           "schema_agency": "https://ror.org/021nxhr62"
         }
       ],
+      "meta_type": "dlco:Grant",
       "name": "Collaborative Research: Possible Climate-induced Change in the Distribution of Pleuragramma Antarcticum on the Western Antarctic Peninsula Shelf",
-      "type": "dlco:Grant",
       "sponsor": "https://ror.org/05nwjp114",
       "cites_as_authority": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=0741351"
     },
@@ -146,7 +146,7 @@
           "schema_agency": "https://doi.org"
         }
       ],
-      "type": "dlco:Publication",
+      "meta_type": "dlco:Publication",
       "qualified_attribution": [
         {
           "had_role": [
@@ -168,11 +168,11 @@
           "schema_agency": "https://orcid.org"
         }
       ],
+      "meta_type": "dlco:ResearchContributor",
       "name": "Allison Horst",
       "same_as": [
         "https://orcid.org/0000-0002-6047-5564"
       ],
-      "type": "dlco:ResearchContributor",
       "email": "ahorst@example.com",
       "affiliation": [
         "thisds:#UCSB"
@@ -186,8 +186,8 @@
           "schema_agency": "https://orcid.org"
         }
       ],
+      "meta_type": "dlco:ResearchContributor",
       "name": "Allison Hill",
-      "type": "dlco:ResearchContributor",
       "email": "ahill@example.com",
       "affiliation": [
         "thisds:#Rstudio"
@@ -201,8 +201,8 @@
           "schema_agency": "https://orcid.org"
         }
       ],
+      "meta_type": "dlco:ResearchContributor",
       "name": "Kirsten Gorman",
-      "type": "dlco:ResearchContributor",
       "email": "kgorman@example.com",
       "affiliation": [
         "https://ror.org/01j7nq853"
@@ -210,13 +210,13 @@
     },
     {
       "id": "thisds:#UCSB",
-      "name": "UC Santa Barbara: Santa Barbara, CA, US",
-      "type": "dlco:Organization"
+      "meta_type": "dlco:Organization",
+      "name": "UC Santa Barbara: Santa Barbara, CA, US"
     },
     {
       "id": "thisds:#RStudio",
-      "name": "RStudio: Boston, MA, US",
-      "type": "dlco:Organization"
+      "meta_type": "dlco:Organization",
+      "name": "RStudio: Boston, MA, US"
     },
     {
       "id": "https://ror.org/01j7nq853",
@@ -226,8 +226,8 @@
           "schema_agency": "https://ror.org"
         }
       ],
-      "name": "University of Alaska Fairbanks: Fairbanks, AK, US",
-      "type": "dlco:Organization"
+      "meta_type": "dlco:Organization",
+      "name": "University of Alaska Fairbanks: Fairbanks, AK, US"
     },
     {
       "id": "https://ror.org/05nwjp114",
@@ -237,8 +237,8 @@
           "schema_agency": "https://ror.org"
         }
       ],
-      "name": "NSF Office of Polar Programs",
-      "type": "dlco:Agent"
+      "meta_type": "dlco:Agent",
+      "name": "NSF Office of Polar Programs"
     },
     {
       "id": "https://ror.org/021nxhr62",
@@ -248,17 +248,17 @@
           "schema_agency": "https://ror.org"
         }
       ],
+      "meta_type": "dlco:Agent",
       "name": "US National Science Foundation",
       "same_as": [
         "https://www.nsf.org"
-      ],
-      "type": "dlco:Agent"
+      ]
     }
   ],
   "has_part": [
     {
       "id": "thisdsver:./adelie.csv",
-      "type": "dlco:Distribution",
+      "meta_type": "dlco:Distribution",
       "byte_size": 23755,
       "checksum": [
         {
@@ -271,7 +271,7 @@
     },
     {
       "id": "thisdsver:./gentoo.csv",
-      "type": "dlco:Distribution",
+      "meta_type": "dlco:Distribution",
       "byte_size": 11263,
       "checksum": [
         {
@@ -284,7 +284,7 @@
     },
     {
       "id": "thisdsver:./chinstrap.csv",
-      "type": "dlco:Distribution",
+      "meta_type": "dlco:Distribution",
       "byte_size": 18872,
       "checksum": [
         {

--- a/src/examples/data-distribution/Distribution-penguins.yaml
+++ b/src/examples/data-distribution/Distribution-penguins.yaml
@@ -40,7 +40,7 @@ qualified_part:
 is_distribution_of: thisdsver:#
 relation:
   - id: thisdsver:#
-    type: dlco:Resource
+    meta_type: dlco:Resource
     date_modified: "2020-07-16"
     description: >-
       The goal of palmerpenguins is to provide a great dataset for data
@@ -105,7 +105,7 @@ relation:
     version: "0.1.0"
 
   - id: thisds:#nsf0217282
-    type: dlco:Grant
+    meta_type: dlco:Grant
     name: "LTER: PALMER, ANTARCTICA LTER: Climate Change, Ecosystem Migration and Teleconnections in an Ice-Dominated Environment"
     identifier:
       - notation: "0217282"
@@ -113,7 +113,7 @@ relation:
     sponsor: https://ror.org/05nwjp114
     cites_as_authority: https://www.nsf.gov/awardsearch/showAward?AWD_ID=0217282
   - id: thisds:#nsf0823101
-    type: dlco:Grant
+    meta_type: dlco:Grant
     name: Palmer, Antarctica Long Term Ecological Research Project
     identifier:
       - notation: "0823101"
@@ -121,7 +121,7 @@ relation:
     sponsor: https://ror.org/05nwjp114
     cites_as_authority: https://www.nsf.gov/awardsearch/showAward?AWD_ID=0823101
   - id: thisds:#nsf0741351
-    type: dlco:Grant
+    meta_type: dlco:Grant
     name: "Collaborative Research: Possible Climate-induced Change in the Distribution of Pleuragramma Antarcticum on the Western Antarctic Peninsula Shelf"
     identifier:
       - notation: "0741351"
@@ -131,7 +131,7 @@ relation:
   # the following publication ID could also be the DOI, but having a global ID is not
   # a requirement (although almost unconditionally advantageous)
   - id: thisds:#gormanetal
-    type: dlco:Publication
+    meta_type: dlco:Publication
     notation: >-
       'Gorman KB, Williams TD, Fraser WR (2014) Ecological Sexual Dimorphism
       and Environmental Variability within a Community of Antarctic Penguins (Genus
@@ -154,7 +154,7 @@ relation:
 # namespace conflict would ever happen across dataset versions.
 was_attributed_to:
   - id: thisds:#ahorst
-    type: dlco:ResearchContributor
+    meta_type: dlco:ResearchContributor
     name: Allison Horst
     email: ahorst@example.com
     identifier:
@@ -167,7 +167,7 @@ was_attributed_to:
     same_as:
       - https://orcid.org/0000-0002-6047-5564
   - id: thisds:#ahill
-    type: dlco:ResearchContributor
+    meta_type: dlco:ResearchContributor
     name: Allison Hill
     email: ahill@example.com
     identifier:
@@ -176,7 +176,7 @@ was_attributed_to:
     affiliation:
       - thisds:#Rstudio
   - id: thisds:#kgorman
-    type: dlco:ResearchContributor
+    meta_type: dlco:ResearchContributor
     name: Kirsten Gorman
     email: kgorman@example.com
     identifier:
@@ -185,13 +185,13 @@ was_attributed_to:
     affiliation:
       - https://ror.org/01j7nq853
   - id: thisds:#UCSB
-    type: dlco:Organization
+    meta_type: dlco:Organization
     name: 'UC Santa Barbara: Santa Barbara, CA, US'
   - id: thisds:#RStudio
-    type: dlco:Organization
+    meta_type: dlco:Organization
     name: 'RStudio: Boston, MA, US'
   - id: https://ror.org/01j7nq853
-    type: dlco:Organization
+    meta_type: dlco:Organization
     name: 'University of Alaska Fairbanks: Fairbanks, AK, US'
     identifier:
       - notation: 01j7nq853

--- a/src/examples/data-distribution/Distribution-penguins.yaml
+++ b/src/examples/data-distribution/Distribution-penguins.yaml
@@ -132,7 +132,7 @@ relation:
   # a requirement (although almost unconditionally advantageous)
   - id: thisds:#gormanetal
     type: dlco:Publication
-    citation: >-
+    notation: >-
       'Gorman KB, Williams TD, Fraser WR (2014) Ecological Sexual Dimorphism
       and Environmental Variability within a Community of Antarctic Penguins (Genus
       Pygoscelis). PLoS ONE 9(3): e90081.'
@@ -160,7 +160,8 @@ was_attributed_to:
     identifier:
       - notation: 0000-0002-6047-5564
         schema_agency: https://orcid.org
-    affiliation: thisds:#UCSB
+    affiliation:
+      - thisds:#UCSB
     # we can also use the ORCID as an equivalence statement, and web resource
     # to link to
     same_as:
@@ -172,7 +173,8 @@ was_attributed_to:
     identifier:
       - notation: 0000-0002-8082-1890
         schema_agency: https://orcid.org
-    affiliation: thisds:#Rstudio
+    affiliation:
+      - thisds:#Rstudio
   - id: thisds:#kgorman
     type: dlco:ResearchContributor
     name: Kirsten Gorman
@@ -180,7 +182,8 @@ was_attributed_to:
     identifier:
       - notation: 0000-0002-0258-9264
         schema_agency: https://orcid.org
-    affiliation: https://ror.org/01j7nq853
+    affiliation:
+      - https://ror.org/01j7nq853
   - id: thisds:#UCSB
     type: dlco:Organization
     name: 'UC Santa Barbara: Santa Barbara, CA, US'

--- a/src/examples/data-distribution/Distribution-resource.json
+++ b/src/examples/data-distribution/Distribution-resource.json
@@ -1,7 +1,6 @@
 {
   "id": "thisdsver:./some/path.ext",
   "type": "dlco:Distribution",
-  "is_distribution_of": "thisdsver:#some/path",
   "relation": [
     {
       "id": "thisdsver:#some/path",
@@ -21,5 +20,6 @@
       "type": "dlco:Resource"
     }
   ],
+  "is_distribution_of": "thisdsver:#some/path",
   "@type": "Distribution"
 }

--- a/src/examples/data-distribution/Distribution-resource.json
+++ b/src/examples/data-distribution/Distribution-resource.json
@@ -1,23 +1,23 @@
 {
   "id": "thisdsver:./some/path.ext",
-  "type": "dlco:Distribution",
+  "meta_type": "dlco:Distribution",
   "relation": [
     {
       "id": "thisdsver:#some/path",
       "description": "Some tabular data",
-      "type": "dlco:Resource",
+      "meta_type": "dlco:Resource",
       "is_part_of": "thisdsver:#"
     },
     {
       "id": "thisdsver:#",
       "description": "A version of a collection of some data",
-      "type": "dlco:Resource",
+      "meta_type": "dlco:Resource",
       "is_version_of": "thisds:#"
     },
     {
       "id": "thisds:#",
       "description": "A collection of some data",
-      "type": "dlco:Resource"
+      "meta_type": "dlco:Resource"
     }
   ],
   "is_distribution_of": "thisdsver:#some/path",

--- a/src/examples/data-distribution/Distribution-resource.yaml
+++ b/src/examples/data-distribution/Distribution-resource.yaml
@@ -11,13 +11,13 @@ id: thisdsver:./some/path.ext
 is_distribution_of: thisdsver:#some/path
 relation:
   - id: thisdsver:#some/path
-    type: dlco:Resource
+    meta_type: dlco:Resource
     description: Some tabular data
     is_part_of: thisdsver:#
   - id: thisdsver:#
-    type: dlco:Resource
+    meta_type: dlco:Resource
     description: A version of a collection of some data
     is_version_of: thisds:#
   - id: thisds:#
-    type: dlco:Resource
+    meta_type: dlco:Resource
     description: A collection of some data

--- a/src/examples/data-distribution/Publication-std.json
+++ b/src/examples/data-distribution/Publication-std.json
@@ -12,11 +12,41 @@
     "https://www.nature.com/subjects/data-publication-and-archiving",
     "https://www.nature.com/subjects/software"
   ],
+  "meta_type": "dlco:Publication",
+  "property": [
+    {
+      "name": "DOI",
+      "type": "bibo:doi",
+      "value": [
+        "https://doi.org/10.1038/s41597-022-01163-2"
+      ]
+    },
+    {
+      "name": "Volume",
+      "type": "bibo:volume",
+      "value": [
+        "9"
+      ]
+    },
+    {
+      "name": "Document number",
+      "type": "bibo:number",
+      "value": [
+        "80"
+      ]
+    },
+    {
+      "name": "Number of pages",
+      "type": "bibo:numPages",
+      "value": [
+        "17"
+      ]
+    }
+  ],
   "same_as": [
     "https://www.nature.com/articles/s41597-022-01163-2"
   ],
   "title": "FAIRly big: A framework for computationally reproducible processing of large-scale data",
-  "type": "dlco:Publication",
   "qualified_attribution": [
     {
       "had_role": [
@@ -192,9 +222,9 @@
           "schema_agency": "https://cordis.europa.eu"
         }
       ],
+      "meta_type": "dlco:Grant",
       "name": "HBP SGA3",
       "title": "Human Brain Project Specific Grant Agreement 3",
-      "type": "dlco:Grant",
       "cites_as_authority": "https://cordis.europa.eu/project/id/945539"
     },
     {
@@ -205,9 +235,9 @@
           "schema_agency": "https://cordis.europa.eu"
         }
       ],
+      "meta_type": "dlco:Grant",
       "name": "VirtualBrainCloud",
       "title": "Personalized Recommendations for Neurodegenerative Disease",
-      "type": "dlco:Grant",
       "cites_as_authority": "https://cordis.europa.eu/project/id/826421"
     },
     {
@@ -218,8 +248,8 @@
           "schema_agency": "https://ror.org/021nxhr62"
         }
       ],
+      "meta_type": "dlco:Grant",
       "title": "Collaborative Proposal: CRCNS US-German Data Sharing Proposal: DataLad - a decentralized system for integrated discovery, management, and publication of digital objects of science",
-      "type": "dlco:Grant",
       "cites_as_authority": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=1912266"
     },
     {
@@ -230,8 +260,8 @@
           "schema_agency": "https://ror.org/021nxhr62"
         }
       ],
+      "meta_type": "dlco:Grant",
       "title": "CRCNS US-German Data Sharing: DataGit - converging catalogues, warehouses, and deployment logistics into a federated 'data distribution'",
-      "type": "dlco:Grant",
       "cites_as_authority": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=1429999"
     },
     {
@@ -242,8 +272,8 @@
           "schema_agency": "https://www.ncn.gov.pl"
         }
       ],
-      "name": "ETIUDA",
-      "type": "dlco:Grant"
+      "meta_type": "dlco:Grant",
+      "name": "ETIUDA"
     },
     {
       "id": "thisds:#grant_bmbf01GQ1411",
@@ -253,8 +283,8 @@
           "schema_agency": "https://www.bmbf.de"
         }
       ],
-      "title": "Datagit - Kombination von Katalogen, Datenbanken und Verteilungslogistik in eine Daten-Distribution",
-      "type": "dlco:Grant"
+      "meta_type": "dlco:Grant",
+      "title": "Datagit - Kombination von Katalogen, Datenbanken und Verteilungslogistik in eine Daten-Distribution"
     },
     {
       "id": "thisds:#grant_bmbf01GQ1905",
@@ -264,9 +294,9 @@
           "schema_agency": "https://www.bmbf.de"
         }
       ],
+      "meta_type": "dlco:Grant",
       "name": "METALAD",
-      "title": "DataLad - ein dezentrales System für Forschungsdatenverwaltung, -publikation und -suche",
-      "type": "dlco:Grant"
+      "title": "DataLad - ein dezentrales System für Forschungsdatenverwaltung, -publikation und -suche"
     },
     {
       "id": "https://portal.issn.org/resource/issn/2052-4463",
@@ -276,14 +306,12 @@
           "schema_agency": "https://portal.issn.org"
         }
       ],
-      "is_about": [
-        "obo:NCIT_C93226"
-      ],
+      "meta_type": "dlco:Entity",
       "same_as": [
         "https://www.nature.com/sdata"
       ],
       "title": "Scientific data",
-      "type": "dlco:Entity"
+      "type": "obo:NCIT_C93226"
     }
   ],
   "was_attributed_to": [
@@ -295,8 +323,8 @@
           "schema_agency": "http://orcid.org"
         }
       ],
+      "meta_type": "dlco:ResearchContributor",
       "name": "Adina S. Wagner",
-      "type": "dlco:ResearchContributor",
       "email": "adina.wagner@t-online.de",
       "affiliation": [
         "https://ror.org/02nv7yv05"
@@ -310,8 +338,8 @@
           "schema_agency": "http://orcid.org"
         }
       ],
+      "meta_type": "dlco:ResearchContributor",
       "name": "Laura K. Waite",
-      "type": "dlco:ResearchContributor",
       "affiliation": [
         "https://ror.org/02nv7yv05"
       ]
@@ -324,8 +352,8 @@
           "schema_agency": "http://orcid.org"
         }
       ],
+      "meta_type": "dlco:ResearchContributor",
       "name": "Małgorzata Wierzba",
-      "type": "dlco:ResearchContributor",
       "affiliation": [
         "https://ror.org/04waf7p94"
       ]
@@ -338,8 +366,8 @@
           "schema_agency": "http://orcid.org"
         }
       ],
+      "meta_type": "dlco:ResearchContributor",
       "name": "Felix Hoffstaedter",
-      "type": "dlco:ResearchContributor",
       "affiliation": [
         "https://ror.org/02nv7yv05"
       ]
@@ -352,8 +380,8 @@
           "schema_agency": "http://orcid.org"
         }
       ],
+      "meta_type": "dlco:ResearchContributor",
       "name": "Alexander Q. Waite",
-      "type": "dlco:ResearchContributor",
       "affiliation": [
         "https://ror.org/02nv7yv05"
       ]
@@ -366,19 +394,19 @@
           "schema_agency": "http://orcid.org"
         }
       ],
+      "meta_type": "dlco:ResearchContributor",
       "name": "Benjamin Poldrack",
-      "type": "dlco:ResearchContributor",
       "affiliation": [
         "https://ror.org/02nv7yv05"
       ]
     },
     {
       "id": "https://www.nature.com/articles/s41597-022-01163-2#auth-Simon_B_-Eickhoff-Aff1-Aff3",
+      "meta_type": "dlco:ResearchContributor",
       "name": "Simon B. Eickhoff",
       "same_as": [
         "https://scholar.google.com/citations?user=wjpISMAAAAAJ"
       ],
-      "type": "dlco:ResearchContributor",
       "affiliation": [
         "https://ror.org/02nv7yv05",
         "https://ror.org/024z2rq82"
@@ -392,8 +420,8 @@
           "schema_agency": "http://orcid.org"
         }
       ],
+      "meta_type": "dlco:ResearchContributor",
       "name": "Michael Hanke",
-      "type": "dlco:ResearchContributor",
       "affiliation": [
         "https://ror.org/02nv7yv05",
         "https://ror.org/024z2rq82"
@@ -407,9 +435,9 @@
           "schema_agency": "https://ror.org"
         }
       ],
+      "meta_type": "dlco:Organization",
       "name": "FZJ-INM7",
-      "title": "Institute of Neuroscience and Medicine, Brain & Behaviour (INM-7), Research Center Jülich, Jülich, Germany",
-      "type": "dlco:Organization"
+      "title": "Institute of Neuroscience and Medicine, Brain & Behaviour (INM-7), Research Center Jülich, Jülich, Germany"
     },
     {
       "id": "https://ror.org/024z2rq82",
@@ -419,9 +447,9 @@
           "schema_agency": "https://ror.org"
         }
       ],
+      "meta_type": "dlco:Organization",
       "name": "HHU-ISN",
-      "title": "Institute of Systems Neuroscience, Medical Faculty, Heinrich Heine University Düsseldorf, Düsseldorf, Germany",
-      "type": "dlco:Organization"
+      "title": "Institute of Systems Neuroscience, Medical Faculty, Heinrich Heine University Düsseldorf, Düsseldorf, Germany"
     },
     {
       "id": "https://ror.org/04waf7p94",
@@ -431,9 +459,9 @@
           "schema_agency": "https://ror.org"
         }
       ],
+      "meta_type": "dlco:Organization",
       "name": "Nencki",
-      "title": "Laboratory of Brain Imaging, Nencki Institute of Experimental Biology, Polish Academy of Sciences, Warsaw, Poland",
-      "type": "dlco:Organization"
+      "title": "Laboratory of Brain Imaging, Nencki Institute of Experimental Biology, Polish Academy of Sciences, Warsaw, Poland"
     },
     {
       "id": "https://ror.org/02frzq211",
@@ -443,8 +471,8 @@
           "schema_agency": "https://ror.org"
         }
       ],
-      "name": "UK Biobank",
-      "type": "dlco:Organization"
+      "meta_type": "dlco:Organization",
+      "name": "UK Biobank"
     },
     {
       "id": "https://ror.org/00k4n6c32",
@@ -454,8 +482,8 @@
           "schema_agency": "https://ror.org"
         }
       ],
-      "name": "European Commission",
-      "type": "dlco:Organization"
+      "meta_type": "dlco:Organization",
+      "name": "European Commission"
     },
     {
       "id": "https://ror.org/021nxhr62",
@@ -465,11 +493,11 @@
           "schema_agency": "https://ror.org"
         }
       ],
+      "meta_type": "dlco:Agent",
       "name": "US National Science Foundation",
       "same_as": [
         "https://www.nsf.org"
-      ],
-      "type": "dlco:Agent"
+      ]
     },
     {
       "id": "https://ror.org/04pz7b180",
@@ -479,17 +507,17 @@
           "schema_agency": "https://ror.org"
         }
       ],
+      "meta_type": "dlco:Organization",
       "name": "Federal Ministry of Education and Research",
       "same_as": [
         "https://www.bmbf.de"
       ],
-      "type": "dlco:Organization",
       "address": "Kapelle-Ufer 1, D-10117 Berlin, Germany"
     },
     {
       "id": "https://www.ncn.gov.pl",
-      "name": "National Science Center Poland",
-      "type": "dlco:Organization"
+      "meta_type": "dlco:Organization",
+      "name": "National Science Center Poland"
     },
     {
       "id": "https://ror.org/03dsk4d59",
@@ -499,8 +527,8 @@
           "schema_agency": "https://ror.org"
         }
       ],
-      "name": "Springer Nature (United Kingdom)",
-      "type": "dlco:Organization"
+      "meta_type": "dlco:Organization",
+      "name": "Springer Nature (United Kingdom)"
     }
   ],
   "address": "Scientific Data 9:80",

--- a/src/examples/data-distribution/Publication-std.json
+++ b/src/examples/data-distribution/Publication-std.json
@@ -1,0 +1,512 @@
+{
+  "id": "https://doi.org/10.1038/s41597-022-01163-2",
+  "description": "Large-scale datasets present unique opportunities to perform scientific investigations with unprecedented breadth. However, they also pose considerable challenges for the findability, accessibility, interoperability, and reusability (FAIR) of research outcomes due to infrastructure limitations, data usage constraints, or software license restrictions. Here we introduce a DataLad-based, domain-agnostic framework suitable for reproducible data processing in compliance with open science mandates. The framework attempts to minimize platform idiosyncrasies and performance-related complexities. It affords the capture of machine-actionable computational provenance records that can be used to retrace and verify the origins of research outcomes, as well as be re-executed independent of the original computing infrastructure. We demonstrate the framework’s performance using two showcases: one highlighting data sharing and transparency (using the studyforrest.org dataset) and another highlighting scalability (using the largest public brain imaging dataset available: the UK Biobank dataset).",
+  "identifier": [
+    {
+      "notation": "10.1038/s41597-022-01163-2",
+      "schema_agency": "https://doi.org"
+    }
+  ],
+  "is_about": [
+    "https://www.nature.com/subjects/data-processing",
+    "https://www.nature.com/subjects/data-publication-and-archiving",
+    "https://www.nature.com/subjects/software"
+  ],
+  "same_as": [
+    "https://www.nature.com/articles/s41597-022-01163-2"
+  ],
+  "title": "FAIRly big: A framework for computationally reproducible processing of large-scale data",
+  "type": "dlco:Publication",
+  "qualified_attribution": [
+    {
+      "had_role": [
+        "marcrel:aut",
+        "obo:NCIT_C25461",
+        "obo:MS_1002034",
+        "marcrel:ccp"
+      ],
+      "agent": "http://orcid.org/0000-0003-2917-3450"
+    },
+    {
+      "had_role": [
+        "marcrel:aut",
+        "obo:MS_1002034",
+        "marcrel:ccp"
+      ],
+      "agent": "http://orcid.org/0000-0003-2213-7465"
+    },
+    {
+      "had_role": [
+        "marcrel:aut",
+        "obo:MS_1002034",
+        "marcrel:ccp"
+      ],
+      "agent": "http://orcid.org/0000-0003-0820-2662"
+    },
+    {
+      "had_role": [
+        "marcrel:aut",
+        "marcrel:ccp"
+      ],
+      "agent": "http://orcid.org/0000-0001-7163-3110"
+    },
+    {
+      "had_role": [
+        "marcrel:aut",
+        "marcrel:ccp"
+      ],
+      "agent": "http://orcid.org/0000-0002-8402-6173"
+    },
+    {
+      "had_role": [
+        "marcrel:aut",
+        "marcrel:ccp"
+      ],
+      "agent": "http://orcid.org/0000-0001-7628-0801"
+    },
+    {
+      "had_role": [
+        "marcrel:aut"
+      ],
+      "agent": "https://www.nature.com/articles/s41597-022-01163-2#auth-Simon_B_-Eickhoff-Aff1-Aff3"
+    },
+    {
+      "had_role": [
+        "marcrel:aut",
+        "marcrel:ccp",
+        "obo:MS_1002035"
+      ],
+      "agent": "http://orcid.org/0000-0001-6398-6370"
+    },
+    {
+      "had_role": [
+        "marcrel:sht"
+      ],
+      "agent": "https://ror.org/02nv7yv05"
+    },
+    {
+      "had_role": [
+        "marcrel:sht"
+      ],
+      "agent": "https://ror.org/04waf7p94"
+    },
+    {
+      "had_role": [
+        "marcrel:sht"
+      ],
+      "agent": "https://ror.org/024z2rq82"
+    },
+    {
+      "had_role": [
+        "obo:NCIT_C16493"
+      ],
+      "agent": "https://ror.org/02frzq211"
+    },
+    {
+      "had_role": [
+        "marcrel:fnd"
+      ],
+      "agent": "https://ror.org/04pz7b180"
+    },
+    {
+      "had_role": [
+        "marcrel:fnd"
+      ],
+      "agent": "https://ror.org/00k4n6c32"
+    },
+    {
+      "had_role": [
+        "marcrel:fnd"
+      ],
+      "agent": "https://ror.org/021nxhr62"
+    },
+    {
+      "had_role": [
+        "marcrel:fnd"
+      ],
+      "agent": "https://www.ncn.gov.pl"
+    },
+    {
+      "had_role": [
+        "marcrel:pbl"
+      ],
+      "agent": "https://ror.org/03dsk4d59"
+    }
+  ],
+  "qualified_relation": [
+    {
+      "had_role": [
+        "http://id.loc.gov/vocabulary/relators/prp"
+      ],
+      "entity": "https://portal.issn.org/resource/issn/2052-4463"
+    },
+    {
+      "had_role": [
+        "schema:funding"
+      ],
+      "entity": "thisds:#grant_bmbf01GQ1905"
+    },
+    {
+      "had_role": [
+        "schema:funding"
+      ],
+      "entity": "thisds:#grant_bmbf01GQ1411"
+    },
+    {
+      "had_role": [
+        "schema:funding"
+      ],
+      "entity": "thisds:#grant_nsc"
+    },
+    {
+      "had_role": [
+        "schema:funding"
+      ],
+      "entity": "thisds:#grant_nsf1429999"
+    },
+    {
+      "had_role": [
+        "schema:funding"
+      ],
+      "entity": "thisds:#grant_nsf1912266"
+    },
+    {
+      "had_role": [
+        "schema:funding"
+      ],
+      "entity": "https://cordis.europa.eu/project/id/826421"
+    },
+    {
+      "had_role": [
+        "schema:funding"
+      ],
+      "entity": "https://cordis.europa.eu/project/id/945539"
+    }
+  ],
+  "relation": [
+    {
+      "id": "https://cordis.europa.eu/project/id/945539",
+      "identifier": [
+        {
+          "notation": "945539",
+          "schema_agency": "https://cordis.europa.eu"
+        }
+      ],
+      "name": "HBP SGA3",
+      "title": "Human Brain Project Specific Grant Agreement 3",
+      "type": "dlco:Grant",
+      "cites_as_authority": "https://cordis.europa.eu/project/id/945539"
+    },
+    {
+      "id": "https://cordis.europa.eu/project/id/826421",
+      "identifier": [
+        {
+          "notation": "826421",
+          "schema_agency": "https://cordis.europa.eu"
+        }
+      ],
+      "name": "VirtualBrainCloud",
+      "title": "Personalized Recommendations for Neurodegenerative Disease",
+      "type": "dlco:Grant",
+      "cites_as_authority": "https://cordis.europa.eu/project/id/826421"
+    },
+    {
+      "id": "thisds:#grant_nsf1912266",
+      "identifier": [
+        {
+          "notation": "1912266",
+          "schema_agency": "https://ror.org/021nxhr62"
+        }
+      ],
+      "title": "Collaborative Proposal: CRCNS US-German Data Sharing Proposal: DataLad - a decentralized system for integrated discovery, management, and publication of digital objects of science",
+      "type": "dlco:Grant",
+      "cites_as_authority": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=1912266"
+    },
+    {
+      "id": "thisds:#grant_nsf1429999",
+      "identifier": [
+        {
+          "notation": "1429999",
+          "schema_agency": "https://ror.org/021nxhr62"
+        }
+      ],
+      "title": "CRCNS US-German Data Sharing: DataGit - converging catalogues, warehouses, and deployment logistics into a federated 'data distribution'",
+      "type": "dlco:Grant",
+      "cites_as_authority": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=1429999"
+    },
+    {
+      "id": "thisds:#grant_nsc",
+      "identifier": [
+        {
+          "notation": "2018/28/T/HS6/00507",
+          "schema_agency": "https://www.ncn.gov.pl"
+        }
+      ],
+      "name": "ETIUDA",
+      "type": "dlco:Grant"
+    },
+    {
+      "id": "thisds:#grant_bmbf01GQ1411",
+      "identifier": [
+        {
+          "notation": "01GQ1411",
+          "schema_agency": "https://www.bmbf.de"
+        }
+      ],
+      "title": "Datagit - Kombination von Katalogen, Datenbanken und Verteilungslogistik in eine Daten-Distribution",
+      "type": "dlco:Grant"
+    },
+    {
+      "id": "thisds:#grant_bmbf01GQ1905",
+      "identifier": [
+        {
+          "notation": "01GQ1905",
+          "schema_agency": "https://www.bmbf.de"
+        }
+      ],
+      "name": "METALAD",
+      "title": "DataLad - ein dezentrales System für Forschungsdatenverwaltung, -publikation und -suche",
+      "type": "dlco:Grant"
+    },
+    {
+      "id": "https://portal.issn.org/resource/issn/2052-4463",
+      "identifier": [
+        {
+          "notation": "2052-4463",
+          "schema_agency": "https://portal.issn.org"
+        }
+      ],
+      "is_about": [
+        "obo:NCIT_C93226"
+      ],
+      "same_as": [
+        "https://www.nature.com/sdata"
+      ],
+      "title": "Scientific data",
+      "type": "dlco:Entity"
+    }
+  ],
+  "was_attributed_to": [
+    {
+      "id": "http://orcid.org/0000-0003-2917-3450",
+      "identifier": [
+        {
+          "notation": "0000-0003-2917-3450",
+          "schema_agency": "http://orcid.org"
+        }
+      ],
+      "name": "Adina S. Wagner",
+      "type": "dlco:ResearchContributor",
+      "email": "adina.wagner@t-online.de",
+      "affiliation": [
+        "https://ror.org/02nv7yv05"
+      ]
+    },
+    {
+      "id": "http://orcid.org/0000-0003-2213-7465",
+      "identifier": [
+        {
+          "notation": "0000-0003-2213-7465",
+          "schema_agency": "http://orcid.org"
+        }
+      ],
+      "name": "Laura K. Waite",
+      "type": "dlco:ResearchContributor",
+      "affiliation": [
+        "https://ror.org/02nv7yv05"
+      ]
+    },
+    {
+      "id": "http://orcid.org/0000-0003-0820-2662",
+      "identifier": [
+        {
+          "notation": "0000-0003-0820-2662",
+          "schema_agency": "http://orcid.org"
+        }
+      ],
+      "name": "Małgorzata Wierzba",
+      "type": "dlco:ResearchContributor",
+      "affiliation": [
+        "https://ror.org/04waf7p94"
+      ]
+    },
+    {
+      "id": "http://orcid.org/0000-0001-7163-3110",
+      "identifier": [
+        {
+          "notation": "0000-0001-7163-3110",
+          "schema_agency": "http://orcid.org"
+        }
+      ],
+      "name": "Felix Hoffstaedter",
+      "type": "dlco:ResearchContributor",
+      "affiliation": [
+        "https://ror.org/02nv7yv05"
+      ]
+    },
+    {
+      "id": "http://orcid.org/0000-0002-8402-6173",
+      "identifier": [
+        {
+          "notation": "0000-0002-8402-6173",
+          "schema_agency": "http://orcid.org"
+        }
+      ],
+      "name": "Alexander Q. Waite",
+      "type": "dlco:ResearchContributor",
+      "affiliation": [
+        "https://ror.org/02nv7yv05"
+      ]
+    },
+    {
+      "id": "http://orcid.org/0000-0001-7628-0801",
+      "identifier": [
+        {
+          "notation": "0000-0001-7628-0801",
+          "schema_agency": "http://orcid.org"
+        }
+      ],
+      "name": "Benjamin Poldrack",
+      "type": "dlco:ResearchContributor",
+      "affiliation": [
+        "https://ror.org/02nv7yv05"
+      ]
+    },
+    {
+      "id": "https://www.nature.com/articles/s41597-022-01163-2#auth-Simon_B_-Eickhoff-Aff1-Aff3",
+      "name": "Simon B. Eickhoff",
+      "same_as": [
+        "https://scholar.google.com/citations?user=wjpISMAAAAAJ"
+      ],
+      "type": "dlco:ResearchContributor",
+      "affiliation": [
+        "https://ror.org/02nv7yv05",
+        "https://ror.org/024z2rq82"
+      ]
+    },
+    {
+      "id": "http://orcid.org/0000-0001-6398-6370",
+      "identifier": [
+        {
+          "notation": "0000-0001-6398-6370",
+          "schema_agency": "http://orcid.org"
+        }
+      ],
+      "name": "Michael Hanke",
+      "type": "dlco:ResearchContributor",
+      "affiliation": [
+        "https://ror.org/02nv7yv05",
+        "https://ror.org/024z2rq82"
+      ]
+    },
+    {
+      "id": "https://ror.org/02nv7yv05",
+      "identifier": [
+        {
+          "notation": "02nv7yv05",
+          "schema_agency": "https://ror.org"
+        }
+      ],
+      "name": "FZJ-INM7",
+      "title": "Institute of Neuroscience and Medicine, Brain & Behaviour (INM-7), Research Center Jülich, Jülich, Germany",
+      "type": "dlco:Organization"
+    },
+    {
+      "id": "https://ror.org/024z2rq82",
+      "identifier": [
+        {
+          "notation": "024z2rq82",
+          "schema_agency": "https://ror.org"
+        }
+      ],
+      "name": "HHU-ISN",
+      "title": "Institute of Systems Neuroscience, Medical Faculty, Heinrich Heine University Düsseldorf, Düsseldorf, Germany",
+      "type": "dlco:Organization"
+    },
+    {
+      "id": "https://ror.org/04waf7p94",
+      "identifier": [
+        {
+          "notation": "04waf7p94",
+          "schema_agency": "https://ror.org"
+        }
+      ],
+      "name": "Nencki",
+      "title": "Laboratory of Brain Imaging, Nencki Institute of Experimental Biology, Polish Academy of Sciences, Warsaw, Poland",
+      "type": "dlco:Organization"
+    },
+    {
+      "id": "https://ror.org/02frzq211",
+      "identifier": [
+        {
+          "notation": "02frzq211",
+          "schema_agency": "https://ror.org"
+        }
+      ],
+      "name": "UK Biobank",
+      "type": "dlco:Organization"
+    },
+    {
+      "id": "https://ror.org/00k4n6c32",
+      "identifier": [
+        {
+          "notation": "00k4n6c32",
+          "schema_agency": "https://ror.org"
+        }
+      ],
+      "name": "European Commission",
+      "type": "dlco:Organization"
+    },
+    {
+      "id": "https://ror.org/021nxhr62",
+      "identifier": [
+        {
+          "notation": "021nxhr62",
+          "schema_agency": "https://ror.org"
+        }
+      ],
+      "name": "US National Science Foundation",
+      "same_as": [
+        "https://www.nsf.org"
+      ],
+      "type": "dlco:Agent"
+    },
+    {
+      "id": "https://ror.org/04pz7b180",
+      "identifier": [
+        {
+          "notation": "04pz7b180",
+          "schema_agency": "https://ror.org"
+        }
+      ],
+      "name": "Federal Ministry of Education and Research",
+      "same_as": [
+        "https://www.bmbf.de"
+      ],
+      "type": "dlco:Organization",
+      "address": "Kapelle-Ufer 1, D-10117 Berlin, Germany"
+    },
+    {
+      "id": "https://www.ncn.gov.pl",
+      "name": "National Science Center Poland",
+      "type": "dlco:Organization"
+    },
+    {
+      "id": "https://ror.org/03dsk4d59",
+      "identifier": [
+        {
+          "notation": "03dsk4d59",
+          "schema_agency": "https://ror.org"
+        }
+      ],
+      "name": "Springer Nature (United Kingdom)",
+      "type": "dlco:Organization"
+    }
+  ],
+  "address": "Scientific Data 9:80",
+  "date_modified": "2022-02-11",
+  "date_published": "2022-03-11",
+  "license": "licenses:CC-BY-4.0",
+  "notation": "Wagner, A.S., Waite, L.K., Wierzba, M. et al. FAIRly big: A framework for computationally reproducible processing of large-scale data. Sci Data 9, 80 (2022).",
+  "@type": "Publication"
+}

--- a/src/examples/data-distribution/Publication-std.yaml
+++ b/src/examples/data-distribution/Publication-std.yaml
@@ -17,6 +17,21 @@ is_about:
 license: licenses:CC-BY-4.0
 same_as:
   - https://www.nature.com/articles/s41597-022-01163-2
+# custom properties can be used to arbitrarily (and possibly redundantly)
+# detail the publication record for better fit with specialized consumers
+property:
+  - type: bibo:doi
+    name: DOI
+    value: https://doi.org/10.1038/s41597-022-01163-2
+  - type: bibo:volume
+    name: Volume
+    value: 9
+  - type: bibo:number
+    name: Document number
+    value: 80
+  - type: bibo:numPages
+    name: Number of pages
+    value: 17
 
 # related entities
 relation:

--- a/src/examples/data-distribution/Publication-std.yaml
+++ b/src/examples/data-distribution/Publication-std.yaml
@@ -21,7 +21,7 @@ same_as:
 # related entities
 relation:
   - id: https://cordis.europa.eu/project/id/945539
-    type: dlco:Grant
+    meta_type: dlco:Grant
     name: HBP SGA3
     title: Human Brain Project Specific Grant Agreement 3
     identifier:
@@ -29,7 +29,7 @@ relation:
         schema_agency: https://cordis.europa.eu
     cites_as_authority: https://cordis.europa.eu/project/id/945539
   - id: https://cordis.europa.eu/project/id/826421
-    type: dlco:Grant
+    meta_type: dlco:Grant
     name: VirtualBrainCloud
     title: Personalized Recommendations for Neurodegenerative Disease
     identifier:
@@ -37,7 +37,7 @@ relation:
         schema_agency: https://cordis.europa.eu
     cites_as_authority: https://cordis.europa.eu/project/id/826421
   - id: thisds:#grant_nsf1912266
-    type: dlco:Grant
+    meta_type: dlco:Grant
     title: "Collaborative Proposal: CRCNS US-German Data Sharing Proposal: DataLad - a decentralized system for integrated discovery, management, and publication of digital objects of science"
     identifier:
       - notation: "1912266"
@@ -45,42 +45,39 @@ relation:
         schema_agency: https://ror.org/021nxhr62
     cites_as_authority: https://www.nsf.gov/awardsearch/showAward?AWD_ID=1912266
   - id: thisds:#grant_nsf1429999
-    type: dlco:Grant
+    meta_type: dlco:Grant
     title: "CRCNS US-German Data Sharing: DataGit - converging catalogues, warehouses, and deployment logistics into a federated 'data distribution'"
     identifier:
       - notation: "1429999"
         schema_agency: https://ror.org/021nxhr62
     cites_as_authority: https://www.nsf.gov/awardsearch/showAward?AWD_ID=1429999
   - id: thisds:#grant_nsc
-    type: dlco:Grant
+    meta_type: dlco:Grant
     name: ETIUDA
     identifier:
       - notation: 2018/28/T/HS6/00507
         schema_agency: https://www.ncn.gov.pl
   - id: thisds:#grant_bmbf01GQ1411
-    type: dlco:Grant
+    meta_type: dlco:Grant
     title: Datagit - Kombination von Katalogen, Datenbanken und Verteilungslogistik in eine Daten-Distribution
     identifier:
       - notation: 01GQ1411
         schema_agency: https://www.bmbf.de
   - id: thisds:#grant_bmbf01GQ1905
-    type: dlco:Grant
+    meta_type: dlco:Grant
     name: METALAD
     title: DataLad - ein dezentrales System für Forschungsdatenverwaltung, -publikation und -suche
     identifier:
       - notation: 01GQ1905
         schema_agency: https://www.bmbf.de
   - id: https://portal.issn.org/resource/issn/2052-4463
-    # TODO this is a type declaration for technical/schema-related reasons
-    # this should really by used for what is_about used for below
-    type: dlco:Entity
+    meta_type: dlco:Entity
+    # peer-reviewed scientific journal
+    type: obo:NCIT_C93226
     title: Scientific data
     identifier:
       - notation: 2052-4463
         schema_agency: https://portal.issn.org
-    is_about:
-      # peer-reviewed scientific journal
-      - obo:NCIT_C93226
     same_as:
       - https://www.nature.com/sdata
 
@@ -117,7 +114,7 @@ qualified_relation:
 was_attributed_to:
   # authors
   - id: http://orcid.org/0000-0003-2917-3450
-    type: dlco:ResearchContributor
+    meta_type: dlco:ResearchContributor
     name: Adina S. Wagner
     email: adina.wagner@t-online.de
     identifier:
@@ -126,7 +123,7 @@ was_attributed_to:
     affiliation:
       - https://ror.org/02nv7yv05
   - id: http://orcid.org/0000-0003-2213-7465
-    type: dlco:ResearchContributor
+    meta_type: dlco:ResearchContributor
     name: Laura K. Waite
     identifier:
       - notation: 0000-0003-2213-7465
@@ -134,7 +131,7 @@ was_attributed_to:
     affiliation:
       - https://ror.org/02nv7yv05
   - id: http://orcid.org/0000-0003-0820-2662
-    type: dlco:ResearchContributor
+    meta_type: dlco:ResearchContributor
     name: Małgorzata Wierzba
     identifier:
       - notation: 0000-0003-0820-2662
@@ -142,7 +139,7 @@ was_attributed_to:
     affiliation:
       - https://ror.org/04waf7p94
   - id: http://orcid.org/0000-0001-7163-3110
-    type: dlco:ResearchContributor
+    meta_type: dlco:ResearchContributor
     name: Felix Hoffstaedter
     identifier:
       - notation: 0000-0001-7163-3110
@@ -150,7 +147,7 @@ was_attributed_to:
     affiliation:
       - https://ror.org/02nv7yv05
   - id: http://orcid.org/0000-0002-8402-6173
-    type: dlco:ResearchContributor
+    meta_type: dlco:ResearchContributor
     name: Alexander Q. Waite
     identifier:
       - notation: 0000-0002-8402-6173
@@ -158,7 +155,7 @@ was_attributed_to:
     affiliation:
       - https://ror.org/02nv7yv05
   - id: http://orcid.org/0000-0001-7628-0801
-    type: dlco:ResearchContributor
+    meta_type: dlco:ResearchContributor
     name: Benjamin Poldrack
     identifier:
       - notation: 0000-0001-7628-0801
@@ -167,7 +164,7 @@ was_attributed_to:
       - https://ror.org/02nv7yv05
   # identifier is publication scope, taken from publisher website
   - id: https://www.nature.com/articles/s41597-022-01163-2#auth-Simon_B_-Eickhoff-Aff1-Aff3
-    type: dlco:ResearchContributor
+    meta_type: dlco:ResearchContributor
     name: Simon B. Eickhoff
     affiliation:
       - https://ror.org/02nv7yv05
@@ -175,7 +172,7 @@ was_attributed_to:
     same_as:
       - https://scholar.google.com/citations?user=wjpISMAAAAAJ
   - id: http://orcid.org/0000-0001-6398-6370
-    type: dlco:ResearchContributor
+    meta_type: dlco:ResearchContributor
     name: Michael Hanke
     identifier:
       - notation: 0000-0001-6398-6370
@@ -186,21 +183,21 @@ was_attributed_to:
 
   # author institutions
   - id: https://ror.org/02nv7yv05
-    type: dlco:Organization
+    meta_type: dlco:Organization
     name: FZJ-INM7
     title: Institute of Neuroscience and Medicine, Brain & Behaviour (INM-7), Research Center Jülich, Jülich, Germany
     identifier:
       - notation: 02nv7yv05
         schema_agency: https://ror.org
   - id: https://ror.org/024z2rq82
-    type: dlco:Organization
+    meta_type: dlco:Organization
     name: HHU-ISN
     title: Institute of Systems Neuroscience, Medical Faculty, Heinrich Heine University Düsseldorf, Düsseldorf, Germany
     identifier:
       - notation: 024z2rq82
         schema_agency: https://ror.org
   - id: https://ror.org/04waf7p94
-    type: dlco:Organization
+    meta_type: dlco:Organization
     name: Nencki
     title: Laboratory of Brain Imaging, Nencki Institute of Experimental Biology, Polish Academy of Sciences, Warsaw, Poland
     identifier:
@@ -209,7 +206,7 @@ was_attributed_to:
 
   # data provider
   - id: https://ror.org/02frzq211
-    type: dlco:Organization
+    meta_type: dlco:Organization
     name: UK Biobank
     identifier:
       - notation: 02frzq211
@@ -217,7 +214,7 @@ was_attributed_to:
 
   # funder
   - id: https://ror.org/00k4n6c32
-    type: dlco:Organization
+    meta_type: dlco:Organization
     name: European Commission
     identifier:
       - notation: 00k4n6c32
@@ -230,7 +227,7 @@ was_attributed_to:
     same_as:
       - https://www.nsf.org
   - id: https://ror.org/04pz7b180
-    type: dlco:Organization
+    meta_type: dlco:Organization
     name: Federal Ministry of Education and Research
     address: Kapelle-Ufer 1, D-10117 Berlin, Germany
     identifier:
@@ -239,12 +236,12 @@ was_attributed_to:
     same_as:
       - https://www.bmbf.de
   - id: https://www.ncn.gov.pl
-    type: dlco:Organization
+    meta_type: dlco:Organization
     name: National Science Center Poland
 
   # publisher
   - id: https://ror.org/03dsk4d59
-    type: dlco:Organization
+    meta_type: dlco:Organization
     name: Springer Nature (United Kingdom)
     identifier:
       - notation: 03dsk4d59

--- a/src/examples/data-distribution/Publication-std.yaml
+++ b/src/examples/data-distribution/Publication-std.yaml
@@ -1,0 +1,344 @@
+id: https://doi.org/10.1038/s41597-022-01163-2
+title: "FAIRly big: A framework for computationally reproducible processing of large-scale data"
+address: "Scientific Data 9:80"
+date_modified: "2022-02-11"
+date_published: "2022-03-11"
+notation:
+  "Wagner, A.S., Waite, L.K., Wierzba, M. et al. FAIRly big: A framework for computationally reproducible processing of large-scale data. Sci Data 9, 80 (2022)."
+description:
+  "Large-scale datasets present unique opportunities to perform scientific investigations with unprecedented breadth. However, they also pose considerable challenges for the findability, accessibility, interoperability, and reusability (FAIR) of research outcomes due to infrastructure limitations, data usage constraints, or software license restrictions. Here we introduce a DataLad-based, domain-agnostic framework suitable for reproducible data processing in compliance with open science mandates. The framework attempts to minimize platform idiosyncrasies and performance-related complexities. It affords the capture of machine-actionable computational provenance records that can be used to retrace and verify the origins of research outcomes, as well as be re-executed independent of the original computing infrastructure. We demonstrate the framework’s performance using two showcases: one highlighting data sharing and transparency (using the studyforrest.org dataset) and another highlighting scalability (using the largest public brain imaging dataset available: the UK Biobank dataset)."
+identifier:
+  - notation: 10.1038/s41597-022-01163-2
+    schema_agency: https://doi.org
+is_about:
+  - https://www.nature.com/subjects/data-processing
+  - https://www.nature.com/subjects/data-publication-and-archiving
+  - https://www.nature.com/subjects/software
+license: licenses:CC-BY-4.0
+same_as:
+  - https://www.nature.com/articles/s41597-022-01163-2
+
+# related entities
+relation:
+  - id: https://cordis.europa.eu/project/id/945539
+    type: dlco:Grant
+    name: HBP SGA3
+    title: Human Brain Project Specific Grant Agreement 3
+    identifier:
+      - notation: "945539"
+        schema_agency: https://cordis.europa.eu
+    cites_as_authority: https://cordis.europa.eu/project/id/945539
+  - id: https://cordis.europa.eu/project/id/826421
+    type: dlco:Grant
+    name: VirtualBrainCloud
+    title: Personalized Recommendations for Neurodegenerative Disease
+    identifier:
+      - notation: "826421"
+        schema_agency: https://cordis.europa.eu
+    cites_as_authority: https://cordis.europa.eu/project/id/826421
+  - id: thisds:#grant_nsf1912266
+    type: dlco:Grant
+    title: "Collaborative Proposal: CRCNS US-German Data Sharing Proposal: DataLad - a decentralized system for integrated discovery, management, and publication of digital objects of science"
+    identifier:
+      - notation: "1912266"
+        # NSF
+        schema_agency: https://ror.org/021nxhr62
+    cites_as_authority: https://www.nsf.gov/awardsearch/showAward?AWD_ID=1912266
+  - id: thisds:#grant_nsf1429999
+    type: dlco:Grant
+    title: "CRCNS US-German Data Sharing: DataGit - converging catalogues, warehouses, and deployment logistics into a federated 'data distribution'"
+    identifier:
+      - notation: "1429999"
+        schema_agency: https://ror.org/021nxhr62
+    cites_as_authority: https://www.nsf.gov/awardsearch/showAward?AWD_ID=1429999
+  - id: thisds:#grant_nsc
+    type: dlco:Grant
+    name: ETIUDA
+    identifier:
+      - notation: 2018/28/T/HS6/00507
+        schema_agency: https://www.ncn.gov.pl
+  - id: thisds:#grant_bmbf01GQ1411
+    type: dlco:Grant
+    title: Datagit - Kombination von Katalogen, Datenbanken und Verteilungslogistik in eine Daten-Distribution
+    identifier:
+      - notation: 01GQ1411
+        schema_agency: https://www.bmbf.de
+  - id: thisds:#grant_bmbf01GQ1905
+    type: dlco:Grant
+    name: METALAD
+    title: DataLad - ein dezentrales System für Forschungsdatenverwaltung, -publikation und -suche
+    identifier:
+      - notation: 01GQ1905
+        schema_agency: https://www.bmbf.de
+  - id: https://portal.issn.org/resource/issn/2052-4463
+    # TODO this is a type declaration for technical/schema-related reasons
+    # this should really by used for what is_about used for below
+    type: dlco:Entity
+    title: Scientific data
+    identifier:
+      - notation: 2052-4463
+        schema_agency: https://portal.issn.org
+    is_about:
+      # peer-reviewed scientific journal
+      - obo:NCIT_C93226
+    same_as:
+      - https://www.nature.com/sdata
+
+# entity roles
+qualified_relation:
+  # publication place: journal scientific data
+  - entity: https://portal.issn.org/resource/issn/2052-4463
+    had_role:
+      - http://id.loc.gov/vocabulary/relators/prp
+  # grants that funded the work
+  - entity: thisds:#grant_bmbf01GQ1905
+    had_role:
+      - schema:funding
+  - entity: thisds:#grant_bmbf01GQ1411
+    had_role:
+      - schema:funding
+  - entity: thisds:#grant_nsc
+    had_role:
+      - schema:funding
+  - entity: thisds:#grant_nsf1429999
+    had_role:
+      - schema:funding
+  - entity: thisds:#grant_nsf1912266
+    had_role:
+      - schema:funding
+  - entity: https://cordis.europa.eu/project/id/826421
+    had_role:
+      - schema:funding
+  - entity: https://cordis.europa.eu/project/id/945539
+    had_role:
+      - schema:funding
+
+# related agents
+was_attributed_to:
+  # authors
+  - id: http://orcid.org/0000-0003-2917-3450
+    type: dlco:ResearchContributor
+    name: Adina S. Wagner
+    email: adina.wagner@t-online.de
+    identifier:
+      - notation: 0000-0003-2917-3450
+        schema_agency: http://orcid.org
+    affiliation:
+      - https://ror.org/02nv7yv05
+  - id: http://orcid.org/0000-0003-2213-7465
+    type: dlco:ResearchContributor
+    name: Laura K. Waite
+    identifier:
+      - notation: 0000-0003-2213-7465
+        schema_agency: http://orcid.org
+    affiliation:
+      - https://ror.org/02nv7yv05
+  - id: http://orcid.org/0000-0003-0820-2662
+    type: dlco:ResearchContributor
+    name: Małgorzata Wierzba
+    identifier:
+      - notation: 0000-0003-0820-2662
+        schema_agency: http://orcid.org
+    affiliation:
+      - https://ror.org/04waf7p94
+  - id: http://orcid.org/0000-0001-7163-3110
+    type: dlco:ResearchContributor
+    name: Felix Hoffstaedter
+    identifier:
+      - notation: 0000-0001-7163-3110
+        schema_agency: http://orcid.org
+    affiliation:
+      - https://ror.org/02nv7yv05
+  - id: http://orcid.org/0000-0002-8402-6173
+    type: dlco:ResearchContributor
+    name: Alexander Q. Waite
+    identifier:
+      - notation: 0000-0002-8402-6173
+        schema_agency: http://orcid.org
+    affiliation:
+      - https://ror.org/02nv7yv05
+  - id: http://orcid.org/0000-0001-7628-0801
+    type: dlco:ResearchContributor
+    name: Benjamin Poldrack
+    identifier:
+      - notation: 0000-0001-7628-0801
+        schema_agency: http://orcid.org
+    affiliation:
+      - https://ror.org/02nv7yv05
+  # identifier is publication scope, taken from publisher website
+  - id: https://www.nature.com/articles/s41597-022-01163-2#auth-Simon_B_-Eickhoff-Aff1-Aff3
+    type: dlco:ResearchContributor
+    name: Simon B. Eickhoff
+    affiliation:
+      - https://ror.org/02nv7yv05
+      - https://ror.org/024z2rq82
+    same_as:
+      - https://scholar.google.com/citations?user=wjpISMAAAAAJ
+  - id: http://orcid.org/0000-0001-6398-6370
+    type: dlco:ResearchContributor
+    name: Michael Hanke
+    identifier:
+      - notation: 0000-0001-6398-6370
+        schema_agency: http://orcid.org
+    affiliation:
+      - https://ror.org/02nv7yv05
+      - https://ror.org/024z2rq82
+
+  # author institutions
+  - id: https://ror.org/02nv7yv05
+    type: dlco:Organization
+    name: FZJ-INM7
+    title: Institute of Neuroscience and Medicine, Brain & Behaviour (INM-7), Research Center Jülich, Jülich, Germany
+    identifier:
+      - notation: 02nv7yv05
+        schema_agency: https://ror.org
+  - id: https://ror.org/024z2rq82
+    type: dlco:Organization
+    name: HHU-ISN
+    title: Institute of Systems Neuroscience, Medical Faculty, Heinrich Heine University Düsseldorf, Düsseldorf, Germany
+    identifier:
+      - notation: 024z2rq82
+        schema_agency: https://ror.org
+  - id: https://ror.org/04waf7p94
+    type: dlco:Organization
+    name: Nencki
+    title: Laboratory of Brain Imaging, Nencki Institute of Experimental Biology, Polish Academy of Sciences, Warsaw, Poland
+    identifier:
+      - notation: 04waf7p94
+        schema_agency: https://ror.org
+
+  # data provider
+  - id: https://ror.org/02frzq211
+    type: dlco:Organization
+    name: UK Biobank
+    identifier:
+      - notation: 02frzq211
+        schema_agency: https://ror.org
+
+  # funder
+  - id: https://ror.org/00k4n6c32
+    type: dlco:Organization
+    name: European Commission
+    identifier:
+      - notation: 00k4n6c32
+        schema_agency: https://ror.org
+  - id: https://ror.org/021nxhr62
+    name: US National Science Foundation
+    identifier:
+      - notation: 021nxhr62
+        schema_agency: https://ror.org
+    same_as:
+      - https://www.nsf.org
+  - id: https://ror.org/04pz7b180
+    type: dlco:Organization
+    name: Federal Ministry of Education and Research
+    address: Kapelle-Ufer 1, D-10117 Berlin, Germany
+    identifier:
+      - notation: 04pz7b180
+        schema_agency: https://ror.org
+    same_as:
+      - https://www.bmbf.de
+  - id: https://www.ncn.gov.pl
+    type: dlco:Organization
+    name: National Science Center Poland
+
+  # publisher
+  - id: https://ror.org/03dsk4d59
+    type: dlco:Organization
+    name: Springer Nature (United Kingdom)
+    identifier:
+      - notation: 03dsk4d59
+        schema_agency: https://ror.org
+
+# agent roles
+qualified_attribution:
+  # adina
+  - agent: http://orcid.org/0000-0003-2917-3450
+    had_role:
+      # author
+      - marcrel:aut
+      # contact person
+      - obo:NCIT_C25461
+      # first author
+      - obo:MS_1002034
+      # conceptor
+      - marcrel:ccp
+  # laura
+  - agent: http://orcid.org/0000-0003-2213-7465
+    had_role:
+      - marcrel:aut
+      - obo:MS_1002034
+      - marcrel:ccp
+  # małgorzata
+  - agent: http://orcid.org/0000-0003-0820-2662
+    had_role:
+      - marcrel:aut
+      - obo:MS_1002034
+      - marcrel:ccp
+  # felix
+  - agent: http://orcid.org/0000-0001-7163-3110
+    had_role:
+      - marcrel:aut
+      - marcrel:ccp
+  # alex
+  - agent: http://orcid.org/0000-0002-8402-6173
+    had_role:
+      - marcrel:aut
+      - marcrel:ccp
+  # benjamin
+  - agent: http://orcid.org/0000-0001-7628-0801
+    had_role:
+      - marcrel:aut
+      - marcrel:ccp
+  # simon
+  - agent: https://www.nature.com/articles/s41597-022-01163-2#auth-Simon_B_-Eickhoff-Aff1-Aff3
+    had_role:
+      - marcrel:aut
+  # michael
+  - agent: http://orcid.org/0000-0001-6398-6370
+    had_role:
+      - marcrel:aut
+      # conceptor
+      - marcrel:ccp
+      # senior author
+      - obo:MS_1002035
+  # fzj
+  - agent: https://ror.org/02nv7yv05
+    had_role:
+      # supporting host
+      - marcrel:sht
+  # nencki
+  - agent: https://ror.org/04waf7p94
+    had_role:
+      - marcrel:sht
+  # hhu
+  - agent: https://ror.org/024z2rq82
+    had_role:
+      - marcrel:sht
+  # ukbiobank
+  - agent: https://ror.org/02frzq211
+    had_role:
+      # data source
+      - obo:NCIT_C16493
+  # bmbf
+  - agent: https://ror.org/04pz7b180
+    had_role:
+      # funder
+      - marcrel:fnd
+  # ec
+  - agent: https://ror.org/00k4n6c32
+    had_role:
+      - marcrel:fnd
+  # nsf
+  - agent: https://ror.org/021nxhr62
+    had_role:
+      - marcrel:fnd
+  # nsc
+  - agent: https://www.ncn.gov.pl
+    had_role:
+      - marcrel:fnd
+  # springer/nature
+  - agent: https://ror.org/03dsk4d59
+    had_role:
+      # publisher
+      - marcrel:pbl

--- a/src/examples/data-distribution/Resource-funding.json
+++ b/src/examples/data-distribution/Resource-funding.json
@@ -1,13 +1,6 @@
 {
   "id": "thisdsver:#",
   "type": "dlco:Resource",
-  "was_attributed_to": [
-    {
-      "id": "https://ror.org/018mejw64",
-      "name": "Deutsche Forschungsgemeinschaft",
-      "type": "dlco:Organization"
-    }
-  ],
   "qualified_relation": [
     {
       "had_role": [
@@ -22,6 +15,13 @@
       "name": "SFB1451",
       "type": "dlco:Grant",
       "sponsor": "https://ror.org/018mejw64"
+    }
+  ],
+  "was_attributed_to": [
+    {
+      "id": "https://ror.org/018mejw64",
+      "name": "Deutsche Forschungsgemeinschaft",
+      "type": "dlco:Organization"
     }
   ],
   "@type": "Resource"

--- a/src/examples/data-distribution/Resource-funding.json
+++ b/src/examples/data-distribution/Resource-funding.json
@@ -1,6 +1,6 @@
 {
   "id": "thisdsver:#",
-  "type": "dlco:Resource",
+  "meta_type": "dlco:Resource",
   "qualified_relation": [
     {
       "had_role": [
@@ -12,16 +12,16 @@
   "relation": [
     {
       "id": "https://gepris.dfg.de/gepris/projekt/431549029",
+      "meta_type": "dlco:Grant",
       "name": "SFB1451",
-      "type": "dlco:Grant",
       "sponsor": "https://ror.org/018mejw64"
     }
   ],
   "was_attributed_to": [
     {
       "id": "https://ror.org/018mejw64",
-      "name": "Deutsche Forschungsgemeinschaft",
-      "type": "dlco:Organization"
+      "meta_type": "dlco:Organization",
+      "name": "Deutsche Forschungsgemeinschaft"
     }
   ],
   "@type": "Resource"

--- a/src/examples/data-distribution/Resource-funding.yaml
+++ b/src/examples/data-distribution/Resource-funding.yaml
@@ -1,7 +1,7 @@
 id: thisdsver:#
 relation:
   - id: https://gepris.dfg.de/gepris/projekt/431549029
-    type: dlco:Grant
+    meta_type: dlco:Grant
     name: SFB1451
     sponsor: https://ror.org/018mejw64
 qualified_relation:
@@ -10,5 +10,5 @@ qualified_relation:
       - schema:funding
 was_attributed_to:
   - id:  https://ror.org/018mejw64
-    type: dlco:Organization
+    meta_type: dlco:Organization
     name: Deutsche Forschungsgemeinschaft

--- a/src/examples/dataset-version/DatasetVersionObject-datacite-nationalgallery.json
+++ b/src/examples/dataset-version/DatasetVersionObject-datacite-nationalgallery.json
@@ -113,19 +113,19 @@
     {
       "meta_type": "dlco:PublicationObject",
       "meta_code": "padfield_zenodo",
-      "citation": "\"Padfield, J. (2008, September 14). Web based presentation tools for environmental data used in The National Gallery. The 18th Annual International Association of Museum Facility Administrators (IAMFA), London. Zenodo. https://doi.org/10.5281/zenodo.7629200\"",
+      "notation": "\"Padfield, J. (2008, September 14). Web based presentation tools for environmental data used in The National Gallery. The 18th Annual International Association of Museum Facility Administrators (IAMFA), London. Zenodo. https://doi.org/10.5281/zenodo.7629200\"",
       "doi": "https://doi.org/10.5281/zenodo.7629200"
     },
     {
       "meta_type": "dlco:PublicationObject",
       "meta_code": "padfield_vandyke_carr",
-      "citation": "\"J. Padfield, S. Vandyke and D. Carr, 'Improving our Environment', published March 2013. http://www.nationalgallery.org.uk/paintings/research/improving-our-environment.\"",
+      "notation": "\"J. Padfield, S. Vandyke and D. Carr, 'Improving our Environment', published March 2013. http://www.nationalgallery.org.uk/paintings/research/improving-our-environment.\"",
       "url": "http://www.nationalgallery.org.uk/paintings/research/improving-our-environment"
     },
     {
       "meta_type": "dlco:PublicationObject",
       "meta_code": "harrison_etal",
-      "citation": "\"Lynne Harrison, Catherine Higgitt & Joseph Padfield (2018) Finding Common Ground: The Role of Preventive Conservation in Response to the Expectations of Contemporary Audiences at the National Gallery, London, Studies in Conservation, 63:sup1, 101-107, DOI: 10.1080/00393630.2018.1504449\"",
+      "notation": "\"Lynne Harrison, Catherine Higgitt & Joseph Padfield (2018) Finding Common Ground: The Role of Preventive Conservation in Response to the Expectations of Contemporary Audiences at the National Gallery, London, Studies in Conservation, 63:sup1, 101-107, DOI: 10.1080/00393630.2018.1504449\"",
       "doi": "https://doi.org/10.1080/00393630.2018.1504449"
     }
   ],

--- a/src/examples/dataset-version/DatasetVersionObject-datacite-nationalgallery.yaml
+++ b/src/examples/dataset-version/DatasetVersionObject-datacite-nationalgallery.yaml
@@ -77,7 +77,7 @@ relation:
     cites_as_authority: https://cordis.europa.eu/project/id/871034
   - meta_type: dlco:PublicationObject
     meta_code: padfield_zenodo
-    citation: >-
+    notation: >-
       "Padfield, J. (2008, September 14). Web based presentation tools
       for environmental data used in The National Gallery. The 18th Annual
       International Association of Museum Facility Administrators (IAMFA),
@@ -85,13 +85,13 @@ relation:
     doi: https://doi.org/10.5281/zenodo.7629200
   - meta_type: dlco:PublicationObject
     meta_code: padfield_vandyke_carr
-    citation: >-
+    notation: >-
       "J. Padfield, S. Vandyke and D. Carr, 'Improving our Environment', published
       March 2013. http://www.nationalgallery.org.uk/paintings/research/improving-our-environment."
     url: http://www.nationalgallery.org.uk/paintings/research/improving-our-environment
   - meta_type: dlco:PublicationObject
     meta_code: harrison_etal
-    citation: >-
+    notation: >-
       "Lynne Harrison, Catherine Higgitt & Joseph Padfield (2018) Finding Common
       Ground: The Role of Preventive Conservation in Response to the Expectations
       of Contemporary Audiences at the National Gallery, London, Studies in
@@ -99,7 +99,7 @@ relation:
     doi: https://doi.org/10.1080/00393630.2018.1504449
   # - meta_type: dlco:PublicationObject
   #   meta_code: env
-  #   citation: >-
+  #   notation: >-
   #     """
   #   url: https://research.ng-london.org.uk/scientific/env/
 qualified_relation:

--- a/src/examples/dataset-version/DatasetVersionObject-penguins.json
+++ b/src/examples/dataset-version/DatasetVersionObject-penguins.json
@@ -225,7 +225,7 @@
     {
       "meta_type": "dlco:PublicationObject",
       "meta_code": "gormanetal",
-      "citation": "'Gorman KB, Williams TD, Fraser WR (2014) Ecological Sexual Dimorphism and Environmental Variability within a Community of Antarctic Penguins (Genus Pygoscelis). PLoS ONE 9(3): e90081.'",
+      "notation": "'Gorman KB, Williams TD, Fraser WR (2014) Ecological Sexual Dimorphism and Environmental Variability within a Community of Antarctic Penguins (Genus Pygoscelis). PLoS ONE 9(3): e90081.'",
       "doi": "https://doi.org/10.1371/journal.pone.0090081"
     }
   ],

--- a/src/examples/dataset-version/DatasetVersionObject-penguins.yaml
+++ b/src/examples/dataset-version/DatasetVersionObject-penguins.yaml
@@ -103,7 +103,7 @@ relation:
     cites_as_authority: https://www.nsf.gov/awardsearch/showAward?AWD_ID=0741351
   - meta_type: dlco:PublicationObject
     meta_code: gormanetal
-    citation: >-
+    notation: >-
       'Gorman KB, Williams TD, Fraser WR (2014) Ecological Sexual Dimorphism
       and Environmental Variability within a Community of Antarctic Penguins (Genus
       Pygoscelis). PLoS ONE 9(3): e90081.'

--- a/src/linkml/ontology/projects.yaml
+++ b/src/linkml/ontology/projects.yaml
@@ -28,14 +28,6 @@ slots:
     exact_mappings:
       - schema:affiliation
 
-  citation:
-    slot_uri: dlco:citation
-    description: >-
-      TODO
-    range: string
-    exact_mappings:
-      - schema:citation
-
   cites_as_authority:
     slot_uri: dlco:cites_as_authority
     description: >-
@@ -89,7 +81,7 @@ classes:
     exact_mappings:
       - schema:Grant
     todos:
-      - We might also want to support `citation` here to support funder-recommended or funder-required citation forms.
+      - We might also want to support `notation` here to support funder-recommended or funder-required citation forms.
 
   Publication:
     class_uri: dlco:Publication
@@ -98,7 +90,7 @@ classes:
     description: >-
       TODO
     slots:
-      - citation
+      - notation
       - doi
       - url
 

--- a/src/linkml/schemas/data-distribution.yaml
+++ b/src/linkml/schemas/data-distribution.yaml
@@ -453,11 +453,21 @@ slots:
       - schema:name
     range: string
 
-  type:
-    slot_uri: RDF:type
+  meta_type:
+    slot_uri: dlco:meta_type
     designates_type: true
     description: >-
-      Type designator of a metadata object.
+      Type designator of a metadata object for validation and schema structure
+      handling purposes. This is used to indicate specialized schema classes
+      for properties that accept a hierarchy of classes as their range.
+    range: uriorcurie
+    exact_mappings:
+      - dcterms:type
+
+  type:
+    slot_uri: RDF:type
+    description: >-
+      State that the subject is an instance of a class.
     range: uriorcurie
     exact_mappings:
       - dcterms:type
@@ -516,6 +526,7 @@ classes:
       - description
       - identifier
       - is_about
+      - meta_type
       - name
       - same_as
       - title

--- a/src/linkml/schemas/data-distribution.yaml
+++ b/src/linkml/schemas/data-distribution.yaml
@@ -180,6 +180,7 @@ slots:
     description: A free-text account of the resource.
     exact_mappings:
       - dcterms:description
+      - RDFS:comment
     range: string
 
   digest:
@@ -403,6 +404,20 @@ slots:
     exact_mappings:
       - skos:notation
 
+  property:
+    slot_uri: dlco:property
+    description: >-
+      An arbitrary (extra) property that is not covered by
+      other dedicated properties.
+    range: Property
+    relational_role: PREDICATE
+
+  range:
+    slot_uri: RDFS:range
+    description: >-
+      State that the values of a property are instances a class.
+    range: uriorcurie
+
   relation:
     slot_uri: dlco:relation
     description: >-
@@ -496,6 +511,14 @@ slots:
     range: EntityInfluence
     multivalued: true
 
+  value:
+    slot_uri: RDFS:value
+    description: >-
+      Value of a resource.
+    range: string
+    multivalued: true
+    relational_role: OBJECT
+
   version:
     slot_uri: dlco:version
     description: >-
@@ -528,6 +551,7 @@ classes:
       - is_about
       - meta_type
       - name
+      - property
       - same_as
       - title
       - type
@@ -536,6 +560,8 @@ classes:
         inlined: true
         inlined_as_list: true
       is_about:
+        multivalued: true
+      property:
         multivalued: true
       same_as:
         multivalued: true
@@ -885,3 +911,28 @@ classes:
       - ADMS:Identifier
     see_also:
       - https://semiceu.github.io/ADMS/releases/2.00/#Identifier
+
+  Property:
+    class_uri: dlco:Property
+    description: >-
+      RDFS inspired class to describe arbitrary properties.
+      The class captures the predicate and object aspects
+      of a relationship with the subject. `description`,
+      `name`, and `type` describe and define the nature of
+      the predicate, while `value` represents the object,
+      and `range` declares the type of the object.
+    slots:
+      - description
+      - name
+      - range
+      - type
+      - value
+    slot_usage:
+      description:
+        aliases:
+          - comment
+      name:
+        aliases:
+          - label
+    close_mappings:
+      - RDFS:Property

--- a/src/linkml/schemas/data-distribution.yaml
+++ b/src/linkml/schemas/data-distribution.yaml
@@ -79,6 +79,15 @@ imports:
 
 
 slots:
+  address:
+    slot_uri: dlco:address
+    description:
+      Physical address of the subject, such as a postal address, a bibliographic
+      locator, or a coordinate of some kind.
+    range: string
+    close_mappings:
+      - schema:address
+
   affiliation:
     slot_uri: dlco:affiliation
     description: >-
@@ -125,14 +134,6 @@ slots:
     range: Checksum
     exact_mappings:
       - spdx:checksum
-
-  citation:
-    slot_uri: dlco:citation
-    description: >-
-      TODO
-    range: string
-    exact_mappings:
-      - schema:citation
 
   cites_as_authority:
     slot_uri: dlco:cites_as_authority
@@ -294,6 +295,16 @@ slots:
       - prov:influencer
     broad_mappings:
       - dcterms:relation
+
+  is_about:
+    slot_uri: dlco:is_about
+    description: >-
+      A relation of an information artifact to an entity.
+      For example, the subject matter of the content.
+    range: uriorcurie
+    exact_mappings:
+      - schema:about
+      - obo:IAO_0000136
 
   is_distribution_of:
     slot_uri: dlco:is_distribution_of
@@ -504,7 +515,7 @@ classes:
       - id
       - description
       - identifier
-      #- is_about
+      - is_about
       - name
       - same_as
       - title
@@ -513,6 +524,8 @@ classes:
       identifier:
         inlined: true
         inlined_as_list: true
+      is_about:
+        multivalued: true
       same_as:
         multivalued: true
         range: uriorcurie
@@ -559,6 +572,7 @@ classes:
     description: >-
       Person agents are people.
     slots:
+      - address
       - email
     exact_mappings:
       - foaf:Person
@@ -570,6 +584,8 @@ classes:
     description: >-
       A social or legal instititution such as a company, a society,
       or a university.
+    slots:
+      - address
     exact_mappings:
       - foaf:Organization
       - prov:Organization
@@ -581,6 +597,9 @@ classes:
       A person that has or could contribute to some research in any capacity.
     slots:
       - affiliation
+    slot_usage:
+      affiliation:
+        multivalued: true
 
   #
   # entities
@@ -594,10 +613,22 @@ classes:
     slots:
       - conforms_to
       - qualified_attribution
+      - qualified_relation
+      - relation
       - was_attributed_to
     slot_usage:
+      relation:
+        multivalued: true
+        inlined: true
+        inlined_as_list: true
+        range: Entity
       qualified_attribution:
         range: Attribution
+        multivalued: true
+        inlined: true
+        inlined_as_list: true
+      qualified_relation:
+        range: EntityInfluence
         multivalued: true
         inlined: true
         inlined_as_list: true
@@ -629,7 +660,6 @@ classes:
       - is_distribution_of
       - license
       - media_type
-      - relation
       - qualified_part
     slot_usage:
       checksum:
@@ -641,11 +671,6 @@ classes:
         inlined: true
         inlined_as_list: true
         range: Distribution
-      relation:
-        multivalued: true
-        inlined: true
-        inlined_as_list: true
-        range: Entity
       qualified_part:
         multivalued: true
         inlined: true
@@ -668,8 +693,6 @@ classes:
       - is_version_of
       - keyword
       - landing_page
-      - qualified_relation
-      - relation
       - version
       #- was_generated_by
     slot_usage:
@@ -677,16 +700,6 @@ classes:
         range: Resource
       is_version_of:
         range: Resource
-      relation:
-        multivalued: true
-        inlined: true
-        inlined_as_list: true
-        range: Entity
-      qualified_relation:
-        range: EntityInfluence
-        multivalued: true
-        inlined: true
-        inlined_as_list: true
     exact_mappings:
       - DCAT:Resource
 
@@ -696,9 +709,11 @@ classes:
     description: >-
       TODO
     slots:
-      - citation
+      - address
+      - date_modified
       - date_published
-      #- url
+      - license
+      - notation
 
   LicenseDocument:
     class_uri: dlco:LicenseDocument
@@ -724,7 +739,7 @@ classes:
     exact_mappings:
       - schema:Grant
     todos:
-      - We might also want to support `citation` here to support funder-recommended or funder-required citation forms.
+      - We might also want to support `notation` here to support funder-recommended or funder-required citation forms.
 
   #
   # basic relations

--- a/tests/data-distribution-schema/validation/Publication.valid.cfg.yaml
+++ b/tests/data-distribution-schema/validation/Publication.valid.cfg.yaml
@@ -1,0 +1,9 @@
+schema: src/linkml/schemas/data-distribution.yaml
+target_class: Publication
+data_sources:
+  - src/examples/data-distribution/Publication-std.yaml
+plugins:
+  JsonschemaValidationPlugin:
+    closed: true
+    include_range_class_descendants: false
+  RecommendedSlotsPlugin:

--- a/tests/dataset-version-schema/validation/DatasetVersionObject-dataverse-rtmefmri.yaml
+++ b/tests/dataset-version-schema/validation/DatasetVersionObject-dataverse-rtmefmri.yaml
@@ -88,14 +88,14 @@ qualified_attribution:
 relation:
   - meta_type: dlco:PublicationObject
     meta_code: data_paper
-    citation: 'Heunis S, Breeuwer M, Caballero-Gaudes C et al. rt-me-fMRI: a task
+    notation: 'Heunis S, Breeuwer M, Caballero-Gaudes C et al. rt-me-fMRI: a task
       and resting state dataset for real-time, multi-echo fMRI methods development
       and validation [version 1; peer review: 1 approved, 1 approved with reservations].
       F1000Research 2021, 10:70 (https://doi.org/10.12688/f1000research.29988.1)'
     doi: https://doi.org/10.12688/f1000research.29988.1
   - meta_type: dlco:PublicationObject
     meta_code: methods_paper
-    citation: S. Heunis, M. Breeuwer, C. Caballero-Gaudes, L. Hellrung, W. Huijbers,
+    notation: S. Heunis, M. Breeuwer, C. Caballero-Gaudes, L. Hellrung, W. Huijbers,
       J.F. Jansen, R. Lamerichs, S. Zinger, A.P. Aldenkamp. The effects of multi-echo
       fMRI combination and rapid T*-mapping on offline and real-time BOLD sensitivity.
       NeuroImage, 238 (2021), Article 118244, 10.1016/j.neuroimage.2021.118244


### PR DESCRIPTION
An example is the primary contribution here. A few changes have been made to enable this:

- property `citation` is removed, it was ill defined (used as "cite_as", but was defined as "cites"). all usage replaced with `notation`
- property `address` has been introduced as a catch-all for any generic "location" description that is not done with a dedicated class
- property `is_about` is introduced for topic annotation
- property `affiliation` is now multivalued
- a `Property` class and property is introduced to enable specification of arbitrary additional properties
- `type` and `meta_type` are distinguished to enable a type annotation detail that is not limited to the granularity of the schema

Apart from these major changes, properties have moved up and down the class hierarchy to better fit this additional use case.