### PR TITLE
Consolidate `prov` schema

### DIFF
--- a/src/distribution/unreleased/examples/Resource-gitcommit.json
+++ b/src/distribution/unreleased/examples/Resource-gitcommit.json
@@ -24,7 +24,21 @@
       "had_activity": "obo:NCIT_C25446"
     }
   ],
-  "was_generated_by": [
+  "relation": [
+    {
+      "id": "gitsha:8d6f033bb2a6109b2c4d64d6f27b0feb181e4d0f#authoring",
+      "meta_type": "dlprov:Activity",
+      "type": "obo:NCIT_C25625",
+      "qualified_association": [
+        {
+          "had_role": [
+            "marcrel:aut"
+          ],
+          "agent": "exthisds:#gituser_doe@example.com"
+        }
+      ],
+      "ended_at": "2001-02-28T18:27:04+02:00"
+    },
     {
       "id": "gitsha:8d6f033bb2a6109b2c4d64d6f27b0feb181e4d0f#committing",
       "meta_type": "dlprov:Activity",
@@ -38,23 +52,13 @@
         }
       ],
       "was_informed_by": [
-        {
-          "id": "gitsha:8d6f033bb2a6109b2c4d64d6f27b0feb181e4d0f#authoring",
-          "meta_type": "dlprov:Activity",
-          "type": "obo:NCIT_C25625",
-          "qualified_association": [
-            {
-              "had_role": [
-                "marcrel:aut"
-              ],
-              "agent": "exthisds:#gituser_doe@example.com"
-            }
-          ],
-          "ended_at": "2001-02-28T18:27:04+02:00"
-        }
+        "gitsha:8d6f033bb2a6109b2c4d64d6f27b0feb181e4d0f#authoring"
       ],
       "ended_at": "2002-05-30T09:30:10+06:00"
     }
+  ],
+  "was_generated_by": [
+    "gitsha:8d6f033bb2a6109b2c4d64d6f27b0feb181e4d0f#committing"
   ],
   "is_version_of": "datalad-ds:cec1da92-0dbd-4df3-8602-7c72b2d12854",
   "version": "8d6f033bb2a6109b2c4d64d6f27b0feb181e4d0f",

--- a/src/distribution/unreleased/examples/Resource-gitcommit.yaml
+++ b/src/distribution/unreleased/examples/Resource-gitcommit.yaml
@@ -30,9 +30,24 @@ qualified_derivation:
     had_activity: obo:NCIT_C25446
     had_role:
       - owl:priorVersion
-# commit activity
-was_generated_by:
+relation:
+  # author activity
+  # this is modeled as a dedicated action so that the
+  # author time can be captured as an independent property.
+  # otherwise the author role could be added above
+  - id: gitsha:8d6f033bb2a6109b2c4d64d6f27b0feb181e4d0f#authoring
+    meta_type: dlprov:Activity
+    # "preparation"
+    type: obo:NCIT_C25625
+    ended_at: "2001-02-28T18:27:04+02:00"
+    qualified_association:
+      # author of the commit
+      - agent: exthisds:#gituser_doe@example.com
+        had_role:
+          - marcrel:aut
+  # commit activity
   - id: gitsha:8d6f033bb2a6109b2c4d64d6f27b0feb181e4d0f#committing
+    meta_type: dlprov:Activity
     # go for activity type: "release", but could also be
     # "label as such" (obo:NCIT_C64662)
     type: obo:NCIT_C42882
@@ -42,17 +57,7 @@ was_generated_by:
       - agent: exthisds:#gituser_doe@example.com
         had_role:
           - marcrel:cre
-    # author activity
-    # this is modeled as a dedicated action so that the
-    # author time can be captured as an independent property.
-    # otherwise the author role could be added above
     was_informed_by:
-      - id: gitsha:8d6f033bb2a6109b2c4d64d6f27b0feb181e4d0f#authoring
-        # "preparation"
-        type: obo:NCIT_C25625
-        ended_at: "2001-02-28T18:27:04+02:00"
-        qualified_association:
-          # author of the commit
-          - agent: exthisds:#gituser_doe@example.com
-            had_role:
-              - marcrel:aut
+      - gitsha:8d6f033bb2a6109b2c4d64d6f27b0feb181e4d0f#authoring
+was_generated_by:
+  - gitsha:8d6f033bb2a6109b2c4d64d6f27b0feb181e4d0f#committing

--- a/src/distribution/unreleased/examples/Resource-study.json
+++ b/src/distribution/unreleased/examples/Resource-study.json
@@ -1,7 +1,39 @@
 {
   "id": "exthisdsver:#",
   "meta_type": "dldist:Resource",
-  "was_generated_by": [
+  "relation": [
+    {
+      "id": "exthisds:#s001",
+      "meta_type": "dlprov:Agent",
+      "name": "s001",
+      "has_property": [
+        {
+          "is_defined_by": "obo:PATO_0002204",
+          "meta_type": "dlthing:Property",
+          "type": "obo:PATO_0002201"
+        }
+      ]
+    },
+    {
+      "id": "exthisds:#s002",
+      "meta_type": "dlprov:Agent",
+      "name": "s002",
+      "has_property": [
+        {
+          "is_defined_by": "obo:PATO_0000384",
+          "meta_type": "dlthing:Property",
+          "type": "obo:PATO_0000047",
+          "value": "male"
+        },
+        {
+          "meta_type": "dlthing:QuantitativeProperty",
+          "name": "age (years)",
+          "type": "obo:NCIT_C37908",
+          "value": "36",
+          "unit": "obo:UO_0000036"
+        }
+      ]
+    },
     {
       "id": "exthisds:#study_2005-004406-93",
       "identifier": [
@@ -28,42 +60,11 @@
           ],
           "agent": "exthisds:#s002"
         }
-      ],
-      "was_associated_with": [
-        {
-          "id": "exthisds:#s001",
-          "meta_type": "dlprov:Agent",
-          "name": "s001",
-          "has_property": [
-            {
-              "is_defined_by": "obo:PATO_0002204",
-              "meta_type": "dlthing:Property",
-              "type": "obo:PATO_0002201"
-            }
-          ]
-        },
-        {
-          "id": "exthisds:#s002",
-          "meta_type": "dlprov:Agent",
-          "name": "s002",
-          "has_property": [
-            {
-              "is_defined_by": "obo:PATO_0000384",
-              "meta_type": "dlthing:Property",
-              "type": "obo:PATO_0000047",
-              "value": "male"
-            },
-            {
-              "meta_type": "dlthing:QuantitativeProperty",
-              "name": "age (years)",
-              "type": "obo:NCIT_C37908",
-              "value": "36",
-              "unit": "obo:UO_0000036"
-            }
-          ]
-        }
       ]
     }
+  ],
+  "was_generated_by": [
+    "exthisds:#study_2005-004406-93"
   ],
   "@type": "Resource"
 }

--- a/src/distribution/unreleased/examples/Resource-study.yaml
+++ b/src/distribution/unreleased/examples/Resource-study.yaml
@@ -1,35 +1,38 @@
 id: exthisdsver:#
-was_generated_by:
+relation:
+  # study participants (role assigned below)
+  - id: exthisds:#s001
+    meta_type: dlprov:Agent
+    name: s001
+    has_property:
+      # handedness
+      - type: obo:PATO_0002201
+        # ambidextrous
+        is_defined_by: obo:PATO_0002204
+  - id: exthisds:#s002
+    meta_type: dlprov:Agent
+    name: s002
+    has_property:
+      # biological sex
+      - type: obo:PATO_0000047
+        value: male
+        is_defined_by: obo:PATO_0000384
+      # age in years
+      - meta_type: dlthing:QuantitativeProperty
+        # length of a person's life, stated in years since birth
+        type: obo:NCIT_C37908
+        name: age (years)
+        value: "36"
+        unit: obo:UO_0000036
+  # study activity
   - id: exthisds:#study_2005-004406-93
+    meta_type: dlprov:Activity
     title: Study about the effectiveness of a disease treatment
     # registered clinical trial
     type: obo:NCIT_C71104
     identifier:
       - notation: 2005-004406-93
         schema_agency: https://eudract.ema.europa.eu
-    # study participants (role assigned below)
-    was_associated_with:
-      - id: exthisds:#s001
-        name: s001
-        has_property:
-          # handedness
-          - type: obo:PATO_0002201
-            # ambidextrous
-            is_defined_by: obo:PATO_0002204
-      - id: exthisds:#s002
-        name: s002
-        has_property:
-          # biological sex
-          - type: obo:PATO_0000047
-            value: male
-            is_defined_by: obo:PATO_0000384
-          # age in years
-          - meta_type: dlthing:QuantitativeProperty
-            # length of a person's life, stated in years since birth
-            type: obo:NCIT_C37908
-            name: age (years)
-            value: "36"
-            unit: obo:UO_0000036
     qualified_association:
       - agent: exthisds:#s001
         had_role:
@@ -42,4 +45,5 @@ was_generated_by:
           - obo:NCIT_C142710
           # subject Assigned to Protocol Treatment Arm
           - obo:NCIT_C173188
-  
+was_generated_by:
+  - exthisds:#study_2005-004406-93

--- a/src/prov/unreleased.yaml
+++ b/src/prov/unreleased.yaml
@@ -4,29 +4,25 @@ version: UNRELEASED
 status: bibo:status/draft
 title: Schema for a generic data provenance
 description: |
-  This schema is centered on the description of concrete data distributions
-  using a single root class that uniformly applies to different kinds of
-  distributions, like an individual file, an archive of files, or a directory
-  of files.
+  This schema builds on the [Thing schema](https://concepts.datalad.org/s/thing), and diversifies it to capture the key provenance concepts `Agent`, `Activity`, `Entity` and their relationships.
+  It does that by drawing on (a subset) of the PROV data model [PROV-DM](https://www.w3.org/TR/prov-dm).
 
-  There is [dedicated documentation](about.md) with general information on the
-  purpose and basic principles of this schema.
+  Central paradigm of the schema is the [qualified relation pattern](https://patterns.dataincubator.org/book/qualified-relation.html).
+  The three `Thing` derived key concepts `Agent`, `Activity`, and `Entity` each provide a `relation` (symmetric property) slot for **inline declaration** of related things.
+  This `relation` slot is also the **only** slots that permits inline declaration.
+  A relationship can be further characterized by referencing a `Thing` by its object identifier in slots like `was_attributed_to` (for an `Agent`).
+  Full relation qualification is supported via inline declaration of `Influence` (derived) class instances in slots like
+ 
+  - `qualified_relation`: for an `EntityInfluence` on an `Entity`
+  - `qualified_association`: for an `AgentInfluence` on an `Activity`
+  - `qualified_attribution`: for an `AgentInfluence` on an `Entity`
 
-  Key goal is the use of global identifiers for most entities.
-
-  A standard record should mostly be a simple key value mapping, where the value
-  part is a URI or CURIE.
-
-  Few slots (provenance related) allow for the inline declaration of (typed)
-  objects, declaring an identifier that can be used to link to such an object
-  in other metadata records.
 comments:
   - ALL CONTENT HERE IS UNRELEASED AND MAY CHANGE ANY TIME
 
 license: MIT
 
 prefixes:
-  ADMS: http://www.w3.org/ns/adms#
   annex-key: https://concepts.datalad.org/ns/annex-key/
   bibo: http://purl.org/ontology/bibo/
   CiTO: http://purl.org/spar/cito/
@@ -124,6 +120,8 @@ slots:
       - This property SHOULD be used to indicate the model, schema, ontology, view or profile that this representation of a dataset conforms to. This is (generally) a complementary concern to the media-type or format.
     exact_mappings:
       - dcterms:conformsTo
+    todos:
+      - Consider making a `Things` property
 
   ended_at:
     slot_uri: dlprov:ended_at
@@ -191,8 +189,14 @@ slots:
   relation:
     slot_uri: dlprov:relation
     description: >-
-      The resource related to the source resource.
+      The subject has a relation to the object.
+    domain: Thing
+    inlined: true
+    inlined_as_list: true
+    multivalued: true
+    range: Thing
     relational_role: OBJECT
+    symmetric: true
     exact_mappings:
       - dcterms:relation
 
@@ -235,8 +239,8 @@ slots:
   was_influenced_by:
     slot_uri: dlprov:was_influenced_by
     description: >-
-      Capacity of an entity, activity, or agent to have an effect on the
-      character, development, or behavior of another.
+      The object had an effect on the character, development, or behavior of
+      the subject.
     domain: Thing
     range: Thing
     exact_mappings:
@@ -314,6 +318,7 @@ classes:
       transforming, modifying, relocating, using, or generating entities.
     slots:
       - qualified_association
+      - relation
       - was_associated_with
       - was_informed_by
       #  - at_location
@@ -322,13 +327,11 @@ classes:
     slot_usage:
       was_associated_with:
         multivalued: true
-        inlined: true
-        inlined_as_list: true
+        inlined: false
         range: Agent
       was_informed_by:
         multivalued: true
-        inlined: true
-        inlined_as_list: true
+        inlined: false
         range: Activity
       qualified_association:
         multivalued: true
@@ -349,6 +352,8 @@ classes:
       Something that bears some form of responsibility for an activity
       taking place, for the existence of an entity, or for another
       agent's activity.
+    slots:
+      - relation
     exact_mappings:
       - foaf:Agent
       - prov:Agent
@@ -372,11 +377,6 @@ classes:
       - was_derived_from
       - was_generated_by
     slot_usage:
-      relation:
-        multivalued: true
-        inlined: true
-        inlined_as_list: true
-        range: Entity
       qualified_attribution:
         range: Attribution
         multivalued: true
@@ -394,18 +394,15 @@ classes:
         inlined_as_list: true
       was_attributed_to:
         multivalued: true
-        inlined: true
-        inlined_as_list: true
+        inlined: false
         range: Agent
       was_derived_from:
         range: Entity
         multivalued: true
-        inlined: true
-        inlined_as_list: true
+        inlined: false
       was_generated_by:
         multivalued: true
-        inlined: true
-        inlined_as_list: true
+        inlined: false
         range: Activity
     exact_mappings:
       - prov:Entity

--- a/src/sdd/unreleased/examples/Distribution-penguins.json
+++ b/src/sdd/unreleased/examples/Distribution-penguins.json
@@ -153,9 +153,7 @@
       ],
       "date_published": "2014-03-05",
       "notation": "'Gorman KB, Williams TD, Fraser WR (2014) Ecological Sexual Dimorphism and Environmental Variability within a Community of Antarctic Penguins (Genus Pygoscelis). PLoS ONE 9(3): e90081.'"
-    }
-  ],
-  "was_attributed_to": [
+    },
     {
       "id": "exthisds:#ahorst",
       "identifier": [
@@ -233,7 +231,7 @@
           "schema_agency": "https://ror.org"
         }
       ],
-      "meta_type": "dlprov:Agent",
+      "meta_type": "dlthing:Thing",
       "name": "NSF Office of Polar Programs"
     },
     {
@@ -244,12 +242,22 @@
           "schema_agency": "https://ror.org"
         }
       ],
-      "meta_type": "dlprov:Agent",
+      "meta_type": "dlthing:Thing",
       "name": "US National Science Foundation",
       "same_as": [
         "https://www.nsf.org"
       ]
     }
+  ],
+  "was_attributed_to": [
+    "exthisds:#ahorst",
+    "exthisds:#ahill",
+    "exthisds:#kgorman",
+    "exthisds:#UCSB",
+    "exthisds:#RStudio",
+    "https://ror.org/01j7nq853",
+    "https://ror.org/05nwjp114",
+    "https://ror.org/021nxhr62"
   ],
   "has_part": [
     {

--- a/src/sdd/unreleased/examples/Distribution-penguins.yaml
+++ b/src/sdd/unreleased/examples/Distribution-penguins.yaml
@@ -143,14 +143,13 @@ relation:
         had_role:
           - marcrel:aut
 
-# Relevant agents.
-# There definition in the scope of the Distribution is arbitrary.
-# They could also be defined inlined at the Resource level, or
-# even not at all in this document (assuming a definition using
-# the exact same identifier would be available elsewhere).
-# We use the `thisds` prefix based on the assumption that no
-# namespace conflict would ever happen across dataset versions.
-was_attributed_to:
+  # Relevant agents.
+  # There definition in the scope of the Distribution is arbitrary.
+  # They could also be defined inlined at the Resource level, or
+  # even not at all in this document (assuming a definition using
+  # the exact same identifier would be available elsewhere).
+  # We use the `thisds` prefix based on the assumption that no
+  # namespace conflict would ever happen across dataset versions.
   - id: exthisds:#ahorst
     meta_type: dldist:Person
     name: Allison Horst
@@ -206,3 +205,12 @@ was_attributed_to:
         schema_agency: https://ror.org
     same_as:
       - https://www.nsf.org
+was_attributed_to:
+  - exthisds:#ahorst
+  - exthisds:#ahill
+  - exthisds:#kgorman
+  - exthisds:#UCSB
+  - exthisds:#RStudio
+  - https://ror.org/01j7nq853
+  - https://ror.org/05nwjp114
+  - https://ror.org/021nxhr62

--- a/src/sdd/unreleased/examples/Publication-std.json
+++ b/src/sdd/unreleased/examples/Publication-std.json
@@ -285,9 +285,7 @@
       ],
       "title": "Scientific data",
       "type": "obo:NCIT_C93226"
-    }
-  ],
-  "was_attributed_to": [
+    },
     {
       "id": "http://orcid.org/0000-0003-2917-3450",
       "identifier": [
@@ -466,7 +464,7 @@
           "schema_agency": "https://ror.org"
         }
       ],
-      "meta_type": "dlprov:Agent",
+      "meta_type": "dlthing:Thing",
       "name": "US National Science Foundation",
       "same_as": [
         "https://www.nsf.org"
@@ -503,6 +501,25 @@
       "meta_type": "dldist:Organization",
       "name": "Springer Nature (United Kingdom)"
     }
+  ],
+  "was_attributed_to": [
+    "http://orcid.org/0000-0003-2917-3450",
+    "http://orcid.org/0000-0003-2213-7465",
+    "http://orcid.org/0000-0003-0820-2662",
+    "http://orcid.org/0000-0001-7163-3110",
+    "http://orcid.org/0000-0002-8402-6173",
+    "http://orcid.org/0000-0001-7628-0801",
+    "https://www.nature.com/articles/s41597-022-01163-2#auth-Simon_B_-Eickhoff-Aff1-Aff3",
+    "http://orcid.org/0000-0001-6398-6370",
+    "https://ror.org/02nv7yv05",
+    "https://ror.org/024z2rq82",
+    "https://ror.org/04waf7p94",
+    "https://ror.org/02frzq211",
+    "https://ror.org/00k4n6c32",
+    "https://ror.org/021nxhr62",
+    "https://ror.org/04pz7b180",
+    "https://www.ncn.gov.pl",
+    "https://ror.org/03dsk4d59"
   ],
   "address": "Scientific Data 9:80",
   "date_modified": "2022-02-11",

--- a/src/sdd/unreleased/examples/Publication-std.yaml
+++ b/src/sdd/unreleased/examples/Publication-std.yaml
@@ -97,27 +97,7 @@ relation:
     same_as:
       - https://www.nature.com/sdata
 
-# entity roles
-qualified_relation:
-  # publication place: journal scientific data
-  - entity: 
-      - https://portal.issn.org/resource/issn/2052-4463
-    had_role:
-      - http://id.loc.gov/vocabulary/relators/prp
-  # grants that funded the work
-  - entity:
-      - exthisds:#grant_bmbf01GQ1905
-      - exthisds:#grant_bmbf01GQ1411
-      - exthisds:#grant_nsc
-      - exthisds:#grant_nsf1429999
-      - exthisds:#grant_nsf1912266
-      - https://cordis.europa.eu/project/id/826421
-      - https://cordis.europa.eu/project/id/945539
-    had_role:
-      - schema:funding
-
-# related agents
-was_attributed_to:
+  # related agents
   # authors
   - id: http://orcid.org/0000-0003-2917-3450
     meta_type: dldist:Person
@@ -252,6 +232,46 @@ was_attributed_to:
     identifier:
       - notation: 03dsk4d59
         schema_agency: https://ror.org
+
+# attribution to agents -- redundant here, but could be
+# used to link agents without declaring a specific role
+was_attributed_to:
+  - http://orcid.org/0000-0003-2917-3450
+  - http://orcid.org/0000-0003-2213-7465
+  - http://orcid.org/0000-0003-0820-2662
+  - http://orcid.org/0000-0001-7163-3110
+  - http://orcid.org/0000-0002-8402-6173
+  - http://orcid.org/0000-0001-7628-0801
+  - https://www.nature.com/articles/s41597-022-01163-2#auth-Simon_B_-Eickhoff-Aff1-Aff3
+  - http://orcid.org/0000-0001-6398-6370
+  - https://ror.org/02nv7yv05
+  - https://ror.org/024z2rq82
+  - https://ror.org/04waf7p94
+  - https://ror.org/02frzq211
+  - https://ror.org/00k4n6c32
+  - https://ror.org/021nxhr62
+  - https://ror.org/04pz7b180
+  - https://www.ncn.gov.pl
+  - https://ror.org/03dsk4d59
+
+# entity roles
+qualified_relation:
+  # publication place: journal scientific data
+  - entity:
+      - https://portal.issn.org/resource/issn/2052-4463
+    had_role:
+      - http://id.loc.gov/vocabulary/relators/prp
+  # grants that funded the work
+  - entity:
+      - exthisds:#grant_bmbf01GQ1905
+      - exthisds:#grant_bmbf01GQ1411
+      - exthisds:#grant_nsc
+      - exthisds:#grant_nsf1429999
+      - exthisds:#grant_nsf1912266
+      - https://cordis.europa.eu/project/id/826421
+      - https://cordis.europa.eu/project/id/945539
+    had_role:
+      - schema:funding
 
 # agent roles
 qualified_attribution:

--- a/src/sdd/unreleased/examples/Resource-funding.json
+++ b/src/sdd/unreleased/examples/Resource-funding.json
@@ -18,14 +18,15 @@
       "meta_type": "dlsdd:Grant",
       "name": "SFB1451",
       "sponsor": "https://ror.org/018mejw64"
-    }
-  ],
-  "was_attributed_to": [
+    },
     {
       "id": "https://ror.org/018mejw64",
       "meta_type": "dldist:Organization",
       "name": "Deutsche Forschungsgemeinschaft"
     }
+  ],
+  "was_attributed_to": [
+    "https://ror.org/018mejw64"
   ],
   "@type": "Resource"
 }

--- a/src/sdd/unreleased/examples/Resource-funding.yaml
+++ b/src/sdd/unreleased/examples/Resource-funding.yaml
@@ -4,12 +4,13 @@ relation:
     meta_type: dlsdd:Grant
     name: SFB1451
     sponsor: https://ror.org/018mejw64
+  - id:  https://ror.org/018mejw64
+    meta_type: dldist:Organization
+    name: Deutsche Forschungsgemeinschaft
 qualified_relation:
   - entity:
       - https://gepris.dfg.de/gepris/projekt/431549029
     had_role:
       - schema:funding
 was_attributed_to:
-  - id:  https://ror.org/018mejw64
-    meta_type: dldist:Organization
-    name: Deutsche Forschungsgemeinschaft
+  - https://ror.org/018mejw64


### PR DESCRIPTION
Key change is that `Agent`, `Activity`, and `Entity` all provide a `relation` slot now. This is declared symmetric and accept the inlined declaration of another `Thing`.

All other only support thing-referenced-by-ID now.

This should considerably simplify the implementation complexity of related data processors. All things can now be discovered by exclusively looking at the `relation` property.