### PR TITLE
Remove `DOI` features not supported by the SHACL exporter

### DIFF
--- a/src/identifiers/unreleased.yaml
+++ b/src/identifiers/unreleased.yaml
@@ -103,17 +103,19 @@ classes:
       DOI Foundation, where individual identifiers are issued by one of several registration
       agencies.
     slot_usage:
-      creator:
-        ifabsent: string(https://doi.org)
-        description: By default, the creator is identified as "https://doi.org".
+      # we cannot have this, because `gen-shacl` does not have support for
+      # ifabsent implemented
+      #creator:
+      #  ifabsent: string(https://doi.org)
+      #  description: By default, the creator is identified as "https://doi.org".
       notation:
         description: >-
           The identifier notation is specified without a URL-prefix, or a `doi:` prefix.
-      schema_agency:
-        ifabsent: string(DOI Foundation)
-        description: By default, the schema agency is identified as `DOI Foundation`.
-    defining_slots:
-      - creator
+      # we cannot have this, because `gen-shacl` does not have support for
+      # ifabsent implemented
+      #schema_agency:
+      #  ifabsent: string(DOI Foundation)
+      #  description: By default, the schema agency is identified as `DOI Foundation`.
     unique_keys:
       value:
         description: The DOI notation is globally unique within the scope of DOIs

--- a/src/identifiers/unreleased/examples/DOI-01-minimal.json
+++ b/src/identifiers/unreleased/examples/DOI-01-minimal.json
@@ -1,6 +1,4 @@
 {
   "notation": "10.1038/s41597-022-01163-2",
-  "creator": "https://doi.org",
-  "schema_agency": "DOI Foundation",
   "@type": "DOI"
 }


### PR DESCRIPTION
We need SHACL as a key part of the downstream pipeline. Even if it is sad to not have `creator` and `schema_agency` autofill for a `DOI`, we have no choice but to disable them until support for `ifabsent` is added.

Reported at https://github.com/linkml/linkml/issues/2464#issuecomment-2586513489