### PR TITLE
Switch examples away from schema.org vocab

### DIFF
--- a/src/things/unreleased/examples/Statement-01-minimal.json
+++ b/src/things/unreleased/examples/Statement-01-minimal.json
@@ -1,5 +1,5 @@
 {
   "object": "https://helmholtz.de",
-  "predicate": "schema:about",
+  "predicate": "dcterms:subject",
   "@type": "Statement"
 }

--- a/src/things/unreleased/examples/Statement-01-minimal.yaml
+++ b/src/things/unreleased/examples/Statement-01-minimal.yaml
@@ -1,5 +1,5 @@
 # A statement contains the missing predicate and object to link to
 # a subject in order to form a full RDF triple. Both are required,
 # and both must be referenced (URI or CURIE) and not be inlined.
-predicate: schema:about
+predicate: dcterms:subject
 object: https://helmholtz.de

--- a/src/things/unreleased/examples/Thing-03-topic.json
+++ b/src/things/unreleased/examples/Thing-03-topic.json
@@ -3,7 +3,7 @@
   "is_characterized_by": [
     {
       "object": "https://www.scicrunch.org/resolver/SCR_003931",
-      "predicate": "schema:about"
+      "predicate": "dcterms:subject"
     }
   ],
   "schema_type": "dlthings:Thing",

--- a/src/things/unreleased/examples/Thing-03-topic.yaml
+++ b/src/things/unreleased/examples/Thing-03-topic.yaml
@@ -3,4 +3,4 @@ id: https://doi.org/10.21105/joss.03262
 is_characterized_by:
   # DataLad software
   - object: https://www.scicrunch.org/resolver/SCR_003931
-    predicate: schema:about
+    predicate: dcterms:subject

--- a/src/things/unreleased/examples/Thing-05-publication.json
+++ b/src/things/unreleased/examples/Thing-05-publication.json
@@ -116,19 +116,19 @@
     },
     {
       "object": "https://www.nature.com/subjects/data-processing",
-      "predicate": "schema:about"
+      "predicate": "dcterms:subject"
     },
     {
       "object": "https://www.nature.com/subjects/data-publication-and-archiving",
-      "predicate": "schema:about"
+      "predicate": "dcterms:subject"
     },
     {
       "object": "https://www.nature.com/subjects/software",
-      "predicate": "schema:about"
+      "predicate": "dcterms:subject"
     },
     {
       "object": "https://www.nature.com/articles/s41597-022-01163-2",
-      "predicate": "schema:sameAs"
+      "predicate": "owl:sameAs"
     },
     {
       "object": "https://spdx.org/licenses/CC-BY-4.0",

--- a/src/things/unreleased/examples/Thing-05-publication.yaml
+++ b/src/things/unreleased/examples/Thing-05-publication.yaml
@@ -59,14 +59,14 @@ is_characterized_by:
   - predicate: dcterms:isPartOf
     object: https://portal.issn.org/resource/issn/2052-4463
   # related topics
-  - predicate: schema:about
+  - predicate: dcterms:subject
     object: https://www.nature.com/subjects/data-processing
-  - predicate: schema:about
+  - predicate: dcterms:subject
     object: https://www.nature.com/subjects/data-publication-and-archiving
-  - predicate: schema:about
+  - predicate: dcterms:subject
     object: https://www.nature.com/subjects/software
   # publisher landing page
-  - predicate: schema:sameAs
+  - predicate: owl:sameAs
     object: https://www.nature.com/articles/s41597-022-01163-2
   - predicate: dcterms:license
     object: https://spdx.org/licenses/CC-BY-4.0

--- a/src/things/unreleased/examples/ValueSpecification-02-quantitative-measurement.json
+++ b/src/things/unreleased/examples/ValueSpecification-02-quantitative-measurement.json
@@ -10,11 +10,11 @@
   "is_characterized_by": [
     {
       "object": "obo:IAO_0000109",
-      "predicate": "schema:about"
+      "predicate": "dcterms:subject"
     },
     {
       "object": "obo:PATO_0000125",
-      "predicate": "schema:about"
+      "predicate": "dcterms:subject"
     },
     {
       "object": "obo:UO_0000009",

--- a/src/things/unreleased/examples/ValueSpecification-02-quantitative-measurement.yaml
+++ b/src/things/unreleased/examples/ValueSpecification-02-quantitative-measurement.yaml
@@ -4,10 +4,10 @@ has_attributes:
     value: "measured mass (kg)"
 is_characterized_by:
   # measurement datum
-  - predicate: schema:about
+  - predicate: dcterms:subject
     object: obo:IAO_0000109
   # mass
-  - predicate: schema:about
+  - predicate: dcterms:subject
     object: obo:PATO_0000125
   # unit: kilogram
   - predicate: obo:UO_0000000

--- a/src/things/v1/examples/Statement-01-minimal.json
+++ b/src/things/v1/examples/Statement-01-minimal.json
@@ -1,5 +1,5 @@
 {
   "object": "https://helmholtz.de",
-  "predicate": "schema:about",
+  "predicate": "dcterms:subject",
   "@type": "Statement"
 }

--- a/src/things/v1/examples/Statement-01-minimal.yaml
+++ b/src/things/v1/examples/Statement-01-minimal.yaml
@@ -1,5 +1,5 @@
 # A statement contains the missing predicate and object to link to
 # a subject in order to form a full RDF triple. Both are required,
 # and both must be referenced (URI or CURIE) and not be inlined.
-predicate: schema:about
+predicate: dcterms:subject
 object: https://helmholtz.de

--- a/src/things/v1/examples/Thing-03-topic.json
+++ b/src/things/v1/examples/Thing-03-topic.json
@@ -3,7 +3,7 @@
   "is_characterized_by": [
     {
       "object": "https://www.scicrunch.org/resolver/SCR_003931",
-      "predicate": "schema:about"
+      "predicate": "dcterms:subject"
     }
   ],
   "schema_type": "dlthings:Thing",

--- a/src/things/v1/examples/Thing-03-topic.yaml
+++ b/src/things/v1/examples/Thing-03-topic.yaml
@@ -3,4 +3,4 @@ id: https://doi.org/10.21105/joss.03262
 is_characterized_by:
   # DataLad software
   - object: https://www.scicrunch.org/resolver/SCR_003931
-    predicate: schema:about
+    predicate: dcterms:subject

--- a/src/things/v1/examples/Thing-05-publication.json
+++ b/src/things/v1/examples/Thing-05-publication.json
@@ -116,19 +116,19 @@
     },
     {
       "object": "https://www.nature.com/subjects/data-processing",
-      "predicate": "schema:about"
+      "predicate": "dcterms:subject"
     },
     {
       "object": "https://www.nature.com/subjects/data-publication-and-archiving",
-      "predicate": "schema:about"
+      "predicate": "dcterms:subject"
     },
     {
       "object": "https://www.nature.com/subjects/software",
-      "predicate": "schema:about"
+      "predicate": "dcterms:subject"
     },
     {
       "object": "https://www.nature.com/articles/s41597-022-01163-2",
-      "predicate": "schema:sameAs"
+      "predicate": "owl:sameAs"
     },
     {
       "object": "https://spdx.org/licenses/CC-BY-4.0",

--- a/src/things/v1/examples/Thing-05-publication.yaml
+++ b/src/things/v1/examples/Thing-05-publication.yaml
@@ -59,14 +59,14 @@ is_characterized_by:
   - predicate: dcterms:isPartOf
     object: https://portal.issn.org/resource/issn/2052-4463
   # related topics
-  - predicate: schema:about
+  - predicate: dcterms:subject
     object: https://www.nature.com/subjects/data-processing
-  - predicate: schema:about
+  - predicate: dcterms:subject
     object: https://www.nature.com/subjects/data-publication-and-archiving
-  - predicate: schema:about
+  - predicate: dcterms:subject
     object: https://www.nature.com/subjects/software
   # publisher landing page
-  - predicate: schema:sameAs
+  - predicate: owl:sameAs
     object: https://www.nature.com/articles/s41597-022-01163-2
   - predicate: dcterms:license
     object: https://spdx.org/licenses/CC-BY-4.0

--- a/src/things/v1/examples/ValueSpecification-02-quantitative-measurement.json
+++ b/src/things/v1/examples/ValueSpecification-02-quantitative-measurement.json
@@ -10,11 +10,11 @@
   "is_characterized_by": [
     {
       "object": "obo:IAO_0000109",
-      "predicate": "schema:about"
+      "predicate": "dcterms:subject"
     },
     {
       "object": "obo:PATO_0000125",
-      "predicate": "schema:about"
+      "predicate": "dcterms:subject"
     },
     {
       "object": "obo:UO_0000009",

--- a/src/things/v1/examples/ValueSpecification-02-quantitative-measurement.yaml
+++ b/src/things/v1/examples/ValueSpecification-02-quantitative-measurement.yaml
@@ -4,10 +4,10 @@ has_attributes:
     value: "measured mass (kg)"
 is_characterized_by:
   # measurement datum
-  - predicate: schema:about
+  - predicate: dcterms:subject
     object: obo:IAO_0000109
   # mass
-  - predicate: schema:about
+  - predicate: dcterms:subject
     object: obo:PATO_0000125
   # unit: kilogram
   - predicate: obo:UO_0000000


### PR DESCRIPTION
It is not a prefix exported by the Things schema.