### PR TITLE
Remove ResearchContributor class

### DIFF
--- a/src/distribution/unreleased.yaml
+++ b/src/distribution/unreleased.yaml
@@ -802,7 +802,11 @@ classes:
       Person agents are people.
     slots:
       - address
+      - affiliation
       - email
+    slot_usage:
+      affiliation:
+        multivalued: true
     exact_mappings:
       - foaf:Person
       - prov:Person
@@ -818,19 +822,6 @@ classes:
     exact_mappings:
       - foaf:Organization
       - prov:Organization
-
-  ResearchContributor:
-    class_uri: dldist:ResearchContributor
-    is_a: Person
-    description: >-
-      A person that has or could contribute to some research in any capacity.
-    slots:
-      - affiliation
-    slot_usage:
-      affiliation:
-        multivalued: true
-    broad_mappings:
-      - prov:Person
 
   #
   # entities

--- a/src/distribution/unreleased/examples/Distribution-penguins.json
+++ b/src/distribution/unreleased/examples/Distribution-penguins.json
@@ -162,7 +162,7 @@
           "schema_agency": "https://orcid.org"
         }
       ],
-      "meta_type": "dldist:ResearchContributor",
+      "meta_type": "dldist:Person",
       "name": "Allison Horst",
       "same_as": [
         "https://orcid.org/0000-0002-6047-5564"
@@ -180,7 +180,7 @@
           "schema_agency": "https://orcid.org"
         }
       ],
-      "meta_type": "dldist:ResearchContributor",
+      "meta_type": "dldist:Person",
       "name": "Allison Hill",
       "email": "ahill@example.com",
       "affiliation": [
@@ -195,7 +195,7 @@
           "schema_agency": "https://orcid.org"
         }
       ],
-      "meta_type": "dldist:ResearchContributor",
+      "meta_type": "dldist:Person",
       "name": "Kirsten Gorman",
       "email": "kgorman@example.com",
       "affiliation": [

--- a/src/distribution/unreleased/examples/Distribution-penguins.yaml
+++ b/src/distribution/unreleased/examples/Distribution-penguins.yaml
@@ -152,7 +152,7 @@ relation:
 # namespace conflict would ever happen across dataset versions.
 was_attributed_to:
   - id: exthisds:#ahorst
-    meta_type: dldist:ResearchContributor
+    meta_type: dldist:Person
     name: Allison Horst
     email: ahorst@example.com
     identifier:
@@ -165,7 +165,7 @@ was_attributed_to:
     same_as:
       - https://orcid.org/0000-0002-6047-5564
   - id: exthisds:#ahill
-    meta_type: dldist:ResearchContributor
+    meta_type: dldist:Person
     name: Allison Hill
     email: ahill@example.com
     identifier:
@@ -174,7 +174,7 @@ was_attributed_to:
     affiliation:
       - exthisds:#Rstudio
   - id: exthisds:#kgorman
-    meta_type: dldist:ResearchContributor
+    meta_type: dldist:Person
     name: Kirsten Gorman
     email: kgorman@example.com
     identifier:

--- a/src/distribution/unreleased/examples/Publication-std.json
+++ b/src/distribution/unreleased/examples/Publication-std.json
@@ -294,7 +294,7 @@
           "schema_agency": "http://orcid.org"
         }
       ],
-      "meta_type": "dldist:ResearchContributor",
+      "meta_type": "dldist:Person",
       "name": "Adina S. Wagner",
       "email": "adina.wagner@t-online.de",
       "affiliation": [
@@ -309,7 +309,7 @@
           "schema_agency": "http://orcid.org"
         }
       ],
-      "meta_type": "dldist:ResearchContributor",
+      "meta_type": "dldist:Person",
       "name": "Laura K. Waite",
       "affiliation": [
         "https://ror.org/02nv7yv05"
@@ -323,7 +323,7 @@
           "schema_agency": "http://orcid.org"
         }
       ],
-      "meta_type": "dldist:ResearchContributor",
+      "meta_type": "dldist:Person",
       "name": "Małgorzata Wierzba",
       "affiliation": [
         "https://ror.org/04waf7p94"
@@ -337,7 +337,7 @@
           "schema_agency": "http://orcid.org"
         }
       ],
-      "meta_type": "dldist:ResearchContributor",
+      "meta_type": "dldist:Person",
       "name": "Felix Hoffstaedter",
       "affiliation": [
         "https://ror.org/02nv7yv05"
@@ -351,7 +351,7 @@
           "schema_agency": "http://orcid.org"
         }
       ],
-      "meta_type": "dldist:ResearchContributor",
+      "meta_type": "dldist:Person",
       "name": "Alexander Q. Waite",
       "affiliation": [
         "https://ror.org/02nv7yv05"
@@ -365,7 +365,7 @@
           "schema_agency": "http://orcid.org"
         }
       ],
-      "meta_type": "dldist:ResearchContributor",
+      "meta_type": "dldist:Person",
       "name": "Benjamin Poldrack",
       "affiliation": [
         "https://ror.org/02nv7yv05"
@@ -373,7 +373,7 @@
     },
     {
       "id": "https://www.nature.com/articles/s41597-022-01163-2#auth-Simon_B_-Eickhoff-Aff1-Aff3",
-      "meta_type": "dldist:ResearchContributor",
+      "meta_type": "dldist:Person",
       "name": "Simon B. Eickhoff",
       "same_as": [
         "https://scholar.google.com/citations?user=wjpISMAAAAAJ"
@@ -391,7 +391,7 @@
           "schema_agency": "http://orcid.org"
         }
       ],
-      "meta_type": "dldist:ResearchContributor",
+      "meta_type": "dldist:Person",
       "name": "Michael Hanke",
       "affiliation": [
         "https://ror.org/02nv7yv05",

--- a/src/distribution/unreleased/examples/Publication-std.yaml
+++ b/src/distribution/unreleased/examples/Publication-std.yaml
@@ -120,7 +120,7 @@ qualified_relation:
 was_attributed_to:
   # authors
   - id: http://orcid.org/0000-0003-2917-3450
-    meta_type: dldist:ResearchContributor
+    meta_type: dldist:Person
     name: Adina S. Wagner
     email: adina.wagner@t-online.de
     identifier:
@@ -129,7 +129,7 @@ was_attributed_to:
     affiliation:
       - https://ror.org/02nv7yv05
   - id: http://orcid.org/0000-0003-2213-7465
-    meta_type: dldist:ResearchContributor
+    meta_type: dldist:Person
     name: Laura K. Waite
     identifier:
       - notation: 0000-0003-2213-7465
@@ -137,7 +137,7 @@ was_attributed_to:
     affiliation:
       - https://ror.org/02nv7yv05
   - id: http://orcid.org/0000-0003-0820-2662
-    meta_type: dldist:ResearchContributor
+    meta_type: dldist:Person
     name: Małgorzata Wierzba
     identifier:
       - notation: 0000-0003-0820-2662
@@ -145,7 +145,7 @@ was_attributed_to:
     affiliation:
       - https://ror.org/04waf7p94
   - id: http://orcid.org/0000-0001-7163-3110
-    meta_type: dldist:ResearchContributor
+    meta_type: dldist:Person
     name: Felix Hoffstaedter
     identifier:
       - notation: 0000-0001-7163-3110
@@ -153,7 +153,7 @@ was_attributed_to:
     affiliation:
       - https://ror.org/02nv7yv05
   - id: http://orcid.org/0000-0002-8402-6173
-    meta_type: dldist:ResearchContributor
+    meta_type: dldist:Person
     name: Alexander Q. Waite
     identifier:
       - notation: 0000-0002-8402-6173
@@ -161,7 +161,7 @@ was_attributed_to:
     affiliation:
       - https://ror.org/02nv7yv05
   - id: http://orcid.org/0000-0001-7628-0801
-    meta_type: dldist:ResearchContributor
+    meta_type: dldist:Person
     name: Benjamin Poldrack
     identifier:
       - notation: 0000-0001-7628-0801
@@ -170,7 +170,7 @@ was_attributed_to:
       - https://ror.org/02nv7yv05
   # identifier is publication scope, taken from publisher website
   - id: https://www.nature.com/articles/s41597-022-01163-2#auth-Simon_B_-Eickhoff-Aff1-Aff3
-    meta_type: dldist:ResearchContributor
+    meta_type: dldist:Person
     name: Simon B. Eickhoff
     affiliation:
       - https://ror.org/02nv7yv05
@@ -178,7 +178,7 @@ was_attributed_to:
     same_as:
       - https://scholar.google.com/citations?user=wjpISMAAAAAJ
   - id: http://orcid.org/0000-0001-6398-6370
-    meta_type: dldist:ResearchContributor
+    meta_type: dldist:Person
     name: Michael Hanke
     identifier:
       - notation: 0000-0001-6398-6370

--- a/src/distribution/unreleased/extra-docs/about.md
+++ b/src/distribution/unreleased/extra-docs/about.md
@@ -32,7 +32,7 @@ TODO: how to declare relationships when no dedicated support for a particular ty
 ### Types
 
 Properties that are used as containers to define related objects support the declaration of specific subtypes of the respective range-defining class.
-For example, `was_attributed_to` accepts any `Agent`, but in a scientific context the specialized `ResearchContributor` class may be a more suitable type.
+For example, `was_attributed_to` accepts any `Agent`, but specialized classes maybe be more suitable in particular contexts.
 Such a derived class can be indicated via the `meta_type` property.
 If declared, it is then used for data structure definition and validation for this particular record.
 


### PR DESCRIPTION
This is too specialized for the target scope of the schema. We merge the `affiliation` property into `Person` and achieve a functionally equivalent class, without having to broaden the semantics.

A change in the derived schema will follow.