### PR TITLE
Switch to non-local imports

### DIFF
--- a/src/prov/unreleased.yaml
+++ b/src/prov/unreleased.yaml
@@ -81,11 +81,11 @@ emit_prefixes:
   - prov
 
 imports:
-  - ../thing/unreleased
-  - ../identifiers/unreleased
-  - ../roles/unreleased
-  - ../spatial/unreleased
-  - ../temporal/unreleased
+  - dlschemas:thing/unreleased
+  - dlschemas:identifiers/unreleased
+  - dlschemas:roles/unreleased
+  - dlschemas:spatial/unreleased
+  - dlschemas:temporal/unreleased
 
 
 slots:

--- a/src/spatial/unreleased.yaml
+++ b/src/spatial/unreleased.yaml
@@ -35,9 +35,9 @@ emit_prefixes:
 default_prefix: dlspatial
 
 imports:
-  - ../identifiers/unreleased
-  - ../thing/unreleased
-  - ../roles/unreleased
+  - dlschemas:identifiers/unreleased
+  - dlschemas:thing/unreleased
+  - dlschemas:roles/unreleased
 
 
 slots:

--- a/src/temporal/unreleased.yaml
+++ b/src/temporal/unreleased.yaml
@@ -31,9 +31,9 @@ default_prefix: dltemporal
 
 imports:
   - linkml:types
-  - ../thing/unreleased
-  - ../identifiers/unreleased
-  - ../roles/unreleased
+  - dlschemas:thing/unreleased
+  - dlschemas:identifiers/unreleased
+  - dlschemas:roles/unreleased
 
 types:
   W3CISO8601:


### PR DESCRIPTION
Local imports break the import implementation of linkml whenever a non-locally imported schema has itself a local import.

Unpleasant...