### PR TITLE
Extend custom properties to quantitative properties

### DIFF
--- a/src/examples/data-distribution/Publication-std.json
+++ b/src/examples/data-distribution/Publication-std.json
@@ -13,35 +13,31 @@
     "https://www.nature.com/subjects/software"
   ],
   "meta_type": "dlco:Publication",
-  "property": [
+  "has_property": [
     {
+      "is_about": "bibo:doi",
+      "meta_type": "dlco:Property",
       "name": "DOI",
-      "type": "bibo:doi",
-      "value": [
-        "https://doi.org/10.1038/s41597-022-01163-2"
-      ]
+      "value": "https://doi.org/10.1038/s41597-022-01163-2"
     },
     {
+      "is_about": "bibo:volume",
+      "meta_type": "dlco:Property",
       "name": "Volume",
-      "type": "bibo:volume",
-      "value": [
-        "9"
-      ]
+      "value": "9"
     },
     {
+      "is_about": "bibo:number",
+      "meta_type": "dlco:Property",
       "name": "Document number",
-      "type": "bibo:number",
-      "value": [
-        "80"
-      ]
+      "value": "80"
     },
     {
+      "is_about": "bibo:numPages",
+      "meta_type": "dlco:Property",
       "name": "Number of pages",
-      "range": "xsd:nonNegativeInteger",
-      "type": "bibo:numPages",
-      "value": [
-        "17"
-      ]
+      "type": "xsd:nonNegativeInteger",
+      "value": "17"
     }
   ],
   "same_as": [

--- a/src/examples/data-distribution/Publication-std.yaml
+++ b/src/examples/data-distribution/Publication-std.yaml
@@ -19,20 +19,20 @@ same_as:
   - https://www.nature.com/articles/s41597-022-01163-2
 # custom properties can be used to arbitrarily (and possibly redundantly)
 # detail the publication record for better fit with specialized consumers
-property:
-  - type: bibo:doi
+has_property:
+  - is_about: bibo:doi
     name: DOI
     value: https://doi.org/10.1038/s41597-022-01163-2
-  - type: bibo:volume
+  - is_about: bibo:volume
     name: Volume
-    value: 9
-  - type: bibo:number
+    value: "9"
+  - is_about: bibo:number
     name: Document number
-    value: 80
-  - type: bibo:numPages
+    value: "80"
+  - is_about: bibo:numPages
     name: Number of pages
-    value: 17
-    range: xsd:nonNegativeInteger
+    value: "17"
+    type: xsd:nonNegativeInteger
 
 # related entities
 relation:

--- a/src/examples/data-distribution/Resource-study.json
+++ b/src/examples/data-distribution/Resource-study.json
@@ -1,0 +1,69 @@
+{
+  "id": "thisdsver:#",
+  "meta_type": "dlco:Resource",
+  "was_generated_by": [
+    {
+      "id": "thisds:#study_2005-004406-93",
+      "identifier": [
+        {
+          "notation": "2005-004406-93",
+          "schema_agency": "https://eudract.ema.europa.eu"
+        }
+      ],
+      "meta_type": "dlco:Activity",
+      "title": "Study about the effectiveness of a disease treatment",
+      "type": "obo:NCIT_C71104",
+      "qualified_association": [
+        {
+          "had_role": [
+            "obo:NCIT_C142710",
+            "obo:NCIT_C94342"
+          ],
+          "agent": "thisds:#s001"
+        },
+        {
+          "had_role": [
+            "obo:NCIT_C142710",
+            "obo:NCIT_C173188"
+          ],
+          "agent": "thisds:#s002"
+        }
+      ],
+      "was_associated_with": [
+        {
+          "id": "thisds:#s001",
+          "meta_type": "dlco:Agent",
+          "name": "s001",
+          "has_property": [
+            {
+              "is_about": "obo:PATO_0002201",
+              "is_defined_by": "obo:PATO_0002204",
+              "meta_type": "dlco:Property"
+            }
+          ]
+        },
+        {
+          "id": "thisds:#s002",
+          "meta_type": "dlco:Agent",
+          "name": "s002",
+          "has_property": [
+            {
+              "is_about": "obo:PATO_0000047",
+              "is_defined_by": "obo:PATO_0000384",
+              "meta_type": "dlco:Property",
+              "value": "male"
+            },
+            {
+              "is_about": "obo:NCIT_C37908",
+              "meta_type": "dlco:QuantitativeProperty",
+              "name": "age (years)",
+              "value": "36",
+              "unit": "obo:UO_0000036"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "@type": "Resource"
+}

--- a/src/examples/data-distribution/Resource-study.yaml
+++ b/src/examples/data-distribution/Resource-study.yaml
@@ -1,0 +1,45 @@
+id: thisdsver:#
+was_generated_by:
+  - id: thisds:#study_2005-004406-93
+    title: Study about the effectiveness of a disease treatment
+    # registered clinical trial
+    type: obo:NCIT_C71104
+    identifier:
+      - notation: 2005-004406-93
+        schema_agency: https://eudract.ema.europa.eu
+    # study participants (role assigned below)
+    was_associated_with:
+      - id: thisds:#s001
+        name: s001
+        has_property:
+          # handedness
+          - is_about: obo:PATO_0002201
+            # ambidextrous
+            is_defined_by: obo:PATO_0002204
+      - id: thisds:#s002
+        name: s002
+        has_property:
+          # biological sex
+          - is_about: obo:PATO_0000047
+            value: male
+            is_defined_by: obo:PATO_0000384
+          # age in years
+          - meta_type: dlco:QuantitativeProperty
+            # length of a person's life, stated in years since birth
+            is_about: obo:NCIT_C37908
+            name: age (years)
+            value: "36"
+            unit: obo:UO_0000036
+    qualified_association:
+      - agent: thisds:#s001
+        had_role:
+          # study participant
+          - obo:NCIT_C142710
+          # healthy control
+          - obo:NCIT_C94342
+      - agent: thisds:#s002
+        had_role:
+          - obo:NCIT_C142710
+          # subject Assigned to Protocol Treatment Arm
+          - obo:NCIT_C173188
+  

--- a/src/extra-docs/data-distribution-schema/about.md
+++ b/src/extra-docs/data-distribution-schema/about.md
@@ -44,7 +44,7 @@ it is still useful to declare its `type` to be, for example, `obo:NCIT_C93226` (
 
 The schema provides a limited set of classes and properties that aim to capture a wide range of use cases in a generic fashion that balances schema complexity and applicability to particular scenarios.
 
-Whenever more specialized properties are required and desired for detailing an `Agent`, `Activity`, or `Entity` the `property` property and the associated `Property` class can be used.
+Whenever more specialized properties are required and desired for detailing an `Agent`, `Activity`, or `Entity` the `has_property` property and the associated `Property` and `QuantitativeProperty` classes can be used.
 For example, the `Publication` schema class does not offer detailed bibliographic properties focused on scientific journal publications, because it aims to capture any kind of publication equally well.
 
 Arbitrary custom properties can be defined by declaring property `type`, associated `value`, and `range` (type of the value).
@@ -52,10 +52,10 @@ Here is an example that declare the number of pages (of a journal article):
 
 ```
 property:
-  - type: bibo:numPages
+  - is_about: bibo:numPages
     name: Number of pages
-    value: 17
-    range: xsd:nonNegativeInteger
+    value: "17"
+    type: xsd:nonNegativeInteger
 ```
 
 The associated `Property` class is permissive.

--- a/src/linkml/schemas/data-distribution.yaml
+++ b/src/linkml/schemas/data-distribution.yaml
@@ -263,6 +263,15 @@ slots:
     exact_mappings:
       - dcterms:hasPart
 
+  has_property:
+    slot_uri: dlco:has_property
+    description: >-
+      Relation between a subject and a quality, capability or role that it bears.
+    range: Property
+    relational_role: PREDICATE
+    exact_mappings:
+      - sio:SIO_000233
+
   id:
     slot_uri: dlco:id
     identifier: true
@@ -306,6 +315,14 @@ slots:
     exact_mappings:
       - schema:about
       - obo:IAO_0000136
+
+  is_defined_by:
+    slot_uri: dlco:is_defined_by
+    description: >-
+      The definition of the subject resource.
+    range: uriorcurie
+    exact_mappings:
+      - RDFS:isDefinedBy
 
   is_distribution_of:
     slot_uri: dlco:is_distribution_of
@@ -404,14 +421,6 @@ slots:
     exact_mappings:
       - skos:notation
 
-  property:
-    slot_uri: dlco:property
-    description: >-
-      An arbitrary (extra) property that is not covered by
-      other dedicated properties.
-    range: Property
-    relational_role: PREDICATE
-
   range:
     slot_uri: RDFS:range
     description: >-
@@ -487,6 +496,15 @@ slots:
     exact_mappings:
       - dcterms:type
 
+  qualified_association:
+    slot_uri: dlco:qualified_association
+    description: >-
+      Assignment of responsibility to an agent for an activity, indicating
+      that the agent had a role in the activity.
+    exact_mappings:
+      - prov:qualifiedAssociation
+    range: AgentInfluence
+
   qualified_attribution:
     slot_uri: dlco:qualified_attribution
     description: >-
@@ -511,12 +529,19 @@ slots:
     range: EntityInfluence
     multivalued: true
 
+  unit:
+    slot_uri: dlco:unit
+    description: >-
+      A unit of measurement is a standardized quantity of a physical quality.
+    range: uriorcurie
+    exact_mappings:
+      - obo:UO_0000000
+
   value:
     slot_uri: RDFS:value
     description: >-
       Value of a resource.
     range: string
-    multivalued: true
     relational_role: OBJECT
 
   version:
@@ -528,12 +553,48 @@ slots:
       - DCAT:version
       - pav:version
 
+  was_influenced_by:
+    slot_uri: dlco:was_influenced_by
+    description: >-
+      Capacity of an entity, activity, or agent to have an effect on the
+      character, development, or behavior of another.
+    domain: ProvConcept
+    range: ProvConcept
+    exact_mappings:
+      - prov:wasInfluencedBy
+
+  was_associated_with:
+    slot_uri: dlco:was_associated_with
+    is_a: was_influenced_by
+    description: >-
+      An activity association is an assignment of responsibility to an agent
+      for an activity, indicating that the agent had a role in the activity.
+      It further allows for a plan to be specified, which is the plan intended
+      by the agent to achieve some goals in the context of this activity.
+    domain: Activity
+    range: Agent
+    exact_mappings:
+      - prov:wasAssociatedWith
+
   was_attributed_to:
     slot_uri: dlco:was_attributed_to
+    is_a: was_influenced_by
     description: >-
       Attribution is the ascribing of an entity to an agent.
     domain: Entity
     range: Agent
+    exact_mappings:
+      - prov:wasAttributedTo
+
+  was_generated_by:
+    slot_uri: dlco:was_generated_by
+    is_a: was_influenced_by
+    description: >-
+      Generation is the completion of production of a new entity by an activity.
+      This entity did not exist before generation and becomes available for usage
+      after this generation.
+    domain: Entity
+    range: Activity
     exact_mappings:
       - prov:wasAttributedTo
 
@@ -551,7 +612,7 @@ classes:
       - is_about
       - meta_type
       - name
-      - property
+      - has_property
       - same_as
       - title
       - type
@@ -561,7 +622,7 @@ classes:
         inlined_as_list: true
       is_about:
         multivalued: true
-      property:
+      has_property:
         multivalued: true
       same_as:
         multivalued: true
@@ -581,10 +642,23 @@ classes:
       An activity is something that occurs over a period of time and acts
       upon or with entities; it may include consuming, processing,
       transforming, modifying, relocating, using, or generating entities.
-      #slots:
+    slots:
+      - qualified_association
+      - was_associated_with
       #  - at_location
       #  - started_at
       #  - ended_at
+    slot_usage:
+      was_associated_with:
+        multivalued: true
+        inlined: true
+        inlined_as_list: true
+        range: Agent
+      qualified_association:
+        multivalued: true
+        inlined: true
+        inlined_as_list: true
+        range: AgentInfluence
     exact_mappings:
       - prov:Activity
 
@@ -653,6 +727,7 @@ classes:
       - qualified_relation
       - relation
       - was_attributed_to
+      - was_generated_by
     slot_usage:
       relation:
         multivalued: true
@@ -674,6 +749,11 @@ classes:
         inlined: true
         inlined_as_list: true
         range: Agent
+      was_generated_by:
+        multivalued: true
+        inlined: true
+        inlined_as_list: true
+        range: Activity
     exact_mappings:
       - prov:Entity
 
@@ -915,24 +995,32 @@ classes:
   Property:
     class_uri: dlco:Property
     description: >-
-      RDFS inspired class to describe arbitrary properties.
-      The class captures the predicate and object aspects
-      of a relationship with the subject. `description`,
-      `name`, and `type` describe and define the nature of
-      the predicate, while `value` represents the object,
-      and `range` declares the type of the object.
+      An inherent quality, function, disposition or process characteristic
+      that is being observed or measured.
     slots:
       - description
+      - is_about
+      - is_defined_by
+      - meta_type
       - name
-      - range
+      - title
       - type
       - value
     slot_usage:
-      description:
-        aliases:
-          - comment
-      name:
-        aliases:
-          - label
+      is_defined_by:
+        description:
+          The property value is defined by this term.
+    exact_mappings:
+      - sio:SIO_000614
+
+  QuantitativeProperty:
+    class_uri: dlco:QuantitativeProperty
+    is_a: Property
+    description: >-
+      An inherent quantitative property that is being observed or measured.
+    slots:
+      - unit
+      #- scale
+      #- distribution
     close_mappings:
-      - RDFS:Property
+      - obo:NCIT_C70766

--- a/tests/data-distribution-schema/validation/Resource.valid.cfg.yaml
+++ b/tests/data-distribution-schema/validation/Resource.valid.cfg.yaml
@@ -2,6 +2,7 @@ schema: src/linkml/schemas/data-distribution.yaml
 target_class: Resource
 data_sources:
   - src/examples/data-distribution/Resource-funding.yaml
+  - src/examples/data-distribution/Resource-study.yaml
 plugins:
   JsonschemaValidationPlugin:
     closed: true


### PR DESCRIPTION
Main changes:

- step away from RDFS like pseudo-definition of properties -- this only looked good superficially
- introduce `has_property` property to hold quantitative and qualitative properties via the established `meta_type` approach.
- `Property` now uses `is_about` for specifying the purpose/topic of a property
- `Property` now uses `type` to indicate the type of the value (pretty much for casting use cases, because `value` itself has a range of `string`)
- `Property` now has `is_defined_by` to indicate the proper term that defined the value (string) or takes its place
- `QuantitativeProperty` is a `Property` with a unit
- `Property.value` is no longer multivalued -- no known use case. Given that a type declaration is needed already and casting must be performed by consumers, an array-like encoding of some kind (JSON?) could be chosen and indicated by a user without being enforced by the schema.

As a demo (for now) we also introduce initial structures to associate an Activity (like a study) with an entity (like a resource), and agents (like study participants) with an activity:

- `was_generated_by`
- `was_associated_with`
- `qualified_association`

They follow the standard patterns already established for other relationships.

Closes #110