### PR TITLE
Add Makefile targets to enable/disable self-contained imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,9 +157,16 @@ convertexamples/%: src/%.yaml src/%/examples
 		exit 22 ; \
 	fi
 
+imports-local:
+	@echo "Switch to local imports"
+	@sed -i -e 's,- dlschemas:\(.*/.*\)$$,- ../../src/\1,' src/*/*.yaml
+
+imports-remote:
+	@echo "Switch to remote imports"
+	@sed -i -e 's,- \.\./\.\./src/\(.*/.*\)$$,- dlschemas:\1,' src/*/*.yaml
 
 clean:
 	rm -rf build
 	rm -f *-stamp
 
-.PHONY: clean check check-models check-validation convert-examples
+.PHONY: clean check check-models check-validation convert-examples localrefs remoterefs


### PR DESCRIPTION
As described in https://github.com/psychoinformatics-de/datalad-concepts/issues/195 we cannot use relative imports. At the same time it is a major complication to exclusively rely on published schemas. This creates the need for a complex update dance.

Here I provide the means to quickly switch from remote to local imports, and vice verse.

`make imports-local`

`make imports-remote`

Sadly, this is not yet a full solution. There could be a complex interplay between doc building and validation and deployment of updates. But it should simplify local development a bit.