### PR TITLE
Migrate to EU vocab named authority list (NAL) for concept status

### DIFF
--- a/src/datalad-dataset/unreleased.yaml
+++ b/src/datalad-dataset/unreleased.yaml
@@ -1,7 +1,7 @@
 id: https://concepts.datalad.org/s/datalad-dataset/unreleased
 name: datalad-dataset-schema
 version: UNRELEASED
-status: bibo:status/draft
+status: eunal:concept-status/DRAFT
 title: Base schema used by the DataLad dataset (de)serializer
 description: |
   At the moment, this is largely identical to the [distribution](https://concepts.datalad.org/s/distribution) schema.
@@ -37,6 +37,7 @@ prefixes:
   dlschemas: https://concepts.datalad.org/s/
   dldist: https://concepts.datalad.org/s/distribution/unreleased/
   dpv: https://w3id.org/dpv#
+  eunal: http://publications.europa.eu/resource/authority/
   foaf: http://xmlns.com/foaf/0.1/
   gitsha: https://concepts.datalad.org/ns/gitsha/
   linkml: https://w3id.org/linkml/

--- a/src/distribution/unreleased.yaml
+++ b/src/distribution/unreleased.yaml
@@ -1,7 +1,7 @@
 id: https://concepts.datalad.org/s/distribution/unreleased
 name: distribution-schema
 version: UNRELEASED
-status: bibo:status/draft
+status: eunal:concept-status/DRAFT
 title: Schema for a generic data distribution record
 description: |
   This schema is centered on the [`Distribution`](Distribution) class for
@@ -63,6 +63,7 @@ prefixes:
   dlprov: https://concepts.datalad.org/s/prov/unreleased/
   dlthings: https://concepts.datalad.org/s/things/v1/
   dpv: https://w3id.org/dpv#
+  eunal: http://publications.europa.eu/resource/authority/
   foaf: http://xmlns.com/foaf/0.1/
   # custom prefix to use Git's SHA identifiers as schema identifiers
   gitsha: https://concepts.datalad.org/ns/gitsha/

--- a/src/identifiers/unreleased.yaml
+++ b/src/identifiers/unreleased.yaml
@@ -1,7 +1,7 @@
 id: https://concepts.datalad.org/s/identifiers/unreleased
 name: identifiers-schema
 version: UNRELEASED
-status: bibo:status/draft
+status: eunal:concept-status/DRAFT
 title: Schema components to express identifiers of things
 description: |
   This schema implements some aspects of the [identifier
@@ -29,6 +29,7 @@ prefixes:
   dlco: https://concepts.datalad.org/
   dlschemas: https://concepts.datalad.org/s/
   dlidentifiers: https://concepts.datalad.org/s/identifiers/unreleased/
+  eunal: http://publications.europa.eu/resource/authority/
   linkml: https://w3id.org/linkml/
   skos: http://www.w3.org/2004/02/skos/core#
 

--- a/src/properties/unreleased.yaml
+++ b/src/properties/unreleased.yaml
@@ -1,7 +1,7 @@
 id: https://concepts.datalad.org/s/properties/unreleased
 name: properties-schema
 version: UNRELEASED
-status: bibo:status/draft
+status: eunal:concept-status/DRAFT
 title: Collection of common properties for use in schemas
 description: |
   This schema provides a collection of common properties for use in other
@@ -37,6 +37,7 @@ prefixes:
   dlco: https://concepts.datalad.org/
   dlschemas: https://concepts.datalad.org/s/
   dlprops: https://concepts.datalad.org/s/properties/unreleased/
+  eunal: http://publications.europa.eu/resource/authority/
   foaf: http://xmlns.com/foaf/0.1/
   linkml: https://w3id.org/linkml/
   obo: http://purl.obolibrary.org/obo/

--- a/src/prov/unreleased.yaml
+++ b/src/prov/unreleased.yaml
@@ -1,7 +1,7 @@
 id: https://concepts.datalad.org/s/prov/unreleased
 name: prov-schema
 version: UNRELEASED
-status: bibo:status/draft
+status: eunal:concept-status/DRAFT
 title: Schema for a generic (data) provenance annotation
 description: |
   This schema builds on the [Thing
@@ -64,6 +64,7 @@ prefixes:
   dlidentifiers: https://concepts.datalad.org/s/identifiers/unreleased/
   dlroles: https://concepts.datalad.org/s/roles/unreleased/
   dlthings: https://concepts.datalad.org/s/things/v1/
+  eunal: http://publications.europa.eu/resource/authority/
   foaf: http://xmlns.com/foaf/0.1/
   linkml: https://w3id.org/linkml/
   obo: http://purl.obolibrary.org/obo/

--- a/src/roles/unreleased.yaml
+++ b/src/roles/unreleased.yaml
@@ -1,7 +1,7 @@
 id: https://concepts.datalad.org/s/roles/unreleased
 name: roles-schema
 version: UNRELEASED
-status: bibo:status/draft
+status: eunal:concept-status/DRAFT
 title: Schema for characterizing relationships with roles
 description: |
   This schema provides the most basic classes and slots to qualify
@@ -37,6 +37,7 @@ prefixes:
   dlco: https://concepts.datalad.org/
   dlschemas: https://concepts.datalad.org/s/
   dlroles: https://concepts.datalad.org/s/roles/unreleased/
+  eunal: http://publications.europa.eu/resource/authority/
   linkml: https://w3id.org/linkml/
   prov: http://www.w3.org/ns/prov#
   marcrel: http://id.loc.gov/vocabulary/relators/

--- a/src/sdd/unreleased.yaml
+++ b/src/sdd/unreleased.yaml
@@ -1,7 +1,7 @@
 id: https://concepts.datalad.org/s/sdd/unreleased
 name: sdd
 version: UNRELEASED
-status: bibo:status/draft
+status: eunal:concept-status/DRAFT
 title: Scientific data distribution
 description: |
   At the moment, this is no more than a place for moving existing concepts too
@@ -36,6 +36,7 @@ prefixes:
   dlsdd: https://concepts.datalad.org/s/sdd/unreleased/
   dex: https://example.org/ns/ex/terms/
   dpv: https://w3id.org/dpv#
+  eunal: http://publications.europa.eu/resource/authority/
   foaf: http://xmlns.com/foaf/0.1/
   gitsha: https://concepts.datalad.org/ns/gitsha/
   linkml: https://w3id.org/linkml/

--- a/src/spatial/unreleased.yaml
+++ b/src/spatial/unreleased.yaml
@@ -1,7 +1,7 @@
 id: https://concepts.datalad.org/s/spatial/unreleased
 name: spatial-schema
 version: UNRELEASED
-status: bibo:status/draft
+status: eunal:concept-status/DRAFT
 title: Schema for characterizing spatial concepts
 description: |
 
@@ -25,6 +25,7 @@ prefixes:
   dlidentifiers: https://concepts.datalad.org/s/identifiers/unreleased/
   dlroles: https://concepts.datalad.org/s/roles/unreleased/
   dlthings: https://concepts.datalad.org/s/things/v1/
+  eunal: http://publications.europa.eu/resource/authority/
   linkml: https://w3id.org/linkml/
   prov: http://www.w3.org/ns/prov#
   # disambiguate a GEO URI from a curie prefix

--- a/src/temporal/unreleased.yaml
+++ b/src/temporal/unreleased.yaml
@@ -1,7 +1,7 @@
 id: https://concepts.datalad.org/s/temporal/unreleased
 name: temporal-schema
 version: UNRELEASED
-status: bibo:status/draft
+status: eunal:concept-status/DRAFT
 title: Schema for characterizing temporal concepts
 description: |
 
@@ -25,6 +25,7 @@ prefixes:
   dlidentifiers: https://concepts.datalad.org/s/identifiers/unreleased/
   dlroles: https://concepts.datalad.org/s/roles/unreleased/
   dlthings: https://concepts.datalad.org/s/things/v1/
+  eunal: http://publications.europa.eu/resource/authority/
   linkml: https://w3id.org/linkml/
   prov: http://www.w3.org/ns/prov#
 

--- a/src/things/unreleased.yaml
+++ b/src/things/unreleased.yaml
@@ -2,8 +2,7 @@ id: https://concepts.datalad.org/s/things/unreleased
 name: things-schema
 # only the major version is reflected in the identifier, but this is the full version
 version: 1.0.0-prerelease
-# TODO: this needs a proper URI, even the linkml example bibo:draft is not valid
-status: bibo:status/draft
+status: eunal:concept-status/DRAFT
 title: Generic schema for an arbitrarily detailed description of "things"
 description: |
   *This is an unreleased development version*
@@ -53,6 +52,7 @@ prefixes:
   dlco: https://concepts.datalad.org/
   dlschemas: https://concepts.datalad.org/s/
   dlthings: https://concepts.datalad.org/s/things/unreleased/
+  eunal: http://publications.europa.eu/resource/authority/
   linkml: https://w3id.org/linkml/
   obo: http://purl.obolibrary.org/obo/
   owl: http://www.w3.org/2002/07/owl#

--- a/src/things/v1.yaml
+++ b/src/things/v1.yaml
@@ -2,8 +2,7 @@ id: https://concepts.datalad.org/s/things/v1
 name: things-schema
 # only the major version is reflected in the identifier, but this is the full version
 version: 1.0.0-prerelease
-# TODO: this needs a proper URI, even the linkml example bibo:draft is not valid
-status: bibo:status/draft
+status: eunal:concept-status/DRAFT
 title: Generic schema for an arbitrarily detailed description of "things"
 description: |
   STILL A DRAFT!!
@@ -56,6 +55,7 @@ prefixes:
   dlco: https://concepts.datalad.org/
   dlschemas: https://concepts.datalad.org/s/
   dlthings: https://concepts.datalad.org/s/things/v1/
+  eunal: http://publications.europa.eu/resource/authority/
   linkml: https://w3id.org/linkml/
   obo: http://purl.obolibrary.org/obo/
   owl: http://www.w3.org/2002/07/owl#


### PR DESCRIPTION
Previously, we used an outdated/removed `bibo` term. After researching candidates (see #227), the EU vocabulary's named authority lists seems to provide the best matching classification system with `concept-status`.

This change introduces a `eunal:` prefix to facilitate adoption of other NALs provided there (dataset, distribution, file, event, product), and migrates all schema status declarations to it.