### PR TITLE
SHACL Property Group schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ build/linkml-docs: \
 	build/linkml-docs/s/identifiers/unreleased \
 	build/linkml-docs/s/distribution/unreleased \
 	build/linkml-docs/s/datalad-dataset/unreleased \
+	build/linkml-docs/s/shacl-propgroups/unreleased \
 	build/linkml-docs/s/sdd/unreleased
 build/linkml-docs/s/%: src/%.yaml src/%/extra-docs
 	gen-doc \
@@ -65,6 +66,7 @@ check-models: \
 	checkmodel/identifiers/unreleased \
 	checkmodel/distribution/unreleased \
 	checkmodel/datalad-dataset/unreleased \
+	checkmodel/shacl-propgroups/unreleased \
 	checkmodel/sdd/unreleased
 checkmodel/%: src/%.yaml
 	@echo [Check $<]
@@ -108,7 +110,9 @@ check-validation: \
 	convertexamples/distribution/unreleased \
 	checkvalidation/distribution/unreleased \
 	convertexamples/datalad-dataset/unreleased \
-	checkvalidation/datalad-dataset/unreleased
+	checkvalidation/datalad-dataset/unreleased \
+	convertexamples/shacl-propgroups/unreleased \
+	checkvalidation/shacl-propgroups/unreleased
 #	convertexamples/sdd/unreleased \
 #	checkvalidation/sdd/unreleased
 checkvalidation/%:
@@ -133,6 +137,7 @@ convert-examples: \
 	convertexamples/identifiers/unreleased \
 	convertexamples/distribution/unreleased \
 	convertexamples/datalad-dataset/unreleased \
+	convertexamples/shacl-propgroups/unreleased \
 	convertexamples/sdd/unreleased
 convertexamples/%: src/%.yaml src/%/examples
 	# loop over all examples, skip the schema file itself

--- a/src/shacl-propgroups/unreleased.yaml
+++ b/src/shacl-propgroups/unreleased.yaml
@@ -1,0 +1,103 @@
+id: https://concepts.datalad.org/s/shacl-propgroups/unreleased
+name: shacl-propgroups-schema
+version: UNRELEASED
+status: bibo:status/draft
+title: Schema for `PropertyGroup`s used in UI annotations of schemas
+description: |
+  This schema provides the structure of a SHACL `PropertyGroup` that can be
+  specified as the value for `sh:group` in UI annotations of slots in a LinkML
+  schema. The aim is to create a conceptual group of slots that belong together
+  in a `sh:PropertyGroup` for the purposes of user interface representation, such
+  as displaying the slots together spatially.
+
+  For more context, see: https://datashapes.org/forms.html#property-groups
+
+  The schema definition is available as
+
+  - [JSON-LD context](../unreleased.jsonld)
+  - [LinkML YAML](../unreleased.yaml)
+  - [OWL TTL](../unreleased.owl.ttl)
+
+comments:
+  - ALL CONTENT HERE IS UNRELEASED AND MAY CHANGE ANY TIME
+
+license: MIT
+
+prefixes:
+  dlco: https://concepts.datalad.org/
+  dlshpg: https://concepts.datalad.org/s/shacl-propgroups/unreleased
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
+  rdfs: http://www.w3.org/2000/01/rdf-schema#
+  sh: http://www.w3.org/ns/shacl#
+  xsd: http://www.w3.org/2001/XMLSchema#
+  linkml: https://w3id.org/linkml/
+
+emit_prefixes:
+  - dlco
+
+imports:
+  - linkml:types
+
+slots:
+  id:
+    identifier: true
+    description: >-
+      The name of the property group that should be unique within the
+      context of a given graph.
+    range: string
+  label:
+    slot_uri: rdfs:label
+    description: >-
+      The label of the property group that will be displayed as the
+      heading of a section for this property group in the user interface
+    range: string
+  order:
+    slot_uri: sh:order
+    description: >-
+      The order that a 
+    range: decimal
+  description:
+    slot_uri: rdfs:comment
+    description: >-
+      A description of the 
+    range: string
+
+classes:
+  PropertyGroup:
+    class_uri: sh:PropertyGroup
+    description: >-
+      A property group will be used by nodes in a graph (i.e. fields) via
+      `sh:group` in order to group these nodes together under a relevant category.
+      All nodes that belong to a specific property group will be rendered together
+      in the resulting UI.
+    slots:
+      - id
+      - label
+      - order
+      - description
+    slot_usage:
+      id:
+        required: true
+      label:
+        required: true
+      order:
+        required: true
+      description:
+        required: true
+    see_also:
+      - https://www.w3.org/TR/shacl/#group
+      - https://datashapes.org/forms.html#property-groups
+  Container:
+    class_uri: dlshpg:Container
+    tree_root: true
+    description: >-
+      A container class to help specify that supplied data
+      should be validated according to provided constraints
+    attributes:
+      property_groups:
+        slot_uri: dlshpg:property_groups
+        description: >-
+          The property groups supplied as a list
+        multivalued: true
+        inlined_as_list: true
+        range: PropertyGroup

--- a/src/shacl-propgroups/unreleased/examples/PropertyGroups.yaml
+++ b/src/shacl-propgroups/unreleased/examples/PropertyGroups.yaml
@@ -1,0 +1,16 @@
+property_groups:
+  - id: dlco:ThingMixinGroup
+    label: Thing Mixin
+    order: 1
+    description: >-
+      Basic properties from the ThingMixin class
+  - id: dlco:ThingBasicGroup
+    label: Thing Basic
+    order: 0
+    description: >-
+      Basic properties from the Thing class
+  - id: dlco:ValueSpecificationMixinGroup
+    label: Value Specification Mixin
+    order: 2
+    description: >-
+      Properties from the ValueSpecificationMixin class

--- a/src/shacl-propgroups/unreleased/validation/PropertyGroups.valid.cfg.yaml
+++ b/src/shacl-propgroups/unreleased/validation/PropertyGroups.valid.cfg.yaml
@@ -1,0 +1,9 @@
+schema: src/shacl-propgroups/unreleased.yaml
+target_class: Container
+data_sources:
+  - src/shacl-propgroups/unreleased/examples/PropertyGroups.yaml
+plugins:
+  JsonschemaValidationPlugin:
+    closed: true
+    include_range_class_descendants: false
+  RecommendedSlotsPlugin:


### PR DESCRIPTION
This adds the property group schema, along with example and validation specification. This schema used for validation of `sh:PropertyGroups` that are specified during UI-specific annotation of LinkML slots, classes, etc. These annotations are useful when the schema is converted to SHACL, which can then in turn be used for the automatic generation of user interfaces influenced by the annotations.

Makefile is also updated accordingly.