### PR TITLE
Achieve an initial exhaustive semantic mapping

### DIFF
--- a/src/linkml/schemas/data-distribution.yaml
+++ b/src/linkml/schemas/data-distribution.yaml
@@ -826,6 +826,8 @@ classes:
     slot_usage:
       affiliation:
         multivalued: true
+    broad_mappings:
+      - prov:Person
 
   #
   # entities
@@ -951,13 +953,20 @@ classes:
     class_uri: dlco:Publication
     is_a: Entity
     description: >-
-      TODO
+      A document that is the output of a publishing process.
+      This can printed or electronic work offered for distribution,
+      and may have been made available by a publisher.
     slots:
       - address
       - date_modified
       - date_published
       - license
       - notation
+    exact_mappings:
+      - obo:IAO_0000311
+      - obo:NCIT_C48471
+    close_mappings:
+      - sio:SIO_000087
 
   LicenseDocument:
     class_uri: dlco:LicenseDocument


### PR DESCRIPTION
With this change, any class or slot definition in the `data-distribution` schema is mapped to an external definition. The mapping is typically "exact", but a few exceptions exist.

Closes: #75