### PR TITLE
Add publication example for `thing` schema

### DIFF
--- a/src/thing/unreleased.yaml
+++ b/src/thing/unreleased.yaml
@@ -44,8 +44,14 @@ prefixes:
 
 default_prefix: dlthing
 
+# list of Curie prefixes that are used in the representation of instances of
+# the model. All prefixes in this list are added to the prefix sections of
+# the target models.
 emit_prefixes:
+  # needed to indicate a QuantitativeProperty via `meta_type`
   - dlthing
+  # single prefix that enables a huge range of ontologies ready-to-use for
+  # descriptions -- seems worth emitting
   - obo
 
 imports:

--- a/src/thing/unreleased/examples/Thing-publication.json
+++ b/src/thing/unreleased/examples/Thing-publication.json
@@ -1,0 +1,73 @@
+{
+  "id": "https://doi.org/10.1038/s41597-022-01163-2",
+  "description": "Large-scale datasets present unique opportunities to perform scientific investigations with unprecedented breadth. However, they also pose considerable challenges for the findability, accessibility, interoperability, and reusability (FAIR) of research outcomes due to infrastructure limitations, data usage constraints, or software license restrictions. Here we introduce a DataLad-based, domain-agnostic framework suitable for reproducible data processing in compliance with open science mandates. The framework attempts to minimize platform idiosyncrasies and performance-related complexities. It affords the capture of machine-actionable computational provenance records that can be used to retrace and verify the origins of research outcomes, as well as be re-executed independent of the original computing infrastructure. We demonstrate the framework’s performance using two showcases: one highlighting data sharing and transparency (using the studyforrest.org dataset) and another highlighting scalability (using the largest public brain imaging dataset available: the UK Biobank dataset).",
+  "identifier": [
+    {
+      "notation": "10.1038/s41597-022-01163-2",
+      "schema_agency": "https://doi.org"
+    }
+  ],
+  "is_about": [
+    "https://www.nature.com/subjects/data-processing",
+    "https://www.nature.com/subjects/data-publication-and-archiving",
+    "https://www.nature.com/subjects/software"
+  ],
+  "meta_type": "dlthing:Thing",
+  "name": "FAIRLy big",
+  "has_property": [
+    {
+      "meta_type": "dlthing:Property",
+      "type": "dcterms:bibliographicCitation",
+      "value": "Wagner, A.S., Waite, L.K., Wierzba, M. et al. FAIRly big: A framework for computationally reproducible processing of large-scale data. Sci Data 9, 80 (2022)."
+    },
+    {
+      "is_defined_by": "https://portal.issn.org/resource/issn/2052-4463",
+      "meta_type": "dlthing:Property",
+      "type": "dcterms:isPartOf",
+      "value": "Scientific Data"
+    },
+    {
+      "meta_type": "dlthing:Property",
+      "name": "DOI",
+      "type": "bibo:doi",
+      "value": "https://doi.org/10.1038/s41597-022-01163-2"
+    },
+    {
+      "meta_type": "dlthing:Property",
+      "name": "Volume",
+      "type": "bibo:volume",
+      "value": "9"
+    },
+    {
+      "meta_type": "dlthing:Property",
+      "name": "Document number",
+      "type": "bibo:number",
+      "value": "80"
+    },
+    {
+      "meta_type": "dlthing:Property",
+      "name": "Number of pages",
+      "type": "bibo:numPages",
+      "range": "xsd:nonNegativeInteger",
+      "value": "17"
+    },
+    {
+      "meta_type": "dlthing:Property",
+      "type": "dcterms:modified",
+      "range": "xsd:date",
+      "value": "2022-02-11"
+    },
+    {
+      "meta_type": "dlthing:Property",
+      "type": "dcterms:date",
+      "range": "xsd:date",
+      "value": "2022-03-11"
+    }
+  ],
+  "same_as": [
+    "https://www.nature.com/articles/s41597-022-01163-2"
+  ],
+  "title": "FAIRly big: A framework for computationally reproducible processing of large-scale data",
+  "type": "bibo:AcademicArticle",
+  "@type": "Thing"
+}

--- a/src/thing/unreleased/examples/Thing-publication.yaml
+++ b/src/thing/unreleased/examples/Thing-publication.yaml
@@ -1,0 +1,48 @@
+# A scientific publication.
+# This is a simplified example lacking any relation descriptions
+# (e.g. authors, funding, etc), see publication examples for
+# other schemas for those aspects.
+id: https://doi.org/10.1038/s41597-022-01163-2
+type: bibo:AcademicArticle
+name: "FAIRLy big"
+title: "FAIRly big: A framework for computationally reproducible processing of large-scale data"
+description:
+  "Large-scale datasets present unique opportunities to perform scientific investigations with unprecedented breadth. However, they also pose considerable challenges for the findability, accessibility, interoperability, and reusability (FAIR) of research outcomes due to infrastructure limitations, data usage constraints, or software license restrictions. Here we introduce a DataLad-based, domain-agnostic framework suitable for reproducible data processing in compliance with open science mandates. The framework attempts to minimize platform idiosyncrasies and performance-related complexities. It affords the capture of machine-actionable computational provenance records that can be used to retrace and verify the origins of research outcomes, as well as be re-executed independent of the original computing infrastructure. We demonstrate the framework’s performance using two showcases: one highlighting data sharing and transparency (using the studyforrest.org dataset) and another highlighting scalability (using the largest public brain imaging dataset available: the UK Biobank dataset)."
+identifier:
+  - notation: 10.1038/s41597-022-01163-2
+    schema_agency: https://doi.org
+# related topics
+is_about:
+  - https://www.nature.com/subjects/data-processing
+  - https://www.nature.com/subjects/data-publication-and-archiving
+  - https://www.nature.com/subjects/software
+#license: licenses:CC-BY-4.0
+same_as:
+  - https://www.nature.com/articles/s41597-022-01163-2
+# custom properties can be used to arbitrarily (and possibly redundantly)
+# detail the publication record for better fit with specialized consumers
+has_property:
+  - type: dcterms:bibliographicCitation
+    value: "Wagner, A.S., Waite, L.K., Wierzba, M. et al. FAIRly big: A framework for computationally reproducible processing of large-scale data. Sci Data 9, 80 (2022)."
+  - type: dcterms:isPartOf
+    value: Scientific Data
+    is_defined_by: https://portal.issn.org/resource/issn/2052-4463
+  - type: bibo:doi
+    name: DOI
+    value: https://doi.org/10.1038/s41597-022-01163-2
+  - type: bibo:volume
+    name: Volume
+    value: "9"
+  - type: bibo:number
+    name: Document number
+    value: "80"
+  - type: bibo:numPages
+    name: Number of pages
+    value: "17"
+    range: xsd:nonNegativeInteger
+  - type: dcterms:modified
+    range: xsd:date
+    value: "2022-02-11"
+  - type: dcterms:date
+    range: xsd:date
+    value: "2022-03-11"

--- a/src/thing/unreleased/validation/Thing.valid.cfg.yaml
+++ b/src/thing/unreleased/validation/Thing.valid.cfg.yaml
@@ -5,6 +5,7 @@ data_sources:
   - src/thing/unreleased/examples/Thing-identifiers.yaml
   - src/thing/unreleased/examples/Thing-topic.yaml
   - src/thing/unreleased/examples/Thing-customproperty.yaml
+  - src/thing/unreleased/examples/Thing-publication.yaml
 plugins:
   JsonschemaValidationPlugin:
     closed: true


### PR DESCRIPTION
This is the same record as in `sdd`, but without the relationships. The purpose here is to have one "rich" example to show that a lot can be expressed with the few building blocks provided.