### PR TITLE
Add prefixes to enable use of CURIEs in shacl ttl export

### DIFF
--- a/src/distribution/unreleased.yaml
+++ b/src/distribution/unreleased.yaml
@@ -58,6 +58,8 @@ prefixes:
   dctypes: http://purl.org/dc/dcmitype/
   dlco: https://concepts.datalad.org/
   dldist: https://concepts.datalad.org/s/distribution/unreleased/
+  dlprov: https://concepts.datalad.org/s/prov/unreleased/
+  dlthing: https://concepts.datalad.org/s/thing/unreleased/
   dpv: https://w3id.org/dpv#
   foaf: http://xmlns.com/foaf/0.1/
   linkml: https://w3id.org/linkml/

--- a/src/prov/unreleased.yaml
+++ b/src/prov/unreleased.yaml
@@ -33,6 +33,7 @@ prefixes:
   dctypes: http://purl.org/dc/dcmitype/
   dlco: https://concepts.datalad.org/
   dlprov: https://concepts.datalad.org/s/prov/unreleased/
+  dlthing: https://concepts.datalad.org/s/thing/unreleased/
   dpv: https://w3id.org/dpv#
   foaf: http://xmlns.com/foaf/0.1/
   gitsha: https://concepts.datalad.org/ns/gitsha/


### PR DESCRIPTION
This makes it easier to interact with the exported shacl as a human, e.g.:

```ttl
<https://concepts.datalad.org/s/thing/unreleased/Property> a sh:NodeShape ;
    sh:closed true ;
    sh:description "An RDF property, a `Thing` used to define a `predicate`, for example in a `Statement`." ;
    sh:ignoredProperties ( rdf:type ) ;
```

vs

```ttl
dlthing:Property a sh:NodeShape ;
    sh:closed true ;
    sh:description "An RDF property, a `Thing` used to define a `predicate`, for example in a `Statement`." ;
    sh:ignoredProperties ( rdf:type ) ;
```

I didn't update prefixes for `sdd` or `datalad-dataset` since IIUC these schemas have yet to be reconsidered after the `Thing` change in any case.