### PR TITLE
First attempt at a data provisioning specification

### DIFF
--- a/src/datalad-dataset/unreleased.yaml
+++ b/src/datalad-dataset/unreleased.yaml
@@ -28,7 +28,7 @@ prefixes:
   annex-key: https://concepts.datalad.org/ns/annex-key/
   bibo: http://purl.org/ontology/bibo/
   CiTO: http://purl.org/spar/cito/
-  DCAT: http://www.w3.org/ns/dcat#
+  dcat: http://www.w3.org/ns/dcat#
   datalad-ds: https://concepts.datalad.org/ns/dataset-uuid/
   dcterms: http://purl.org/dc/terms/
   DCTYPES: http://purl.org/dc/dcmitype/
@@ -70,7 +70,7 @@ default_prefix: dldist
 
 emit_prefixes:
   - CiTO
-  - DCAT
+  - dcat
   - dldist
   - licenses
   - marcrel

--- a/src/datalad-dataset/unreleased.yaml
+++ b/src/datalad-dataset/unreleased.yaml
@@ -31,7 +31,7 @@ prefixes:
   dcat: http://www.w3.org/ns/dcat#
   datalad-ds: https://concepts.datalad.org/ns/dataset-uuid/
   dcterms: http://purl.org/dc/terms/
-  DCTYPES: http://purl.org/dc/dcmitype/
+  dctypes: http://purl.org/dc/dcmitype/
   dlco: https://concepts.datalad.org/
   dldist: https://concepts.datalad.org/s/distribution/unreleased/
   dpv: https://w3id.org/dpv#

--- a/src/datalad-dataset/unreleased/examples/Distribution-datasetcontentaccess.json
+++ b/src/datalad-dataset/unreleased/examples/Distribution-datasetcontentaccess.json
@@ -1,0 +1,38 @@
+{
+  "id": "gitsha:eb4d2457a1165519c61859152fe0e3394200d75d",
+  "identifier": [
+    {
+      "notation": "eb4d2457a1165519c61859152fe0e3394200d75d",
+      "schema_agency": "https://git-scm.com"
+    }
+  ],
+  "meta_type": "dldist:Distribution",
+  "type": "https://git-scm.com/book/en/v2/Git-Internals-Git-Objects#_git_commit_objects",
+  "relation": [
+    {
+      "id": "https://github.com/datalad-datasets/machinelearning-books.git",
+      "meta_type": "dldist:DataService",
+      "type": "http://usefulinc.com/ns/doap#GitRepository",
+      "endpoint_url": "https://github.com/datalad-datasets/machinelearning-books.git"
+    }
+  ],
+  "access_service": [
+    "https://github.com/datalad-datasets/machinelearning-books.git"
+  ],
+  "has_part": [
+    {
+      "id": "gitsha:f776e30f386b83e13196eab6445f30d3ab54c155",
+      "meta_type": "dldist:Distribution",
+      "access_service": [
+        "https://github.com/datalad-datasets/machinelearning-books.git"
+      ]
+    }
+  ],
+  "qualified_part": [
+    {
+      "name": "README.md",
+      "entity": "gitsha:f776e30f386b83e13196eab6445f30d3ab54c155"
+    }
+  ],
+  "@type": "Distribution"
+}

--- a/src/datalad-dataset/unreleased/examples/Distribution-datasetcontentaccess.yaml
+++ b/src/datalad-dataset/unreleased/examples/Distribution-datasetcontentaccess.yaml
@@ -1,0 +1,40 @@
+# A dataset version distribution in the form of a Git commit
+id: gitsha:eb4d2457a1165519c61859152fe0e3394200d75d
+# abusing the documentation as a type definition URL of a Git commit
+# TODO define term in `datalad-dataset` schema
+type: https://git-scm.com/book/en/v2/Git-Internals-Git-Objects#_git_commit_objects
+identifier:
+  # a Git SHA
+  notation: eb4d2457a1165519c61859152fe0e3394200d75d
+  schema_agency: https://git-scm.com
+# A hosted (http-accessible) Git repository is the access service for this
+# commit and the associated tree.
+# We could also consider all of GitHub as an access service, and declare
+# `org` and `project as two parameters. This would make sense in a larger
+# setup, but here we are trying to be self-contained and minimal --
+# applicable to any Git repo hosted anywhere
+access_service:
+  - https://github.com/datalad-datasets/machinelearning-books.git
+relation:
+  # we leave inline information on the hosted Git repo in a relation.
+  # use id from access_service property above
+  - id: https://github.com/datalad-datasets/machinelearning-books.git
+    # identify as a dataservice -- not strictly needed for an implementation
+    # that wants to obtain the commit, because we have the id from `access_service`
+    # to match against
+    meta_type: dldist:DataService
+    # we use the DOAP (description of a project) term to identify this dataservice
+    # as a Git repository.
+    # TODO define term in `datalad-dataset` schema
+    type: http://usefulinc.com/ns/doap#GitRepository
+    # endpoint URL is the cloneable URL
+    endpoint_url: https://github.com/datalad-datasets/machinelearning-books.git
+has_part:
+  # use the Git blob SHA as ID
+  # TODO enable `commit:relpath` type identifier?
+  - id: gitsha:f776e30f386b83e13196eab6445f30d3ab54c155
+    access_service:
+    - https://github.com/datalad-datasets/machinelearning-books.git
+qualified_part:
+  name: README.md
+  entity: gitsha:f776e30f386b83e13196eab6445f30d3ab54c155

--- a/src/distribution/unreleased.yaml
+++ b/src/distribution/unreleased.yaml
@@ -53,7 +53,7 @@ prefixes:
   ADMS: http://www.w3.org/ns/adms#
   bibo: http://purl.org/ontology/bibo/
   CiTO: http://purl.org/spar/cito/
-  DCAT: http://www.w3.org/ns/dcat#
+  dcat: http://www.w3.org/ns/dcat#
   dcterms: http://purl.org/dc/terms/
   DCTYPES: http://purl.org/dc/dcmitype/
   dlco: https://concepts.datalad.org/
@@ -93,7 +93,7 @@ default_prefix: dldist
 
 emit_prefixes:
   - CiTO
-  - DCAT
+  - dcat
   - dldist
   - licenses
   - marcrel
@@ -140,10 +140,10 @@ slots:
       - SHOULD be used to link to a description of a dcat:DataService that can provide access to the subject.
     range: DataService
     exact_mappings:
-      - DCAT:accessService
+      - dcat:accessService
     related_mappings:
-      - DCAT:accessURL
-      - DCAT:landingPage
+      - dcat:accessURL
+      - dcat:landingPage
 
   access_url:
     slot_uri: dldist:access_url
@@ -153,10 +153,10 @@ slots:
     comments:
       - If the subject is available directly, typically through a HTTP Get request, `download_url` SHOULD be used instead.
     exact_mappings:
-      - DCAT:accessURL
+      - dcat:accessURL
     related_mappings:
-      - DCAT:downloadURL
-      - DCAT:landingPage
+      - dcat:downloadURL
+      - dcat:landingPage
 
   address:
     slot_uri: dldist:address
@@ -191,7 +191,7 @@ slots:
       The size of a distribution in bytes.
     range: NonNegativeInteger
     exact_mappings:
-      - DCAT:byteSize
+      - dcat:byteSize
 
   checksum:
     slot_uri: dldist:checksum
@@ -208,7 +208,7 @@ slots:
       Relevant contact information for the subject.
     range: Agent
     exact_mappings:
-      - DCAT:contactPoint
+      - dcat:contactPoint
 
   date_modified:
     slot_uri: dldist:date_modified
@@ -247,9 +247,9 @@ slots:
       An available distribution of a resource.
     range: Distribution
     close_mappings:
-      - DCAT:distribution
+      - dcat:distribution
     comments:
-      - Unlike `DCAT:distribution`, this property does not restrict its domain to
+      - Unlike `dcat:distribution`, this property does not restrict its domain to
         a dataset.
 
   download_url:
@@ -260,10 +260,10 @@ slots:
     comments:
       - SHOULD be used for the URL at which this distribution is available directly, typically through a HTTP Get request.
     exact_mappings:
-      - DCAT:downloadURL
+      - dcat:downloadURL
     related_mappings:
-      - DCAT:accessURL
-      - DCAT:landingPage
+      - dcat:accessURL
+      - dcat:landingPage
 
   download_url_template:
     slot_uri: dldist:download_url_template
@@ -294,7 +294,7 @@ slots:
       including their operations, parameters etc.
     range: uri
     exact_mappings:
-      - DCAT:downloadURL
+      - dcat:downloadURL
     related_mappings:
       - dldist:endpoint_url
       - dlthing:conforms_to
@@ -305,7 +305,7 @@ slots:
       The root location or primary endpoint of a service (a Web-resolvable IRI).
     range: uri
     exact_mappings:
-      - DCAT:endpointURL
+      - dcat:endpointURL
     related_mappings:
       - dldist:endpoint_description
       - dlthing:conforms_to
@@ -341,7 +341,7 @@ slots:
   is_distribution_of:
     slot_uri: dldist:is_distribution_of
     description: >-
-      Inverse property of `DCAT:distribution`.
+      Inverse property of `dcat:distribution`.
     domain: Distribution
     range: Resource
     inverse: distribution
@@ -360,7 +360,7 @@ slots:
       A related resource of which the described resource is a version.
     range: uriorcurie
     exact_mappings:
-      - DCAT:isVersionOf
+      - dcat:isVersionOf
 
   keyword:
     slot_uri: dldist:keyword
@@ -379,7 +379,7 @@ slots:
       to a resource, its distributions and/or additional information.
     range: uri
     exact_mappings:
-      - DCAT:landingPage
+      - dcat:landingPage
       - foaf:page
     comments:
       - If the distribution(s) are accessible only through a landing page (i.e., direct download URLs are not known), then the landing page link SHOULD be duplicated as `dldist:access_url` on a distribution.
@@ -392,7 +392,7 @@ slots:
     range: LicenseDocument
     exact_mappings:
       - dcterms:license
-      - DCAT:license
+      - dcat:license
 
   license_text:
     slot_uri: dldist:license_text
@@ -415,15 +415,15 @@ slots:
     see_also:
       - https://www.iana.org/assignments/media-types
     exact_mappings:
-      - DCAT:mediaType
+      - dcat:mediaType
 
   qualified_access:
     slot_uri: dlco:qualified_access
     description: >-
       Link to a description of a `access_service` relationship with
-      `DCAT:DataService`.
+      `dcat:DataService`.
     broad_mappings:
-      - DCAT:qualifiedRelation
+      - dcat:qualifiedRelation
     range: QualifiedAccess
 
   qualified_part:
@@ -431,7 +431,7 @@ slots:
     description: >-
       Qualified a `hasPart` relationship with another entity.
     broad_mappings:
-      - DCAT:qualifiedRelation
+      - dcat:qualifiedRelation
 
   version:
     slot_uri: dldist:version
@@ -439,7 +439,7 @@ slots:
       Version indicator (name or identifier) of a resource.
     range: string
     exact_mappings:
-      - DCAT:version
+      - dcat:version
       - pav:version
 
 
@@ -530,7 +530,7 @@ classes:
         inlined_as_list: true
         range: DistributionPart
     exact_mappings:
-      - DCAT:Distribution
+      - dcat:Distribution
 
   Resource:
     class_uri: dldist:Resource
@@ -554,7 +554,7 @@ classes:
       is_version_of:
         range: Resource
     exact_mappings:
-      - DCAT:Resource
+      - dcat:Resource
 
   LicenseDocument:
     class_uri: dldist:LicenseDocument
@@ -578,7 +578,7 @@ classes:
       An association class for attaching additional information to a
       hasPart relationship.
     broad_mappings:
-      - DCAT:Relationship
+      - dcat:Relationship
     slots:
       - name
       - entity
@@ -643,9 +643,9 @@ classes:
     comments:
       - Characteristics of a particular `Dataservice` that do not vary across `Distributions` that can be requested from the `DataService` are considered properties (`has_property`) of the `Dataservice`. In contrast, information needed in addition for requesting a particular `Distribution` are considered an access request parameter (`has_parameter`). Such parameters can be declared for a `DataService`, and provided for a particular `Distribution` via a dedicated `QualifiedAccess` relation.
     exact_mappings:
-      - DCAT:DataService
+      - dcat:DataService
     broad_mappings:
-      - DCAT:Resource
+      - dcat:Resource
       - DCTYPES:Service
     todos:
       - Enable indication what kind of credentials are required for access, and where to obtain them.
@@ -654,10 +654,10 @@ classes:
     class_uri: dldist:QualifiedAccess
     description: >-
       An association class for attaching additional information to an
-      `access_service` relationship between a `DCAT:Distribution` and
-      a `DCAT:DataService`.
+      `access_service` relationship between a `dcat:Distribution` and
+      a `dcat:DataService`.
     related_mappings:
-      - DCAT:access_service
+      - dcat:access_service
     slots:
       - access_service
       - has_parameter

--- a/src/distribution/unreleased.yaml
+++ b/src/distribution/unreleased.yaml
@@ -55,7 +55,7 @@ prefixes:
   CiTO: http://purl.org/spar/cito/
   dcat: http://www.w3.org/ns/dcat#
   dcterms: http://purl.org/dc/terms/
-  DCTYPES: http://purl.org/dc/dcmitype/
+  dctypes: http://purl.org/dc/dcmitype/
   dlco: https://concepts.datalad.org/
   dldist: https://concepts.datalad.org/s/distribution/unreleased/
   dpv: https://w3id.org/dpv#
@@ -646,7 +646,7 @@ classes:
       - dcat:DataService
     broad_mappings:
       - dcat:Resource
-      - DCTYPES:Service
+      - dctypes:Service
     todos:
       - Enable indication what kind of credentials are required for access, and where to obtain them.
 

--- a/src/distribution/unreleased/examples/DataService-annexremote.json
+++ b/src/distribution/unreleased/examples/DataService-annexremote.json
@@ -16,7 +16,7 @@
     },
     {
       "name": "url",
-      "type": "DCAT:endpointURL",
+      "type": "dcat:endpointURL",
       "value": "https://dav.box.com/dav/git-annex",
       "meta_type": "dlthing:Property"
     },

--- a/src/distribution/unreleased/examples/DataService-annexremote.yaml
+++ b/src/distribution/unreleased/examples/DataService-annexremote.yaml
@@ -23,7 +23,7 @@ has_property:
     value: webdav
   - name: url
     value: https://dav.box.com/dav/git-annex
-    type: DCAT:endpointURL
+    type: dcat:endpointURL
   - name: chunk
     value: 10mb
   - name: keyid

--- a/src/linkml/ontology/common.yaml
+++ b/src/linkml/ontology/common.yaml
@@ -90,7 +90,7 @@ slots:
     range: LicenseDocument
     exact_mappings:
       - dcterms:license
-      - DCAT:license
+      - dcat:license
 
   license_text:
     slot_uri: dlco:license_text
@@ -173,7 +173,7 @@ slots:
       Version indicator (name or identifier) of a resource.
     range: string
     exact_mappings:
-      - DCAT:version
+      - dcat:version
       - pav:version
 
   uuid:

--- a/src/linkml/ontology/datasets.yaml
+++ b/src/linkml/ontology/datasets.yaml
@@ -17,7 +17,7 @@ description: >
   identifier for requesting a particular resource from a `DataService`.
 prefixes:
   afo: http://purl.allotrope.org/ontologies/result#
-  DCAT: http://www.w3.org/ns/dcat#
+  dcat: http://www.w3.org/ns/dcat#
   dctypes: http://purl.org/dc/dcmitype/
   dcterms: http://purl.org/dc/terms/
   dlco: https://concepts.datalad.org/ontology/
@@ -42,17 +42,17 @@ slots:
       - dcterms:identifier
     range: string
     related_mappings:
-      - DCAT:servesDataset
+      - dcat:servesDataset
 
   access_service:
     slot_uri: dlco:access_service
     description: >-
       A data service that gives access to the distribution of a `Resource`
     close_mappings:
-      - DCAT:accessService
+      - dcat:accessService
     range: DataService
     comments:
-      - Unlike `DCAT:access_service`, this property does not restrict its
+      - Unlike `dcat:access_service`, this property does not restrict its
         domain to a dataset.
 
   access_url:
@@ -62,7 +62,7 @@ slots:
       E.g., landing page, feed, SPARQL endpoint.
     range: uri
     close_mappings:
-      - DCAT:accessURL
+      - dcat:accessURL
 
   byte_size:
     slot_uri: dlco:byte_size
@@ -70,7 +70,7 @@ slots:
       The size of a distribution in bytes.
     range: NonNegativeInteger
     exact_mappings:
-      - DCAT:byteSize
+      - dcat:byteSize
 
   distribution:
     slot_uri: dlco:distribution
@@ -78,9 +78,9 @@ slots:
       An available distribution of a resource.
     range: Distribution
     close_mappings:
-      - DCAT:distribution
+      - dcat:distribution
     comments:
-      - Unlike `DCAT:distribution`, this property does not restrict its domain to
+      - Unlike `dcat:distribution`, this property does not restrict its domain to
         a dataset.
 
   download_url:
@@ -89,7 +89,7 @@ slots:
       URL of downloadable resourcefile in a given format.
     range: uri
     exact_mappings:
-      - DCAT:downloadURL
+      - dcat:downloadURL
 
   endpoint_url:
     slot_uri: dlco:endpoint_url
@@ -98,7 +98,7 @@ slots:
       (a resolvable IRI).
     range: uri
     exact_mappings:
-      - DCAT:endpointURL
+      - dcat:endpointURL
 
   is_version_of:
     slot_uri: dlco:is_version_of
@@ -106,7 +106,7 @@ slots:
       A related resource of which the described resource is a version.
     range: uriorcurie
     exact_mappings:
-      - DCAT:isVersionOf
+      - dcat:isVersionOf
 
   landing_page:
     slot_uri: dlco:landing_page
@@ -115,7 +115,7 @@ slots:
       to a resource, its distributions and/or additional information.
     range: uri
     exact_mappings:
-      - DCAT:landingPage
+      - dcat:landingPage
       - foaf:page
     comments:
       - If the distribution(s) are accessible only through a landing page (i.e., direct download URLs are not known), then the landing page link SHOULD be duplicated as `dlco:access_url` on a distribution.
@@ -126,16 +126,16 @@ slots:
     slot_uri: dlco:qualified_access
     description: >-
       Link to a description of a `access_service` relationship with
-      `DCAT:DataService`.
+      `dcat:DataService`.
     broad_mappings:
-      - DCAT:qualifiedRelation
+      - dcat:qualifiedRelation
     range: QualifiedAccess
 
   qualified_relation:
     slot_uri: dlco:qualified_relation
     description: >-
     exact_mappings:
-      - DCAT:qualifiedRelation
+      - dcat:qualifiedRelation
     range: EntityInfluence
 
   qualified_part:
@@ -143,7 +143,7 @@ slots:
     description: >-
       Link to a description of a `hasPart` relationship with another resource.
     broad_mappings:
-      - DCAT:qualifiedRelation
+      - dcat:qualifiedRelation
     range: QualifiedPart
     todos:
       - Rename to `named_part`? See also todo for `QualifiedPart`
@@ -215,7 +215,7 @@ classes:
         description: >-
           Type of resource, e.g. `Dataset`.
     exact_mappings:
-      - DCAT:Resource
+      - dcat:Resource
 
   Relationship:
     class_uri: dlco:Relationship
@@ -232,7 +232,7 @@ classes:
         todos:
           - Ideally this would be a structured_alias to `influencer`. However, this does not seem to work at all in the way that it is described.
     exact_mappings:
-      - DCAT:Relationship
+      - dcat:Relationship
       - prov:EntityInfluence
     broad_mappings:
       - prov:Influence
@@ -250,12 +250,12 @@ classes:
     is_a: Relationship
     description: >-
       An association class for attaching additional information to an
-      `access_service` relationship between a `DCAT:Distribution` and
-      a `DCAT:DataService`.
+      `access_service` relationship between a `dcat:Distribution` and
+      a `dcat:DataService`.
     broad_mappings:
-      - DCAT:Relationship
+      - dcat:Relationship
     related_mappings:
-      - DCAT:access_service
+      - dcat:access_service
     slots:
       - access_id
     slot_usage:
@@ -269,7 +269,7 @@ classes:
       An association class for attaching additional information to a
       hasPart relationship between DCAT Resources
     broad_mappings:
-      - DCAT:Relationship
+      - dcat:Relationship
     slots:
       - name
       - relation
@@ -296,7 +296,7 @@ classes:
       for transfer. Distributions of a dataset can be provided via data
       services.
     exact_mappings:
-      - DCAT:Dataset
+      - dcat:Dataset
       - dctypes:Dataset
       - schema:Dataset
     slots:
@@ -310,7 +310,7 @@ classes:
       A specific representation of a dataset (part). Such a resource
       might be available in multiple serializations.
     close_mappings:
-      - DCAT:Distribution
+      - dcat:Distribution
     slots:
       - access_service
       - access_url
@@ -323,9 +323,9 @@ classes:
       - qualified_attribution
     comments:
       - >-
-        Compared to `DCAT:Distribution` this class has a `qualified_access`
+        Compared to `dcat:Distribution` this class has a `qualified_access`
         property to enable the specification of access-related parameters
-        that cannot be inferred from a standard `DCAT:Distribution`.
+        that cannot be inferred from a standard `dcat:Distribution`.
     todos:
       - Now that there is a `Directory` subclass, re-evaluate the utility
         of the `checksum` property at this level.
@@ -374,9 +374,9 @@ classes:
       A collection of operations that provides access to one or more
       datasets or data processing functions.
     exact_mappings:
-      - DCAT:DataService
+      - dcat:DataService
     broad_mappings:
-      - DCAT:Resource
+      - dcat:Resource
       - dctypes:Service
     slots:
       - endpoint_url

--- a/src/linkml/ontology/git-annex.yaml
+++ b/src/linkml/ontology/git-annex.yaml
@@ -45,7 +45,7 @@ classes:
     is_a: QualifiedAccess
     description: >-
       An association class for attaching additional information to an
-      `access_service` relationship between a `DCAT:Distribution` and
+      `access_service` relationship between a `dcat:Distribution` and
       a `dlco:AnnexRemote`.
     slot_usage:
       relation:

--- a/src/linkml/ontology/provenance.yaml
+++ b/src/linkml/ontology/provenance.yaml
@@ -47,7 +47,7 @@ slots:
     range: Role
     exact_mappings:
       - prov:hadRole
-      - DCAT:had_role
+      - dcat:had_role
     comments:
       - May be used in a qualified-attribution to specify the role of an Agent with respect to an Entity.
       - May be used in a qualified-relation to specify the role of an Entity with respect to another Entity.
@@ -390,7 +390,7 @@ classes:
       resource relationships.
     exact_mappings:
       - prov:Role
-      - DCAT:Role
+      - dcat:Role
 
   #
   # misc concepts

--- a/src/linkml/schemas/dataset-version.yaml
+++ b/src/linkml/schemas/dataset-version.yaml
@@ -18,7 +18,7 @@ license: MIT
 prefixes:
   bibo: http://purl.org/ontology/bibo/
   CiTO: http://purl.org/spar/cito/
-  DCAT: http://www.w3.org/ns/dcat#
+  dcat: http://www.w3.org/ns/dcat#
   dcterms: http://purl.org/dc/terms/
   dlco: https://concepts.datalad.org/ontology/
   dlns: https://concepts.datalad.org/ns/
@@ -35,7 +35,7 @@ prefixes:
 
 emit_prefixes:
   - CiTO
-  - DCAT
+  - dcat
   - dlco
   - licenses
   - customlicenses

--- a/src/prov/unreleased.yaml
+++ b/src/prov/unreleased.yaml
@@ -31,7 +31,7 @@ license: MIT
 prefixes:
   bibo: http://purl.org/ontology/bibo/
   CiTO: http://purl.org/spar/cito/
-  DCAT: http://www.w3.org/ns/dcat#
+  dcat: http://www.w3.org/ns/dcat#
   dcterms: http://purl.org/dc/terms/
   DCTYPES: http://purl.org/dc/dcmitype/
   dlco: https://concepts.datalad.org/
@@ -72,7 +72,7 @@ default_prefix: dlprov
 
 emit_prefixes:
   - CiTO
-  - DCAT
+  - dcat
   - dlprov
   - licenses
   - marcrel
@@ -157,7 +157,7 @@ slots:
     range: Role
     exact_mappings:
       - prov:hadRole
-      - DCAT:had_role
+      - dcat:had_role
     comments:
       - May be used in a qualified-attribution to specify the role of an Agent with respect to an Entity.
       - May be used in a qualified-relation to specify the role of an Entity with respect to another Entity.
@@ -222,7 +222,7 @@ slots:
     description: >-
       Characterizes the relationship or role of an entity with respect to the subject entity.
     exact_mappings:
-      - DCAT:qualifiedRelation
+      - dcat:qualifiedRelation
     range: EntityInfluence
     multivalued: true
 
@@ -488,4 +488,4 @@ classes:
       - id
     exact_mappings:
       - prov:Role
-      - DCAT:Role
+      - dcat:Role

--- a/src/prov/unreleased.yaml
+++ b/src/prov/unreleased.yaml
@@ -33,7 +33,7 @@ prefixes:
   CiTO: http://purl.org/spar/cito/
   dcat: http://www.w3.org/ns/dcat#
   dcterms: http://purl.org/dc/terms/
-  DCTYPES: http://purl.org/dc/dcmitype/
+  dctypes: http://purl.org/dc/dcmitype/
   dlco: https://concepts.datalad.org/
   dlprov: https://concepts.datalad.org/s/prov/unreleased/
   dpv: https://w3id.org/dpv#

--- a/src/sdd/unreleased.yaml
+++ b/src/sdd/unreleased.yaml
@@ -24,7 +24,7 @@ prefixes:
   annex-key: https://concepts.datalad.org/ns/annex-key/
   bibo: http://purl.org/ontology/bibo/
   CiTO: http://purl.org/spar/cito/
-  DCAT: http://www.w3.org/ns/dcat#
+  dcat: http://www.w3.org/ns/dcat#
   datalad-ds: https://concepts.datalad.org/ns/dataset-uuid/
   dcterms: http://purl.org/dc/terms/
   dlco: https://concepts.datalad.org/
@@ -56,7 +56,7 @@ default_prefix: dex
 
 emit_prefixes:
   - CiTO
-  - DCAT
+  - dcat
   - dldist
   - licenses
   - marcrel


### PR DESCRIPTION
The idea here is to use a "dataset description", unmodified, also as a "download specification". The difference is that rather being an exhaustive description, only the minimal information necessary is included to:

- drive a generic data provisioning tool
- precisely identify which data subsets are needed

The included specification asks to provision:

- a Git worktree matching a particular commit
- a particular Git blob from the same repository, presented as a `README.md` file in the worktree.

Closes #174