### PR TITLE
Adjust `(Quantitative)Property` to use `type` not `is_about`

### DIFF
--- a/src/examples/data-distribution/Distribution-datatypes.json
+++ b/src/examples/data-distribution/Distribution-datatypes.json
@@ -3,10 +3,10 @@
   "meta_type": "dlco:Distribution",
   "has_property": [
     {
-      "is_about": "obo:NCIT_C42645",
       "is_defined_by": "obo:NCIT_C95650",
       "meta_type": "dlco:Property",
       "name": "data type",
+      "type": "obo:NCIT_C42645",
       "value": "encapsulated image data"
     }
   ],

--- a/src/examples/data-distribution/Distribution-datatypes.yaml
+++ b/src/examples/data-distribution/Distribution-datatypes.yaml
@@ -18,7 +18,7 @@ qualified_relation:
 # it is also combinable with a custom data type definition in
 # a relation.
 has_property:
-  - is_about: obo:NCIT_C42645
+  - type: obo:NCIT_C42645
     is_defined_by: obo:NCIT_C95650
     # optionally:
     name: data type

--- a/src/examples/data-distribution/Publication-std.json
+++ b/src/examples/data-distribution/Publication-std.json
@@ -15,28 +15,28 @@
   "meta_type": "dlco:Publication",
   "has_property": [
     {
-      "is_about": "bibo:doi",
       "meta_type": "dlco:Property",
       "name": "DOI",
+      "type": "bibo:doi",
       "value": "https://doi.org/10.1038/s41597-022-01163-2"
     },
     {
-      "is_about": "bibo:volume",
       "meta_type": "dlco:Property",
       "name": "Volume",
+      "type": "bibo:volume",
       "value": "9"
     },
     {
-      "is_about": "bibo:number",
       "meta_type": "dlco:Property",
       "name": "Document number",
+      "type": "bibo:number",
       "value": "80"
     },
     {
-      "is_about": "bibo:numPages",
       "meta_type": "dlco:Property",
       "name": "Number of pages",
-      "type": "xsd:nonNegativeInteger",
+      "type": "bibo:numPages",
+      "range": "xsd:nonNegativeInteger",
       "value": "17"
     }
   ],

--- a/src/examples/data-distribution/Publication-std.yaml
+++ b/src/examples/data-distribution/Publication-std.yaml
@@ -20,19 +20,19 @@ same_as:
 # custom properties can be used to arbitrarily (and possibly redundantly)
 # detail the publication record for better fit with specialized consumers
 has_property:
-  - is_about: bibo:doi
+  - type: bibo:doi
     name: DOI
     value: https://doi.org/10.1038/s41597-022-01163-2
-  - is_about: bibo:volume
+  - type: bibo:volume
     name: Volume
     value: "9"
-  - is_about: bibo:number
+  - type: bibo:number
     name: Document number
     value: "80"
-  - is_about: bibo:numPages
+  - type: bibo:numPages
     name: Number of pages
     value: "17"
-    type: xsd:nonNegativeInteger
+    range: xsd:nonNegativeInteger
 
 # related entities
 relation:

--- a/src/examples/data-distribution/Resource-customproperty.json
+++ b/src/examples/data-distribution/Resource-customproperty.json
@@ -1,0 +1,22 @@
+{
+  "id": "thisdsver:#",
+  "meta_type": "dlco:Resource",
+  "has_property": [
+    {
+      "is_defined_by": "http://dbpedia.org/resource/Canada",
+      "meta_type": "dlco:Property",
+      "name": "origin country",
+      "type": "obo:HSO_0000360",
+      "value": "Canada"
+    },
+    {
+      "meta_type": "dlco:QuantitativeProperty",
+      "name": "biospecimen weight (kg)",
+      "type": "obo:NCIT_C181733",
+      "range": "xsd:decimal",
+      "value": "145.3",
+      "unit": "obo:UO_0000009"
+    }
+  ],
+  "@type": "Resource"
+}

--- a/src/examples/data-distribution/Resource-customproperty.yaml
+++ b/src/examples/data-distribution/Resource-customproperty.yaml
@@ -11,7 +11,7 @@ has_property:
   - meta_type: dlco:QuantitativeProperty
     type: obo:NCIT_C181733
     name: biospecimen weight (kg)
-    value: 145.3
+    value: "145.3"
     # kilogram
     unit: obo:UO_0000009
     range: xsd:decimal

--- a/src/examples/data-distribution/Resource-customproperty.yaml
+++ b/src/examples/data-distribution/Resource-customproperty.yaml
@@ -1,0 +1,17 @@
+# arbitrary well-defined properties can be attached to any
+# Agent, Activity, or Entity
+#
+# Example: dataset on something heavy from Canada
+id: thisdsver:#
+has_property:
+  - type: obo:HSO_0000360
+    name: origin country
+    value: Canada
+    is_defined_by: http://dbpedia.org/resource/Canada
+  - meta_type: dlco:QuantitativeProperty
+    type: obo:NCIT_C181733
+    name: biospecimen weight (kg)
+    value: 145.3
+    # kilogram
+    unit: obo:UO_0000009
+    range: xsd:decimal

--- a/src/examples/data-distribution/Resource-study.json
+++ b/src/examples/data-distribution/Resource-study.json
@@ -36,9 +36,9 @@
           "name": "s001",
           "has_property": [
             {
-              "is_about": "obo:PATO_0002201",
               "is_defined_by": "obo:PATO_0002204",
-              "meta_type": "dlco:Property"
+              "meta_type": "dlco:Property",
+              "type": "obo:PATO_0002201"
             }
           ]
         },
@@ -48,15 +48,15 @@
           "name": "s002",
           "has_property": [
             {
-              "is_about": "obo:PATO_0000047",
               "is_defined_by": "obo:PATO_0000384",
               "meta_type": "dlco:Property",
+              "type": "obo:PATO_0000047",
               "value": "male"
             },
             {
-              "is_about": "obo:NCIT_C37908",
               "meta_type": "dlco:QuantitativeProperty",
               "name": "age (years)",
+              "type": "obo:NCIT_C37908",
               "value": "36",
               "unit": "obo:UO_0000036"
             }

--- a/src/examples/data-distribution/Resource-study.yaml
+++ b/src/examples/data-distribution/Resource-study.yaml
@@ -13,20 +13,20 @@ was_generated_by:
         name: s001
         has_property:
           # handedness
-          - is_about: obo:PATO_0002201
+          - type: obo:PATO_0002201
             # ambidextrous
             is_defined_by: obo:PATO_0002204
       - id: thisds:#s002
         name: s002
         has_property:
           # biological sex
-          - is_about: obo:PATO_0000047
+          - type: obo:PATO_0000047
             value: male
             is_defined_by: obo:PATO_0000384
           # age in years
           - meta_type: dlco:QuantitativeProperty
             # length of a person's life, stated in years since birth
-            is_about: obo:NCIT_C37908
+            type: obo:NCIT_C37908
             name: age (years)
             value: "36"
             unit: obo:UO_0000036

--- a/src/extra-docs/data-distribution-schema/about.md
+++ b/src/extra-docs/data-distribution-schema/about.md
@@ -52,7 +52,7 @@ Here is an example that declare the number of pages (of a journal article):
 
 ```
 property:
-  - is_about: bibo:numPages
+  - type: bibo:numPages
     name: Number of pages
     value: "17"
     type: xsd:nonNegativeInteger

--- a/src/linkml/schemas/data-distribution.yaml
+++ b/src/linkml/schemas/data-distribution.yaml
@@ -452,7 +452,7 @@ slots:
   range:
     slot_uri: RDFS:range
     description: >-
-      State that the values of a property are instances a class.
+      State that the values of a property are instances of a class.
     range: uriorcurie
 
   relation:
@@ -1089,12 +1089,12 @@ classes:
       that is being observed or measured.
     slots:
       - description
-      - is_about
       - is_defined_by
       - meta_type
       - name
       - title
       - type
+      - range
       - value
     slot_usage:
       is_defined_by:

--- a/src/linkml/schemas/data-distribution.yaml
+++ b/src/linkml/schemas/data-distribution.yaml
@@ -625,6 +625,10 @@ slots:
       Value of a resource.
     range: string
     relational_role: OBJECT
+    notes:
+      - We would really want to be able to leave the range undefined and permit
+        any type. However, linkml requires a range specification. A workaround
+        via linkml:Any does not produce a satisfactory solution.
 
   version:
     slot_uri: dlco:version

--- a/src/linkml/schemas/data-distribution.yaml
+++ b/src/linkml/schemas/data-distribution.yaml
@@ -79,7 +79,51 @@ emit_prefixes:
   - prov
 
 imports:
-  - ../ontology/types
+  - linkml:types
+  #- ../ontology/types
+
+types:
+  EmailAddress:
+    uri: dlco:EmailAddress
+    base: str
+    description: RFC 5322 compliant email address
+    pattern: '(?:[a-z0-9!#$%&''*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&''*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])'
+    notes:
+      - The validation regex is taken from https://stackoverflow.com/a/201378
+      - The regex is single-quoted for YAML encoding, hence all inner "'" have been doubled
+
+  HexBinary:
+    uri: xsd:hexBinary
+    base: str
+    pattern: "^[a-fA-F0-9]+$"
+    description: >-
+      hex-encoded binary data.
+
+  W3CISO8601:
+    uri: https://www.w3.org/TR/NOTE-datetime
+    description:
+      W3C variant/subset of IS08601 for specifying date(times).
+      Supported are
+      - YYYY (eg 1997)
+      - YYYY-MM (eg 1997-07)
+      - YYYY-MM-DD (eg 1997-07-16)
+      - YYYY-MM-DDThh:mmTZD (eg 1997-07-16T19:20+01:00)
+      - YYYY-MM-DDThh:mm:ssTZD (eg 1997-07-16T19:20:30+01:00)
+      - YYYY-MM-DDThh:mm:ss.sTZD (eg 1997-07-16T19:20:30.45+01:00)
+      where TZD is the time zone designator (Z or +hh:mm or -hh:mm)
+    typeof: string
+    pattern: '^(\d{4})|(\d{4}-[01]\d)|(\d{4}-[01]\d-[0-3]\d)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z))|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z))|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z))$'
+    see_also: https://www.w3.org/TR/NOTE-datetime
+
+  NonNegativeInteger:
+    uri: xsd:nonNegativeInteger
+    base: int
+    description: An integer
+    notes: >-
+      Integer with minimum (inclusive) value of zero, i.e. the standard
+      mathematical concept of the non-negative integers.
+    broad_mappings:
+      - schema:Integer
 
 
 slots:

--- a/tests/data-distribution-schema/validation/Resource.valid.cfg.yaml
+++ b/tests/data-distribution-schema/validation/Resource.valid.cfg.yaml
@@ -1,6 +1,7 @@
 schema: src/linkml/schemas/data-distribution.yaml
 target_class: Resource
 data_sources:
+  - src/examples/data-distribution/Resource-customproperty.yaml
   - src/examples/data-distribution/Resource-funding.yaml
   - src/examples/data-distribution/Resource-study.yaml
   - src/examples/data-distribution/Resource-gitcommit.yaml


### PR DESCRIPTION
This gives a stronger, more appropriate statement. A turtle example shows this nicely:

```ttl
<https://example.com/custom-namespace/datasetversion/#> dlco:has_property [ a "obo:NCIT_C181733"^^xsd:anyURI ;
            RDFS:range "xsd:decimal"^^xsd:anyURI ;
            RDFS:value "145.3" ;
            dlco:meta_type "dlco:QuantitativeProperty"^^xsd:anyURI ;
            dlco:name "biospecimen weight (kg)" ;
            dlco:unit "obo:UO_0000009"^^xsd:anyURI ] ;
```

Dataset "has_property" a "obo:NCIT_C181733 (biospeciment weight)" with value "145.3" and unit "kg"

`meta_type` states that this declaration comes in the form of a `QuantitativeProperty` schema class.