### PR TITLE
Add example for a data type annotation (two possible approaches)

### DIFF
--- a/src/examples/data-distribution/Distribution-datatypes.json
+++ b/src/examples/data-distribution/Distribution-datatypes.json
@@ -1,0 +1,24 @@
+{
+  "id": "thisdsver:./file.jpeg",
+  "meta_type": "dlco:Distribution",
+  "has_property": [
+    {
+      "is_about": "obo:NCIT_C42645",
+      "is_defined_by": "obo:NCIT_C95650",
+      "meta_type": "dlco:Property",
+      "name": "data type",
+      "value": "encapsulated image data"
+    }
+  ],
+  "qualified_relation": [
+    {
+      "had_role": [
+        "obo:NCIT_C42645"
+      ],
+      "entity": [
+        "obo:NCIT_C95650"
+      ]
+    }
+  ],
+  "@type": "Distribution"
+}

--- a/src/examples/data-distribution/Distribution-datatypes.yaml
+++ b/src/examples/data-distribution/Distribution-datatypes.yaml
@@ -1,0 +1,25 @@
+id: thisdsver:./file.jpeg
+# two approaches:
+# first using the common qualified-relation pattern.
+qualified_relation:
+  - entity:
+      # encapsulated image data
+      - obo:NCIT_C95650
+    had_role:
+      # data type
+      - obo:NCIT_C42645
+# when standardized terms for identifying data types are not available,
+# the can be defined in a custom entity.
+#relation:
+#  - id: thisds:#dtype_funky
+#    ...
+
+# this is an alternative approach via a custom property.
+# it is also combinable with a custom data type definition in
+# a relation.
+has_property:
+  - is_about: obo:NCIT_C42645
+    is_defined_by: obo:NCIT_C95650
+    # optionally:
+    name: data type
+    value: encapsulated image data

--- a/tests/data-distribution-schema/validation/Distribution.valid.cfg.yaml
+++ b/tests/data-distribution-schema/validation/Distribution.valid.cfg.yaml
@@ -6,6 +6,7 @@ data_sources:
   - src/examples/data-distribution/Distribution-resource.yaml
   - src/examples/data-distribution/Distribution-parts.yaml
   - src/examples/data-distribution/Distribution-formats.yaml
+  - src/examples/data-distribution/Distribution-datatypes.yaml
   - src/examples/data-distribution/Distribution-annexkey.yaml
   - src/examples/data-distribution/Distribution-gitblob.yaml
   - src/examples/data-distribution/Distribution-gittree.yaml


### PR DESCRIPTION
This documents that we need no additional features in the schema to be able to express associated data types.

Closes #107