### PR TITLE
Data access description example

### DIFF
--- a/src/datalad-dataset/unreleased.yaml
+++ b/src/datalad-dataset/unreleased.yaml
@@ -42,8 +42,6 @@ prefixes:
   owl: http://www.w3.org/2002/07/owl#
   pav: http://purl.org/pav/
   prov: http://www.w3.org/ns/prov#
-  RDF: http://www.w3.org/1999/02/22-rdf-syntax-ns#
-  RDFS: http://www.w3.org/2000/01/rdf-schema#
   schema: http://schema.org/
   skos: http://www.w3.org/2004/02/skos/core#
   sio: http://semanticscience.org/resource/

--- a/src/datalad-dataset/unreleased/examples/Distribution-annexaccess.json
+++ b/src/datalad-dataset/unreleased/examples/Distribution-annexaccess.json
@@ -1,53 +1,17 @@
 {
   "id": "annex-key:MD5E-s3214--ba1f2511fc30423bdbb183fe33f3dd0f.csv",
   "meta_type": "dldist:Distribution",
-  "qualified_relation": [
+  "qualified_access": [
     {
-      "had_role": [
-        "DCAT:DataService"
-      ],
-      "entity": [
+      "access_service": [
         "annex-uuid:0a8713ca-ef42-11ee-a805-d3e9a774e795"
       ],
-      "meta_type": "dldist:QualifiedAccess",
-      "access_id": "MD5E-s3214--ba1f2511fc30423bdbb183fe33f3dd0f.csv"
-    }
-  ],
-  "relation": [
-    {
-      "id": "annex-uuid:0a8713ca-ef42-11ee-a805-d3e9a774e795",
-      "identifier": [
+      "has_parameter": [
         {
-          "notation": "0a8713ca-ef42-11ee-a805-d3e9a774e795",
-          "schema_agency": "https://git-annex.branchable.com"
+          "name": "key",
+          "value": "MD5E-s3214--ba1f2511fc30423bdbb183fe33f3dd0f.csv"
         }
-      ],
-      "meta_type": "dldist:DataService",
-      "name": "box.com",
-      "has_property": [
-        {
-          "meta_type": "dlthing:Property",
-          "name": "type",
-          "value": "webdav"
-        },
-        {
-          "meta_type": "dlthing:Property",
-          "name": "url",
-          "type": "DCAT:endpointURL",
-          "value": "https://dav.box.com/dav/git-annex"
-        },
-        {
-          "meta_type": "dlthing:Property",
-          "name": "chunk",
-          "value": "10mb"
-        },
-        {
-          "meta_type": "dlthing:Property",
-          "name": "keyid",
-          "value": "id@joeyh.name"
-        }
-      ],
-      "type": "https://git-annex.branchable.com/special_remotes/webdav"
+      ]
     }
   ],
   "@type": "Distribution"

--- a/src/datalad-dataset/unreleased/examples/Distribution-annexaccess.yaml
+++ b/src/datalad-dataset/unreleased/examples/Distribution-annexaccess.yaml
@@ -1,37 +1,13 @@
-# specification of a distribution access via a git-annex
-# special remote -- without using specifialized concepts
+# specification of a distribution access via a git-annex special remote
 id: annex-key:MD5E-s3214--ba1f2511fc30423bdbb183fe33f3dd0f.csv
-relation:
-  - id: annex-uuid:0a8713ca-ef42-11ee-a805-d3e9a774e795
-    meta_type: dldist:DataService
-    name: box.com
-    # TODO have a definition of a generic annex remote
-    type: https://git-annex.branchable.com/special_remotes/webdav
-    identifier:
-      - notation: 0a8713ca-ef42-11ee-a805-d3e9a774e795
-        schema_agency: https://git-annex.branchable.com
-    # as a generic approach specify init/enableremote parameters
-    # as key-value pairs. each of them could have associated
-    # definitions to communicate the semantics in a more commonly
-    # understood way
-    has_property:
-      - name: type
-        value: webdav
-      - name: url
-        value: https://dav.box.com/dav/git-annex
-        type: DCAT:endpointURL
-      - name: chunk
-        value: 10mb
-      - name: keyid
-        value: id@joeyh.name
-qualified_relation:
-  - meta_type: dldist:QualifiedAccess
-    # one or more annex remotes ...
-    entity:
+qualified_access:
+  - access_service:
+      # see example DataService-annexremote for a matching specification
       - annex-uuid:0a8713ca-ef42-11ee-a805-d3e9a774e795
-    # ... from which this annex key is available
-    access_id: MD5E-s3214--ba1f2511fc30423bdbb183fe33f3dd0f.csv
-    # we need to make the role explicit, because linkml currently
-    # does not support defaults for multivalued slots
-    had_role:
-      - DCAT:DataService
+        # there could be more remotes from which the same key is provided
+    # identify the annex key matching this Distribution, to complete the information
+    # required to perform a request. The name has to match the parameter specification
+    # of the access service
+    has_parameter:
+      - name: key
+        value: MD5E-s3214--ba1f2511fc30423bdbb183fe33f3dd0f.csv

--- a/src/distribution/unreleased.yaml
+++ b/src/distribution/unreleased.yaml
@@ -128,6 +128,32 @@ slots:
     related_mappings:
       - DCAT:servesDataset
 
+  access_service:
+    slot_uri: dldist:access_service
+    description: >-
+      A data service that gives access to the subject.
+    comments:
+      - SHOULD be used to link to a description of a dcat:DataService that can provide access to the subject.
+    range: uriorcurie
+    exact_mappings:
+      - DCAT:accessService
+    related_mappings:
+      - DCAT:accessURL
+      - DCAT:landingPage
+
+  access_url:
+    slot_uri: dldist:access_url
+    description: >-
+      URL that gives access to the subject. This can be, e.g, a landing page, feed, SPARQL endpoint.
+    range: uri
+    comments:
+      - If the subject is available directly, typically through a HTTP Get request, `download_url` SHOULD be used instead.
+    exact_mappings:
+      - DCAT:accessURL
+    related_mappings:
+      - DCAT:downloadURL
+      - DCAT:landingPage
+
   address:
     slot_uri: dldist:address
     description:
@@ -227,10 +253,15 @@ slots:
   download_url:
     slot_uri: dldist:download_url
     description: >-
-      URL of downloadable resourcefile in a given format.
+      URL that gives direct access to the subject in the form of a downloadable file in a given format.
     range: uri
+    comments:
+      - SHOULD be used for the URL at which this distribution is available directly, typically through a HTTP Get request.
     exact_mappings:
       - DCAT:downloadURL
+    related_mappings:
+      - DCAT:accessURL
+      - DCAT:landingPage
 
   email:
     slot_uri: dldist:email
@@ -406,7 +437,10 @@ classes:
       A specific representation of data, which may come in the form of
       a single file, or an archive or directory of many files, may be
       standalone or part of a dataset.
+    comments:
+      - If a distribution is accessible only through a landing page, then the landing page URL associated with respective ressource SHOULD be duplicated as `access_url` on a distribution.
     slots:
+      - access_url
       - byte_size
       - checksum
       - conforms_to
@@ -422,10 +456,14 @@ classes:
       - qualified_access
       - qualified_part
     slot_usage:
+      access_url:
+        multivalued: true
       checksum:
         multivalued: true
         inlined: true
         inlined_as_list: true
+      download_url:
+        multivalued: true
       has_part:
         multivalued: true
         inlined: true

--- a/src/distribution/unreleased.yaml
+++ b/src/distribution/unreleased.yaml
@@ -65,8 +65,6 @@ prefixes:
   owl: http://www.w3.org/2002/07/owl#
   pav: http://purl.org/pav/
   prov: http://www.w3.org/ns/prov#
-  RDF: http://www.w3.org/1999/02/22-rdf-syntax-ns#
-  RDFS: http://www.w3.org/2000/01/rdf-schema#
   schema: http://schema.org/
   skos: http://www.w3.org/2004/02/skos/core#
   sio: http://semanticscience.org/resource/

--- a/src/distribution/unreleased.yaml
+++ b/src/distribution/unreleased.yaml
@@ -4,24 +4,41 @@ version: UNRELEASED
 status: bibo:status/draft
 title: Schema for a generic data distribution record
 description: |
-  This schema is centered on the description of concrete data distributions
-  using a single root class that uniformly applies to different kinds of
-  distributions, like an individual file, an archive of files, or a directory
-  of files.
+  This schema is centered on the [`Distribution`](Distribution) class for
+  describing concrete data distributions, such as an individual file, an archive
+  of files, or a directory of files.
 
-  There is [dedicated documentation](about.md) with general information on the
-  purpose and basic principles of this schema.
+  The schema builds on the elements and principles of the
+  [Thing](https://concepts.datalad.org/s/thing) and
+  [Provenance](https://concepts.datalad.org/s/prov) schemas, and extends them
+  with elements from [DCAT vocabulary](https://www.w3.org/TR/vocab-dcat-3).
 
-  Key goal is the use of global identifiers for most entities.
+  Through the joint set of included concepts and properties this schema
+  supports the description of
 
-  A standard record should mostly be a simple key value mapping, where the value
-  part is a URI or CURIE.
+  - data versions and composition
+  - data access methods
+  - data access rights and policies
+  - related resources, including topics, data types/formats
+  - provenance of data and related entities
 
-  Few slots (provenance related) allow for the inline declaration of (typed)
-  objects, declaring an identifier that can be used to link to such an object
-  in other metadata records.
+  Importantly, all this information can be represented using the
+  [`Distribution`](Distribution) class as a structural container. Hence this schema
+  is particularly suitable for systems that (only) support attaching metadata to
+  data objects.
 
-  Available as
+  For more information, see the [general documentation](about.md), and concrete
+  examples on the documentation pages of individual classes. Some noteworthy
+  examples are
+
+  - [data type annotation](Distribution/#example-distribution-datatypes)
+  - [data format annotation](Distribution/#example-distribution-format)
+  - [dataset as an outcome of a study](Resource/#example-resource-study)
+  - [access to a `Distribution`](Distribution/#example-distribution-access)
+  - [dataset version in the form of a Git commit](Resource/#example-resource-gitcommit)
+  - [git-annex remote as a `DataService`](DataService/#example-dataservice-annexremote)
+
+  The schema is available as
 
   - [JSON-LD context](../unreleased.jsonld)
   - [LinkML YAML](../unreleased.yaml)
@@ -117,24 +134,13 @@ types:
 
 
 slots:
-  access_id:
-    slot_uri: dldist:access_id
-    description: >-
-      An identifier with which a resource distribution can be requested from a
-      `DataService`.
-    broad_mappings:
-      - dcterms:identifier
-    range: string
-    related_mappings:
-      - DCAT:servesDataset
-
   access_service:
     slot_uri: dldist:access_service
     description: >-
-      A data service that gives access to the subject.
+      A data service that gives access to a distribution.
     comments:
       - SHOULD be used to link to a description of a dcat:DataService that can provide access to the subject.
-    range: uriorcurie
+    range: DataService
     exact_mappings:
       - DCAT:accessService
     related_mappings:
@@ -198,15 +204,13 @@ slots:
     exact_mappings:
       - spdx:checksum
 
-  conforms_to:
-    slot_uri: dlprov:conforms_to
+  contact_point:
+    slot_uri: dldist:contact_point
     description: >-
-      An established standard to which the subject conforms.
-    range: uriorcurie
-    comments:
-      - This property SHOULD be used to indicate the model, schema, ontology, view or profile that this representation of a dataset conforms to. This is (generally) a complementary concern to the media-type or format.
+      Relevant contact information for the subject.
+    range: Agent
     exact_mappings:
-      - dcterms:conformsTo
+      - DCAT:contactPoint
 
   date_modified:
     slot_uri: dldist:date_modified
@@ -263,6 +267,20 @@ slots:
       - DCAT:accessURL
       - DCAT:landingPage
 
+  download_url_template:
+    slot_uri: dldist:download_url_template
+    description: >-
+      A URL template with placeholders enclosed in braces (`{example}`).
+      When expanded with a given set of named parameters, the instantiated template
+      forms a valid URL suitable for requesting a download.
+    range: string
+    notes:
+      - the `range` is string, because structural elements of the URL (e.g., the protocol) could also be a placeholder.
+    close_mappings:
+      - linkml:structured_pattern
+    related_mappings:
+      - dldist:download_url
+
   email:
     slot_uri: dldist:email
     description: Email address associated with an entity.
@@ -270,6 +288,29 @@ slots:
       - schema:email
       - obo:IAO_0000429
     range: EmailAddress
+
+  endpoint_description:
+    slot_uri: dldist:endpoint_description
+    description: >-
+      A description of the services available via the end-points,
+      including their operations, parameters etc.
+    range: uri
+    exact_mappings:
+      - DCAT:downloadURL
+    related_mappings:
+      - dldist:endpoint_url
+      - dlthing:conforms_to
+
+  endpoint_url:
+    slot_uri: dldist:endpoint_url
+    description: >-
+      The root location or primary endpoint of a service (a Web-resolvable IRI).
+    range: uri
+    exact_mappings:
+      - DCAT:endpointURL
+    related_mappings:
+      - dldist:endpoint_description
+      - dlthing:conforms_to
 
   format:
     slot_uri: dldist:format
@@ -281,6 +322,15 @@ slots:
       - dcterms:format
     notes:
       - When type of the distribution is defined by IANA, `media_type` should be used.
+
+  has_parameter:
+    slot_uri: dldist:has_parameter
+    description: >-
+      Relation between a process or function and an information entity which
+      modulates the behaviour of the subject.
+    close_mappings:
+      - sio:SIO_000552
+      - obo:OBI_0000293
 
   has_part:
     slot_uri: dldist:has_part
@@ -438,12 +488,12 @@ classes:
       a single file, or an archive or directory of many files, may be
       standalone or part of a dataset.
     comments:
-      - If a distribution is accessible only through a landing page, then the landing page URL associated with respective ressource SHOULD be duplicated as `access_url` on a distribution.
+      - If a distribution is accessible only through a landing page, then the landing page URL associated with respective resource SHOULD be duplicated as `access_url` on a distribution.
     slots:
+      - access_service
       - access_url
       - byte_size
       - checksum
-      - conforms_to
       - date_modified
       - date_published
       # TODO multivalued?
@@ -456,6 +506,8 @@ classes:
       - qualified_access
       - qualified_part
     slot_usage:
+      access_service:
+        multivalued: true
       access_url:
         multivalued: true
       checksum:
@@ -490,6 +542,7 @@ classes:
     notes:
       - Try to make having specific subtypes of this class unnecessary
     slots:
+      - contact_point
       - date_modified
       - date_published
       - is_part_of
@@ -570,6 +623,27 @@ classes:
     description: >-
       A collection of operations that provides access to one or more
       distributions or data processing functions.
+    slots:
+      - download_url_template
+      - endpoint_description
+      - endpoint_url
+      - has_parameter
+    slot_usage:
+      has_parameter:
+        description: >-
+          Parameter that needs to be supplied in order to request a
+          particular `Distribution` from the `DataService`.
+          Any such concrete parameter values can be specific in a
+          dedicated `QualifiedAccess` relation, linking a `Distribution`
+          to a `DataService`.
+          A `Parameter` value property given in the scope of a `DataService`
+          can be considered as a default value.
+        inlined: true
+        inlined_as_list: true
+        multivalued: true
+        range: Parameter
+    comments:
+      - Characteristics of a particular `Dataservice` that do not vary across `Distributions` that can be requested from the `DataService` are considered properties (`has_property`) of the `Dataservice`. In contrast, information needed in addition for requesting a particular `Distribution` are considered an access request parameter (`has_parameter`). Such parameters can be declared for a `DataService`, and provided for a particular `Distribution` via a dedicated `QualifiedAccess` relation.
     exact_mappings:
       - DCAT:DataService
     broad_mappings:
@@ -580,7 +654,6 @@ classes:
 
   QualifiedAccess:
     class_uri: dldist:QualifiedAccess
-    is_a: EntityInfluence
     description: >-
       An association class for attaching additional information to an
       `access_service` relationship between a `DCAT:Distribution` and
@@ -588,16 +661,20 @@ classes:
     related_mappings:
       - DCAT:access_service
     slots:
-      - access_id
+      - access_service
+      - has_parameter
     slot_usage:
-      #had_role:
-        # in this context we can auto-fill the role
-        # (but had_role is multivalued, and linkml does not support
-        # defaults for multivalued slots)
-        # ifabsent: string(DCAT:DataService)
-      entity:
-        # must duplicate multivalued property, although unchanged
-        # otherwise linkml will use wrong dtype for identifier
-        # (array of CURIE)
+      access_service:
         multivalued: true
         range: DataService
+      has_parameter:
+        multivalued: true
+        range: Parameter
+
+  Parameter:
+    class_uri: dldist:Parameter
+    is_a: Characteristic
+    description: >-
+      A variable whose value changes the characteristics of a system or a function.
+    exact_mappings:
+      - sio:SIO_000144

--- a/src/distribution/unreleased/examples/DataService-annexremote.json
+++ b/src/distribution/unreleased/examples/DataService-annexremote.json
@@ -1,0 +1,46 @@
+{
+  "id": "https://concepts.datalad.org/ns/annex-uuid/0a8713ca-ef42-11ee-a805-d3e9a774e795",
+  "identifier": [
+    {
+      "notation": "0a8713ca-ef42-11ee-a805-d3e9a774e795",
+      "schema_agency": "https://git-annex.branchable.com"
+    }
+  ],
+  "meta_type": "dldist:DataService",
+  "name": "box.com",
+  "has_property": [
+    {
+      "name": "type",
+      "value": "webdav",
+      "meta_type": "dlthing:Property"
+    },
+    {
+      "name": "url",
+      "type": "DCAT:endpointURL",
+      "value": "https://dav.box.com/dav/git-annex",
+      "meta_type": "dlthing:Property"
+    },
+    {
+      "name": "chunk",
+      "value": "10mb",
+      "meta_type": "dlthing:Property"
+    },
+    {
+      "name": "keyid",
+      "value": "id@joeyh.name",
+      "meta_type": "dlthing:Property"
+    }
+  ],
+  "type": "https://git-annex.branchable.com/special_remotes",
+  "endpoint_description": "https://git-annex.branchable.com/special_remotes/webdav/",
+  "endpoint_url": "https://dav.box.com/dav/git-annex",
+  "has_parameter": [
+    {
+      "description": "git-annex key",
+      "name": "key",
+      "type": "obo:NCIT_C99023",
+      "range": "https://git-annex.branchable.com/internals/key_format"
+    }
+  ],
+  "@type": "DataService"
+}

--- a/src/distribution/unreleased/examples/DataService-annexremote.yaml
+++ b/src/distribution/unreleased/examples/DataService-annexremote.yaml
@@ -1,0 +1,39 @@
+# specification of a git-annex special remote as a DataService
+id: https://concepts.datalad.org/ns/annex-uuid/0a8713ca-ef42-11ee-a805-d3e9a774e795
+meta_type: dldist:DataService
+name: box.com
+# TODO have a definition of a generic annex remote
+type: https://git-annex.branchable.com/special_remotes
+identifier:
+  - notation: 0a8713ca-ef42-11ee-a805-d3e9a774e795
+    schema_agency: https://git-annex.branchable.com
+endpoint_url: https://dav.box.com/dav/git-annex
+# we are using a box.com WebDAV endpoint, but through a git-annex special remote,
+# hence its documentation is the more appropriate description
+endpoint_description: https://git-annex.branchable.com/special_remotes/webdav/
+# as a generic approach specify init/enableremote parameters
+# as key-value pairs. each of them could have associated
+# definitions to communicate the semantics in a more commonly
+# understood way.
+# These are modeled as properties of the dataservice, because the dataservice
+# is a generic git-annex special remote, and only these (fixed) properties
+# define protocol/layout/content of the dataservice
+has_property:
+  - name: type
+    value: webdav
+  - name: url
+    value: https://dav.box.com/dav/git-annex
+    type: DCAT:endpointURL
+  - name: chunk
+    value: 10mb
+  - name: keyid
+    value: id@joeyh.name
+# identification of parameters that have to be provided in order to perform
+# content retrieval
+has_parameter:
+  - name: key
+    description: git-annex key
+    # content identifier
+    type: obo:NCIT_C99023
+    # (ab)use design document on annex keys as range identifier
+    range: https://git-annex.branchable.com/internals/key_format

--- a/src/distribution/unreleased/examples/Distribution-access.json
+++ b/src/distribution/unreleased/examples/Distribution-access.json
@@ -1,0 +1,65 @@
+{
+  "id": "exthisdsver:./some/path.ext",
+  "meta_type": "dldist:Distribution",
+  "relation": [
+    {
+      "id": "https://coscine.example.com",
+      "description": "Central RDM service at example.com",
+      "meta_type": "dldist:DataService",
+      "type": "https://coscine.rwth-aachen.de",
+      "contact_point": "exthisns:coscine-admin",
+      "download_url_template": "https://coscine.example.com/coscine/api/v2/projects/{projectId}/resources/{resourceId}/blobs/{key}",
+      "endpoint_description": "https://coscine.rwth-aachen.de/coscine/api/swagger/v2/swagger.json",
+      "endpoint_url": "https://coscine.example.com/coscine",
+      "has_parameter": [
+        {
+          "description": "Coscine project identifier",
+          "name": "projectId",
+          "type": "obo:NCIT_C165055"
+        },
+        {
+          "description": "Coscine resource identifier",
+          "name": "resourceId",
+          "type": "obo:NCIT_C165071"
+        },
+        {
+          "description": "Coscine blob identifier",
+          "name": "key",
+          "type": "obo:NCIT_C99023"
+        }
+      ]
+    }
+  ],
+  "access_service": [
+    "https://coscine.example.com"
+  ],
+  "access_url": [
+    "https://coscine.example.com/coscine"
+  ],
+  "download_url": [
+    "https://www.example.com/path.ext",
+    "https://coscine.example.com/coscine/api/v2/projects/p123/resources/r456/blobs/k789"
+  ],
+  "qualified_access": [
+    {
+      "access_service": [
+        "https://coscine.example.com"
+      ],
+      "has_parameter": [
+        {
+          "name": "projectId",
+          "value": "p123"
+        },
+        {
+          "name": "resourceId",
+          "value": "r456"
+        },
+        {
+          "name": "key",
+          "value": "k789"
+        }
+      ]
+    }
+  ],
+  "@type": "Distribution"
+}

--- a/src/distribution/unreleased/examples/Distribution-access.yaml
+++ b/src/distribution/unreleased/examples/Distribution-access.yaml
@@ -32,15 +32,37 @@ relation:
     endpoint_description: https://coscine.rwth-aachen.de/coscine/api/swagger/v2/swagger.json
     # API end point
     endpoint_url: https://coscine.example.com/coscine
-    # 
-    endpoint_path: /api/v2/projects/{projectId}/resources/{resourceId}/blobs/{key}
+    # parameter needed to perform an access request can be enumerated.
+    # providing type (and possibly range, description, and default values, can
+    # help to pass useful information to a user, or to implement generic
+    # request handler)
+    has_parameter:
+      - name: projectId
+        description: Coscine project identifier
+        # project identifier
+        type: obo:NCIT_C165055
+      - name: resourceId
+        description: Coscine resource identifier
+        # resource identifier
+        type: obo:NCIT_C165071
+      - name: key
+        description: Coscine blob identifier
+        # content identifier
+        type: obo:NCIT_C99023
+    # specify how download URLs can be determined from a template and
+    # content-specific parameters.
+    # this is optional, but enables generic, dataservice-unspecific download
+    # handler implementations.
+    download_url_template: https://coscine.example.com/coscine/api/v2/projects/{projectId}/resources/{resourceId}/blobs/{key}
+
 # qualified relation to describe how a specific distribution can be obtained
 # from a particular dataservice
 qualified_access:
     # providing dataservice
-  - access_service: https://coscine.example.com
+  - access_service:
+      - https://coscine.example.com
     # service parameter needed for obtaining `exthisdsver:./some/path.ext`
-    access_parameter:
+    has_parameter:
       - name: projectId
         value: p123
       - name: resourceId

--- a/src/distribution/unreleased/examples/Distribution-annexaccess.json
+++ b/src/distribution/unreleased/examples/Distribution-annexaccess.json
@@ -1,53 +1,17 @@
 {
   "id": "https://concepts.datalad.org/ns/annex-key/MD5E-s3214--ba1f2511fc30423bdbb183fe33f3dd0f.csv",
   "meta_type": "dldist:Distribution",
-  "qualified_relation": [
+  "qualified_access": [
     {
-      "had_role": [
-        "DCAT:DataService"
-      ],
-      "entity": [
+      "access_service": [
         "https://concepts.datalad.org/ns/annex-uuid/0a8713ca-ef42-11ee-a805-d3e9a774e795"
       ],
-      "meta_type": "dldist:QualifiedAccess",
-      "access_id": "MD5E-s3214--ba1f2511fc30423bdbb183fe33f3dd0f.csv"
-    }
-  ],
-  "relation": [
-    {
-      "id": "https://concepts.datalad.org/ns/annex-uuid/0a8713ca-ef42-11ee-a805-d3e9a774e795",
-      "identifier": [
+      "has_parameter": [
         {
-          "notation": "0a8713ca-ef42-11ee-a805-d3e9a774e795",
-          "schema_agency": "https://git-annex.branchable.com"
+          "name": "key",
+          "value": "MD5E-s3214--ba1f2511fc30423bdbb183fe33f3dd0f.csv"
         }
-      ],
-      "meta_type": "dldist:DataService",
-      "name": "box.com",
-      "has_property": [
-        {
-          "meta_type": "dlthing:Property",
-          "name": "type",
-          "value": "webdav"
-        },
-        {
-          "meta_type": "dlthing:Property",
-          "name": "url",
-          "type": "DCAT:endpointURL",
-          "value": "https://dav.box.com/dav/git-annex"
-        },
-        {
-          "meta_type": "dlthing:Property",
-          "name": "chunk",
-          "value": "10mb"
-        },
-        {
-          "meta_type": "dlthing:Property",
-          "name": "keyid",
-          "value": "id@joeyh.name"
-        }
-      ],
-      "type": "https://git-annex.branchable.com/special_remotes/webdav"
+      ]
     }
   ],
   "@type": "Distribution"

--- a/src/distribution/unreleased/examples/Distribution-annexaccess.yaml
+++ b/src/distribution/unreleased/examples/Distribution-annexaccess.yaml
@@ -1,37 +1,13 @@
-# specification of a distribution access via a git-annex
-# special remote -- without using specifialized concepts
+# specification of a distribution access via a git-annex special remote
 id: https://concepts.datalad.org/ns/annex-key/MD5E-s3214--ba1f2511fc30423bdbb183fe33f3dd0f.csv
-relation:
-  - id: https://concepts.datalad.org/ns/annex-uuid/0a8713ca-ef42-11ee-a805-d3e9a774e795
-    meta_type: dldist:DataService
-    name: box.com
-    # TODO have a definition of a generic annex remote
-    type: https://git-annex.branchable.com/special_remotes/webdav
-    identifier:
-      - notation: 0a8713ca-ef42-11ee-a805-d3e9a774e795
-        schema_agency: https://git-annex.branchable.com
-    # as a generic approach specify init/enableremote parameters
-    # as key-value pairs. each of them could have associated
-    # definitions to communicate the semantics in a more commonly
-    # understood way
-    has_property:
-      - name: type
-        value: webdav
-      - name: url
-        value: https://dav.box.com/dav/git-annex
-        type: DCAT:endpointURL
-      - name: chunk
-        value: 10mb
-      - name: keyid
-        value: id@joeyh.name
-qualified_relation:
-  - meta_type: dldist:QualifiedAccess
-    # one or more annex remotes ...
-    entity:
+qualified_access:
+  - access_service:
+      # see example DataService-annexremote for a matching specification
       - https://concepts.datalad.org/ns/annex-uuid/0a8713ca-ef42-11ee-a805-d3e9a774e795
-    # ... from which this annex key is available
-    access_id: MD5E-s3214--ba1f2511fc30423bdbb183fe33f3dd0f.csv
-    # we need to make the role explicit, because linkml currently
-    # does not support defaults for multivalued slots
-    had_role:
-      - DCAT:DataService
+        # there could be more remotes from which the same key is provided
+    # identify the annex key matching this Distribution, to complete the information
+    # required to perform a request. The name has to match the parameter specification
+    # of the access service
+    has_parameter:
+      - name: key
+        value: MD5E-s3214--ba1f2511fc30423bdbb183fe33f3dd0f.csv

--- a/src/distribution/unreleased/examples/Distribution-datatypes.json
+++ b/src/distribution/unreleased/examples/Distribution-datatypes.json
@@ -4,10 +4,10 @@
   "has_property": [
     {
       "is_defined_by": "obo:NCIT_C95650",
-      "meta_type": "dlthing:Property",
       "name": "data type",
       "type": "obo:NCIT_C42645",
-      "value": "encapsulated image data"
+      "value": "encapsulated image data",
+      "meta_type": "dlthing:Property"
     }
   ],
   "qualified_relation": [

--- a/src/distribution/unreleased/examples/Distribution-directurlaccess.yaml
+++ b/src/distribution/unreleased/examples/Distribution-directurlaccess.yaml
@@ -1,0 +1,49 @@
+id: exthisdsver:./some/path.ext
+# if a distribution is accessible directly (e.g. HTTP GET)
+# any number of download URLs can be recorded
+download_url: 
+  # file on a webserver
+  - https://www.example.com/path.ext
+  # see the rest of the record below for how this URL is constructed
+  - https://coscine.example.com/coscine/api/v2/projects/p123/resources/r456/blobs/k789
+# if a distribution is not accessible directly,
+# different types of access URLs can be recorded
+access_url:
+  # dataservice query endpoint URL, matching `access_service.endpoint_url`
+  - https://coscine.example.com/coscine
+# references to any data service that can give access to the file
+access_service:
+  - https://coscine.example.com
+# if needed, a dataservice record can be declared inlined as a relation.
+# typically a dataservice would be define in a more general record, rather
+# than inlined in a specific distribution record (done here for demonstration
+# purposes).
+relation:
+  - id: https://coscine.example.com
+    meta_type: dldist:DataService
+    # (ab)using the URL of the upstream instance as a type identifier
+    type: https://coscine.rwth-aachen.de
+    # identify a person/organization to contact for any inquiries about the data service.
+    # value is identifier of an agent record
+    contact_point: exthisns:coscine-admin
+    # any general (human-readable) description of the dataservice
+    description: Central RDM service at example.com
+    # API description
+    endpoint_description: https://coscine.rwth-aachen.de/coscine/api/swagger/v2/swagger.json
+    # API end point
+    endpoint_url: https://coscine.example.com/coscine
+    # 
+    endpoint_path: /api/v2/projects/{projectId}/resources/{resourceId}/blobs/{key}
+# qualified relation to describe how a specific distribution can be obtained
+# from a particular dataservice
+qualified_access:
+    # providing dataservice
+  - access_service: https://coscine.example.com
+    # service parameter needed for obtaining `exthisdsver:./some/path.ext`
+    access_parameter:
+      - name: projectId
+        value: p123
+      - name: resourceId
+        value: r456
+      - name: key
+        value: k789

--- a/src/distribution/unreleased/examples/Distribution-formats.json
+++ b/src/distribution/unreleased/examples/Distribution-formats.json
@@ -1,7 +1,9 @@
 {
   "id": "exthisdsver:.",
+  "conforms_to": [
+    "https://bids-specification.readthedocs.io/en/v1.4.0"
+  ],
   "meta_type": "dldist:Distribution",
-  "conforms_to": "https://bids-specification.readthedocs.io/en/v1.4.0",
   "has_part": [
     {
       "id": "exthisdsver:./dataset_description.json",

--- a/src/distribution/unreleased/examples/Distribution-formats.yaml
+++ b/src/distribution/unreleased/examples/Distribution-formats.yaml
@@ -2,7 +2,8 @@
 id: exthisdsver:.
 # identify a particular version of BIDS as the organization standard
 # used for the distribution
-conforms_to: https://bids-specification.readthedocs.io/en/v1.4.0
+conforms_to:
+  - https://bids-specification.readthedocs.io/en/v1.4.0
 has_part:
   - id: exthisdsver:./dataset_description.json
     # file format specification as IANA media type

--- a/src/distribution/unreleased/examples/Resource-study.json
+++ b/src/distribution/unreleased/examples/Resource-study.json
@@ -9,8 +9,8 @@
       "has_property": [
         {
           "is_defined_by": "obo:PATO_0002204",
-          "meta_type": "dlthing:Property",
-          "type": "obo:PATO_0002201"
+          "type": "obo:PATO_0002201",
+          "meta_type": "dlthing:Property"
         }
       ]
     },
@@ -21,15 +21,15 @@
       "has_property": [
         {
           "is_defined_by": "obo:PATO_0000384",
-          "meta_type": "dlthing:Property",
           "type": "obo:PATO_0000047",
-          "value": "male"
+          "value": "male",
+          "meta_type": "dlthing:Property"
         },
         {
-          "meta_type": "dlthing:QuantitativeProperty",
           "name": "age (years)",
           "type": "obo:NCIT_C37908",
           "value": "36",
+          "meta_type": "dlthing:QuantitativeProperty",
           "unit": "obo:UO_0000036"
         }
       ]

--- a/src/distribution/unreleased/validation/DataService.valid.cfg.yaml
+++ b/src/distribution/unreleased/validation/DataService.valid.cfg.yaml
@@ -1,0 +1,9 @@
+schema: src/distribution/unreleased.yaml
+target_class: DataService
+data_sources:
+  - src/distribution/unreleased/examples/DataService-annexremote.yaml
+plugins:
+  JsonschemaValidationPlugin:
+    closed: true
+    include_range_class_descendants: false
+  RecommendedSlotsPlugin:

--- a/src/distribution/unreleased/validation/Distribution.valid.cfg.yaml
+++ b/src/distribution/unreleased/validation/Distribution.valid.cfg.yaml
@@ -2,6 +2,7 @@ schema: src/distribution/unreleased.yaml
 target_class: Distribution
 data_sources:
   - src/distribution/unreleased/examples/Distribution-basic.yaml
+  - src/distribution/unreleased/examples/Distribution-directurlaccess.yaml
   - src/distribution/unreleased/examples/Distribution-annexaccess.yaml
   - src/distribution/unreleased/examples/Distribution-customlicense.yaml
   - src/distribution/unreleased/examples/Distribution-resource.yaml

--- a/src/distribution/unreleased/validation/Distribution.valid.cfg.yaml
+++ b/src/distribution/unreleased/validation/Distribution.valid.cfg.yaml
@@ -2,7 +2,7 @@ schema: src/distribution/unreleased.yaml
 target_class: Distribution
 data_sources:
   - src/distribution/unreleased/examples/Distribution-basic.yaml
-  - src/distribution/unreleased/examples/Distribution-directurlaccess.yaml
+  - src/distribution/unreleased/examples/Distribution-access.yaml
   - src/distribution/unreleased/examples/Distribution-annexaccess.yaml
   - src/distribution/unreleased/examples/Distribution-customlicense.yaml
   - src/distribution/unreleased/examples/Distribution-resource.yaml

--- a/src/prov/unreleased.yaml
+++ b/src/prov/unreleased.yaml
@@ -44,8 +44,6 @@ prefixes:
   owl: http://www.w3.org/2002/07/owl#
   pav: http://purl.org/pav/
   prov: http://www.w3.org/ns/prov#
-  RDF: http://www.w3.org/1999/02/22-rdf-syntax-ns#
-  RDFS: http://www.w3.org/2000/01/rdf-schema#
   schema: http://schema.org/
   skos: http://www.w3.org/2004/02/skos/core#
   sio: http://semanticscience.org/resource/

--- a/src/prov/unreleased.yaml
+++ b/src/prov/unreleased.yaml
@@ -222,7 +222,7 @@ slots:
   qualified_relation:
     slot_uri: dlprov:qualified_relation
     description: >-
-      TODO
+      Characterizes the relationship or role of an entity with respect to the subject entity.
     exact_mappings:
       - DCAT:qualifiedRelation
     range: EntityInfluence

--- a/src/sdd/unreleased.yaml
+++ b/src/sdd/unreleased.yaml
@@ -40,8 +40,6 @@ prefixes:
   owl: http://www.w3.org/2002/07/owl#
   pav: http://purl.org/pav/
   prov: http://www.w3.org/ns/prov#
-  RDF: http://www.w3.org/1999/02/22-rdf-syntax-ns#
-  RDFS: http://www.w3.org/2000/01/rdf-schema#
   schema: http://schema.org/
   skos: http://www.w3.org/2004/02/skos/core#
   sio: http://semanticscience.org/resource/

--- a/src/sdd/unreleased/examples/Distribution-penguins.json
+++ b/src/sdd/unreleased/examples/Distribution-penguins.json
@@ -270,7 +270,9 @@
           "digest": "e7e2be6b203a221949f05e02fcefd853"
         }
       ],
-      "download_url": "https://portal.edirepository.org/nis/dataviewer?packageid=knb-lter-pal.219.3&entityid=002f3893385f710df69eeebe893144ff",
+      "download_url": [
+        "https://portal.edirepository.org/nis/dataviewer?packageid=knb-lter-pal.219.3&entityid=002f3893385f710df69eeebe893144ff"
+      ],
       "media_type": "text/csv"
     },
     {
@@ -283,7 +285,9 @@
           "digest": "1549566fb97afa879dc9446edcf2015f"
         }
       ],
-      "download_url": "https://portal.edirepository.org/nis/dataviewer?packageid=knb-lter-pal.220.3&entityid=e03b43c924f226486f2f0ab6709d2381",
+      "download_url": [
+        "https://portal.edirepository.org/nis/dataviewer?packageid=knb-lter-pal.220.3&entityid=e03b43c924f226486f2f0ab6709d2381"
+      ],
       "media_type": "text/csv"
     },
     {
@@ -296,7 +300,9 @@
           "digest": "e4b0710c69297031d63866ce8b888f25"
         }
       ],
-      "download_url": "https://portal.edirepository.org/nis/dataviewer?packageid=knb-lter-pal.221.2&entityid=fe853aa8f7a59aa84cdd3197619ef462",
+      "download_url": [
+        "https://portal.edirepository.org/nis/dataviewer?packageid=knb-lter-pal.221.2&entityid=fe853aa8f7a59aa84cdd3197619ef462"
+      ],
       "media_type": "text/csv"
     }
   ],

--- a/src/sdd/unreleased/examples/Distribution-penguins.yaml
+++ b/src/sdd/unreleased/examples/Distribution-penguins.yaml
@@ -12,21 +12,24 @@ has_part:
     checksum:
       - algorithm: md5
         digest: e7e2be6b203a221949f05e02fcefd853
-    download_url: https://portal.edirepository.org/nis/dataviewer?packageid=knb-lter-pal.219.3&entityid=002f3893385f710df69eeebe893144ff
+    download_url:
+      - https://portal.edirepository.org/nis/dataviewer?packageid=knb-lter-pal.219.3&entityid=002f3893385f710df69eeebe893144ff
     media_type: text/csv
   - id: exthisdsver:./gentoo.csv
     byte_size: 11263
     checksum:
       - algorithm: md5
         digest: 1549566fb97afa879dc9446edcf2015f
-    download_url: https://portal.edirepository.org/nis/dataviewer?packageid=knb-lter-pal.220.3&entityid=e03b43c924f226486f2f0ab6709d2381
+    download_url:
+      - https://portal.edirepository.org/nis/dataviewer?packageid=knb-lter-pal.220.3&entityid=e03b43c924f226486f2f0ab6709d2381
     media_type: text/csv
   - id: exthisdsver:./chinstrap.csv
     byte_size: 18872
     checksum:
       - algorithm: md5
         digest: e4b0710c69297031d63866ce8b888f25
-    download_url: https://portal.edirepository.org/nis/dataviewer?packageid=knb-lter-pal.221.2&entityid=fe853aa8f7a59aa84cdd3197619ef462
+    download_url:
+      - https://portal.edirepository.org/nis/dataviewer?packageid=knb-lter-pal.221.2&entityid=fe853aa8f7a59aa84cdd3197619ef462
     media_type: text/csv
 qualified_part:
   - name: adelie.csv

--- a/src/sdd/unreleased/examples/Publication-std.json
+++ b/src/sdd/unreleased/examples/Publication-std.json
@@ -15,29 +15,29 @@
   "meta_type": "dlsdd:Publication",
   "has_property": [
     {
-      "meta_type": "dlthing:Property",
       "name": "DOI",
       "type": "bibo:doi",
-      "value": "https://doi.org/10.1038/s41597-022-01163-2"
+      "value": "https://doi.org/10.1038/s41597-022-01163-2",
+      "meta_type": "dlthing:Property"
     },
     {
-      "meta_type": "dlthing:Property",
       "name": "Volume",
       "type": "bibo:volume",
-      "value": "9"
+      "value": "9",
+      "meta_type": "dlthing:Property"
     },
     {
-      "meta_type": "dlthing:Property",
       "name": "Document number",
       "type": "bibo:number",
-      "value": "80"
+      "value": "80",
+      "meta_type": "dlthing:Property"
     },
     {
-      "meta_type": "dlthing:Property",
       "name": "Number of pages",
       "type": "bibo:numPages",
       "range": "xsd:nonNegativeInteger",
-      "value": "17"
+      "value": "17",
+      "meta_type": "dlthing:Property"
     }
   ],
   "same_as": [

--- a/src/thing/unreleased.yaml
+++ b/src/thing/unreleased.yaml
@@ -33,8 +33,8 @@ prefixes:
   linkml: https://w3id.org/linkml/
   obo: http://purl.obolibrary.org/obo/
   owl: http://www.w3.org/2002/07/owl#
-  RDF: http://www.w3.org/1999/02/22-rdf-syntax-ns#
-  RDFS: http://www.w3.org/2000/01/rdf-schema#
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
+  rdfs: http://www.w3.org/2000/01/rdf-schema#
   sio: http://semanticscience.org/resource/
   skos: http://www.w3.org/2004/02/skos/core#
   # Example convenience namespace that makes it possible to not think about
@@ -80,7 +80,7 @@ slots:
     description: A free-text account of the thing.
     exact_mappings:
       - dcterms:description
-      - RDFS:comment
+      - rdfs:comment
     range: string
 
   has_property:
@@ -128,13 +128,13 @@ slots:
       The definition of the subject thing.
     range: uriorcurie
     exact_mappings:
-      - RDFS:isDefinedBy
+      - rdfs:isDefinedBy
 
   name:
     slot_uri: dlthing:name
     description: Name of a thing.
     exact_mappings:
-      - RDFS:label
+      - rdfs:label
       - schema:name
       - foaf:name
     range: string
@@ -149,7 +149,7 @@ slots:
       - skos:notation
 
   range:
-    slot_uri: RDFS:range
+    slot_uri: rdfs:range
     description: >-
       State that the values of a property are instances of a class.
     range: uriorcurie
@@ -201,7 +201,7 @@ slots:
       - dcterms:type
 
   type:
-    slot_uri: RDF:type
+    slot_uri: rdf:type
     description: >-
       State that the subject is an instance of a class.
     range: uriorcurie
@@ -217,7 +217,7 @@ slots:
       - obo:UO_0000000
 
   value:
-    slot_uri: RDFS:value
+    slot_uri: rdfs:value
     description: >-
       Value of a thing.
     relational_role: OBJECT

--- a/src/thing/unreleased.yaml
+++ b/src/thing/unreleased.yaml
@@ -132,7 +132,7 @@ slots:
   notation:
     slot_uri: dlthing:notation
     description: >-
-      String of characters such as "T58.5" or "303.4833" used to uniquely
+      String of characters such as "T58:5" or "30:4833" used to uniquely
       identify a concept within the scope of a given concept scheme.
     range: string
     exact_mappings:
@@ -260,15 +260,13 @@ classes:
     see_also:
       - https://semiceu.github.io/ADMS/releases/2.00/#Identifier
 
-  Property:
-    class_uri: dlthing:Property
+  Characteristic:
+    class_uri: dlthing:Characteristic
     description: >-
-      An inherent quality, function, disposition or process characteristic
-      that is being observed or measured.
+      An inherent quality, function, disposition or process characteristic.
     slots:
       - description
       - is_defined_by
-      - meta_type
       - name
       - title
       - type
@@ -300,6 +298,17 @@ classes:
             via linkml:Any does not produce a satisfactory solution.
     exact_mappings:
       - sio:SIO_000614
+
+  Property:
+    class_uri: dlthing:Property
+    is_a: Characteristic
+    description: >-
+      An inherent quality, function, disposition or process characteristic
+      that is being observed or measured.
+    slots:
+      - meta_type
+    exact_mappings:
+      - sio:SIO_000613
 
   QuantitativeProperty:
     class_uri: dlthing:QuantitativeProperty

--- a/src/thing/unreleased.yaml
+++ b/src/thing/unreleased.yaml
@@ -65,6 +65,16 @@ imports:
   - linkml:types
 
 slots:
+  conforms_to:
+    slot_uri: dlthing:conforms_to
+    description: >-
+      An established standard to which the subject conforms.
+    range: uriorcurie
+    comments:
+      - This property SHOULD be used to indicate a model, schema, ontology, view or profile that the subject conforms to.
+    exact_mappings:
+      - dcterms:conformsTo
+
   description:
     slot_uri: dlthing:description
     description: A free-text account of the thing.
@@ -220,6 +230,7 @@ classes:
       The most basic item.
     slots:
       - id
+      - conforms_to
       - description
       - identifier
       - is_about
@@ -230,6 +241,8 @@ classes:
       - title
       - type
     slot_usage:
+      conforms_to:
+        multivalued: true
       identifier:
         inlined: true
         inlined_as_list: true

--- a/src/thing/unreleased/examples/Thing-customproperty.json
+++ b/src/thing/unreleased/examples/Thing-customproperty.json
@@ -4,17 +4,17 @@
   "has_property": [
     {
       "is_defined_by": "http://dbpedia.org/resource/Canada",
-      "meta_type": "dlthing:Property",
       "name": "origin country",
       "type": "obo:HSO_0000360",
-      "value": "Canada"
+      "value": "Canada",
+      "meta_type": "dlthing:Property"
     },
     {
-      "meta_type": "dlthing:QuantitativeProperty",
       "name": "biospecimen weight (kg)",
       "type": "obo:NCIT_C181733",
       "range": "xsd:decimal",
       "value": "145.3",
+      "meta_type": "dlthing:QuantitativeProperty",
       "unit": "obo:UO_0000009"
     }
   ],

--- a/src/thing/unreleased/examples/Thing-publication.json
+++ b/src/thing/unreleased/examples/Thing-publication.json
@@ -16,52 +16,52 @@
   "name": "FAIRLy big",
   "has_property": [
     {
-      "meta_type": "dlthing:Property",
       "type": "dcterms:bibliographicCitation",
-      "value": "Wagner, A.S., Waite, L.K., Wierzba, M. et al. FAIRly big: A framework for computationally reproducible processing of large-scale data. Sci Data 9, 80 (2022)."
+      "value": "Wagner, A.S., Waite, L.K., Wierzba, M. et al. FAIRly big: A framework for computationally reproducible processing of large-scale data. Sci Data 9, 80 (2022).",
+      "meta_type": "dlthing:Property"
     },
     {
       "is_defined_by": "https://portal.issn.org/resource/issn/2052-4463",
-      "meta_type": "dlthing:Property",
       "type": "dcterms:isPartOf",
-      "value": "Scientific Data"
+      "value": "Scientific Data",
+      "meta_type": "dlthing:Property"
     },
     {
-      "meta_type": "dlthing:Property",
       "name": "DOI",
       "type": "bibo:doi",
-      "value": "https://doi.org/10.1038/s41597-022-01163-2"
+      "value": "https://doi.org/10.1038/s41597-022-01163-2",
+      "meta_type": "dlthing:Property"
     },
     {
-      "meta_type": "dlthing:Property",
       "name": "Volume",
       "type": "bibo:volume",
-      "value": "9"
+      "value": "9",
+      "meta_type": "dlthing:Property"
     },
     {
-      "meta_type": "dlthing:Property",
       "name": "Document number",
       "type": "bibo:number",
-      "value": "80"
+      "value": "80",
+      "meta_type": "dlthing:Property"
     },
     {
-      "meta_type": "dlthing:Property",
       "name": "Number of pages",
       "type": "bibo:numPages",
       "range": "xsd:nonNegativeInteger",
-      "value": "17"
+      "value": "17",
+      "meta_type": "dlthing:Property"
     },
     {
-      "meta_type": "dlthing:Property",
       "type": "dcterms:modified",
       "range": "xsd:date",
-      "value": "2022-02-11"
+      "value": "2022-02-11",
+      "meta_type": "dlthing:Property"
     },
     {
-      "meta_type": "dlthing:Property",
       "type": "dcterms:date",
       "range": "xsd:date",
-      "value": "2022-03-11"
+      "value": "2022-03-11",
+      "meta_type": "dlthing:Property"
     }
   ],
   "same_as": [


### PR DESCRIPTION
Major changes are:
    
- more useful and accurate `distribution` schema description
- more complete `DataService` class
- new `Parameter` concept
- examples that document the capabilities
    
While most changes more-or-less reflect the continued adoption of `DCAT`
concepts and properties, the introduction of `Parameter` is noteworthy.
    
`Parameter` is a variant of `Property` and serves a similar purpose
(declare arbitrary additional aspects without prescribing a vocabulary
to do so) with only a change in semantics of the class itself. In
contrast to `Property` (observed or measured, fixed), `Parameter` is a
variable with impact on a system or function.
    
Closes #171
    
Via the property `has_parameter` particular parameters can be declared
as supported/needed (e.g., `DataService`), or provided
(`QualifiedAccess`). Examples are included.
    
`QualifiedAccess` is no longer derived from `EntityInfluence` -- it has
been too much of a stretch. It is now focused on access, and no longer
requires a role specification.
    
Closes #156
