### PR TITLE
Bring back DOI `creator` and `schema_agency` via `ifabsent` patch

### DIFF
--- a/patches/shacl_ifabsent.diff
+++ b/patches/shacl_ifabsent.diff
@@ -1,0 +1,14 @@
+This patches shacl_ifabsent_processor.py by adding ifabsent handling for the
+uriorcurie type, which is needed for the 'creator' slot in the identifiers schema
+--- shacl_ifabsent_processor.py
++++ shacl_ifabsent_processor.py
+@@ -62,7 +62,8 @@ class ShaclIfAbsentProcessor(IfAbsentProcessor):
+         return Literal(f"{year}-{month}-{day}T{hour}:{minutes}:{seconds}", datatype=ShaclDataType.DATETIME.uri_ref)
+ 
+     def map_uri_or_curie_default_value(self, default_value: str, slot: SlotDefinition, cls: ClassDefinition):
+-        raise NotImplementedError()
++        uri = URIRef(self.schema_view.expand_curie(default_value))
++        return Literal(uri, datatype=ShaclDataType.URI.uri_ref)
+ 
+     def map_curie_default_value(self, default_value: str, slot: SlotDefinition, cls: ClassDefinition):
+         return Literal(default_value, datatype=ShaclDataType.CURIE.uri_ref)

--- a/src/identifiers/unreleased.yaml
+++ b/src/identifiers/unreleased.yaml
@@ -104,19 +104,15 @@ classes:
       DOI Foundation, where individual identifiers are issued by one of several registration
       agencies.
     slot_usage:
-      # we cannot have this, because `gen-shacl` does not have support for
-      # ifabsent implemented
-      #creator:
-      #  ifabsent: string(https://doi.org)
-      #  description: By default, the creator is identified as "https://doi.org".
+      creator:
+        ifabsent: string(https://doi.org)
+        description: By default, the creator is identified as "https://doi.org".
       notation:
         description: >-
           The identifier notation is specified without a URL-prefix, or a `doi:` prefix.
-      # we cannot have this, because `gen-shacl` does not have support for
-      # ifabsent implemented
-      #schema_agency:
-      #  ifabsent: string(DOI Foundation)
-      #  description: By default, the schema agency is identified as `DOI Foundation`.
+      schema_agency:
+        ifabsent: string(DOI Foundation)
+        description: By default, the schema agency is identified as `DOI Foundation`.
     unique_keys:
       value:
         description: The DOI notation is globally unique within the scope of DOIs

--- a/src/identifiers/unreleased/examples/DOI-01-minimal.json
+++ b/src/identifiers/unreleased/examples/DOI-01-minimal.json
@@ -1,4 +1,6 @@
 {
   "notation": "10.1038/s41597-022-01163-2",
+  "creator": "https://doi.org",
+  "schema_agency": "DOI Foundation",
   "@type": "DOI"
 }

--- a/tools/patch_linkml
+++ b/tools/patch_linkml
@@ -10,3 +10,5 @@ patch -d $(python -c 'import os; import linkml.generators.jsonschemagen as m; pr
 #patch -d $(python -c 'import os; import linkml_runtime.dumpers as m; print(os.path.dirname(m.__file__))') < patches/rdflib_dumper_canonical.diff
 # Create correct 'order' properties when generating SHACL
 patch -d $(python -c 'import os; import linkml.generators.shaclgen as m; print(os.path.dirname(m.__file__))') < patches/shaclgen_annotations.diff
+# Allow ifabsent handling of uriorcurie type during SHACL generation
+patch -d $(python -c 'import os; import linkml.generators.shacl.shacl_ifabsent_processor as m; print(os.path.dirname(m.__file__))') < patches/shacl_ifabsent.diff


### PR DESCRIPTION
This PR brings back the slots `creator` and `schema_agency` in the `identifiers` schema which were previously excluded (see https://github.com/psychoinformatics-de/datalad-concepts/pull/202) because `ifabsent` handling during shacl generation was not supported for the `uriorcurie type`. This is now made possible by the included patch to LinkML's `shacl_ifabsent_processor.py`.

I opted for a new commit that reverses the previous changes, instead of removing the previous commits, in order to keep the history of the thought process.

A PR to add the change to LinkML has been submitted: https://github.com/linkml/linkml/pull/2503. Once that is merged, the patch can be removed here.