### PR TITLE
Add shaclgen patch for correct handling of `sh:order`

### DIFF
--- a/patches/shaclgen_order.diff
+++ b/patches/shaclgen_order.diff
@@ -1,0 +1,26 @@
+Prevent creation of faulty order lists, where order should just be
+a single numerical value. See for context:
+https://github.com/linkml/linkml/pull/2111#issuecomment-2116208229
+--- shaclgen.py
++++ shaclgen.py
+@@ -112,8 +112,6 @@ class ShaclGenerator(Generator):
+                         g.add((pnode, p, Literal(v)))
+ 
+                 prop_pv(SH.path, slot_uri)
+-                prop_pv_literal(SH.order, order)
+-                order += 1
+                 prop_pv_literal(SH.name, s.title)
+                 prop_pv_literal(SH.description, s.description)
+                 # minCount
+@@ -220,6 +218,11 @@ class ShaclGenerator(Generator):
+                 default_value = ifabsent_processor.process_slot(s, c)
+                 if default_value:
+                     prop_pv(SH.defaultValue, default_value)
++                
++                # sh:order may already have been added to the graph via annotations
++                if not (pnode, SH.order, None) in g:
++                    prop_pv_literal(SH.order, order)
++                    order += 1
+ 
+         return g
+ 

--- a/tools/patch_linkml
+++ b/tools/patch_linkml
@@ -8,3 +8,5 @@
 patch -d $(python -c 'import os; import linkml.generators.jsonschemagen as m; print(os.path.dirname(m.__file__))') < patches/jsonschemagen_mixins.diff
 #patch -d $(python -c 'import os; import linkml.validators.jsonschemavalidator as m; print(os.path.dirname(m.__file__))') < patches/jsonschemavalidator_plainyaml.diff
 #patch -d $(python -c 'import os; import linkml_runtime.dumpers as m; print(os.path.dirname(m.__file__))') < patches/rdflib_dumper_canonical.diff
+# Create correct 'order' properties when generating SHACL
+patch -d $(python -c 'import os; import linkml.generators.shaclgen as m; print(os.path.dirname(m.__file__))') < patches/shaclgen_order.diff


### PR DESCRIPTION
See https://github.com/linkml/linkml/pull/2111#issuecomment-2116208229 for more context. In addition to the suggested fix in that comment, the fix also had to be moved lower down in the shaclgen code in order for it to run _after_ annotations for slots have been added. This wasn't tested before.