### PR TITLE
Represent a checksum as a computed identifier

### DIFF
--- a/src/datalad-dataset/unreleased/examples/Distribution-annexkey.json
+++ b/src/datalad-dataset/unreleased/examples/Distribution-annexkey.json
@@ -4,8 +4,9 @@
   "byte_size": 3214,
   "checksum": [
     {
-      "algorithm": "spdx:checksumAlgorithm_md5",
-      "digest": "ba1f2511fc30423bdbb183fe33f3dd0f"
+      "notation": "ba1f2511fc30423bdbb183fe33f3dd0f",
+      "creator": "spdx:checksumAlgorithm_md5",
+      "type": "dlidentifiers:Checksum"
     }
   ],
   "media_type": "text/csv",

--- a/src/datalad-dataset/unreleased/examples/Distribution-annexkey.yaml
+++ b/src/datalad-dataset/unreleased/examples/Distribution-annexkey.yaml
@@ -1,6 +1,6 @@
 id: annex-key:MD5E-s3214--ba1f2511fc30423bdbb183fe33f3dd0f.csv
 byte_size: 3214
 checksum:
-  - algorithm: spdx:checksumAlgorithm_md5
-    digest: ba1f2511fc30423bdbb183fe33f3dd0f
+  - creator: spdx:checksumAlgorithm_md5
+    notation: ba1f2511fc30423bdbb183fe33f3dd0f
 media_type: text/csv

--- a/src/distribution/unreleased.yaml
+++ b/src/distribution/unreleased.yaml
@@ -123,13 +123,6 @@ types:
       - The validation regex is taken from https://stackoverflow.com/a/201378
       - The regex is single-quoted for YAML encoding, hence all inner "'" have been doubled
 
-  HexBinary:
-    uri: xsd:hexBinary
-    base: str
-    pattern: "^[a-fA-F0-9]+$"
-    description: >-
-      hex-encoded binary data.
-
   NonNegativeInteger:
     uri: xsd:nonNegativeInteger
     base: int
@@ -186,16 +179,6 @@ slots:
     exact_mappings:
       - schema:affiliation
 
-  algorithm:
-    description: >-
-      The algorithm or rules to follow to compute a score, an effective method
-      expressed as a finite list of well-defined instructions for calculating
-      a function.
-    range: uriorcurie
-    exact_mappings:
-      - schema:algorithm
-      - obo:IAO_0000064
-
   byte_size:
     slot_uri: dldist:byte_size
     description: >-
@@ -242,15 +225,6 @@ slots:
     notes:
       - successful validation with `datetime` as a range and linkml-jsonschema-validate` depends on a patched linkml, see https://github.com/linkml/linkml/issues/1806
       - a related problem also exists for `linkml-validate`, we cannot have a more specific range right now
-
-  digest:
-    slot_uri: dldist:digest
-    description: >-
-      Lower case hexadecimal encoded checksum digest value produced using a
-      specific algorithm.
-    range: HexBinary
-    exact_mappings:
-      - spdx:checksumValue
 
   distribution:
     slot_uri: dldist:distribution
@@ -558,27 +532,6 @@ classes:
       - This class is a key element of the data model. It enables referencing
         a particular resource (e.g., a file's content, or versioned directory
         tree in multiple contexts, such as different versions of a dataset).
-
-  #
-  # utilities
-  #
-  Checksum:
-    class_uri: dldist:Checksum
-    description: >-
-      A Checksum is a value that allows to check the integrity of the contents
-      of a file. Even small changes to the content of the file will change its
-      checksum. This class allows the results of a variety of checksum and
-      cryptographic message digest algorithms to be represented.
-    slots:
-      - algorithm
-      - digest
-    slot_usage:
-      algorithm:
-        slot_uri: spdx:algorithm
-        description: >-
-          Identifies the algorithm used to produce the subject `Checksum`.
-    exact_mappings:
-      - spdx:Checksum
 
   #
   # data access

--- a/src/distribution/unreleased/examples/Distribution-annexkey.json
+++ b/src/distribution/unreleased/examples/Distribution-annexkey.json
@@ -4,8 +4,9 @@
   "byte_size": 3214,
   "checksum": [
     {
-      "algorithm": "spdx:checksumAlgorithm_md5",
-      "digest": "ba1f2511fc30423bdbb183fe33f3dd0f"
+      "notation": "ba1f2511fc30423bdbb183fe33f3dd0f",
+      "creator": "spdx:checksumAlgorithm_md5",
+      "type": "dlidentifiers:Checksum"
     }
   ],
   "media_type": "text/csv",

--- a/src/distribution/unreleased/examples/Distribution-annexkey.yaml
+++ b/src/distribution/unreleased/examples/Distribution-annexkey.yaml
@@ -1,6 +1,6 @@
 id: https://concepts.datalad.org/ns/annex-key/MD5E-s3214--ba1f2511fc30423bdbb183fe33f3dd0f.csv
 byte_size: 3214
 checksum:
-  - algorithm: spdx:checksumAlgorithm_md5
-    digest: ba1f2511fc30423bdbb183fe33f3dd0f
+  - creator: spdx:checksumAlgorithm_md5
+    notation: ba1f2511fc30423bdbb183fe33f3dd0f
 media_type: text/csv

--- a/src/distribution/unreleased/examples/Distribution-basic.json
+++ b/src/distribution/unreleased/examples/Distribution-basic.json
@@ -11,12 +11,14 @@
   "byte_size": 123456789,
   "checksum": [
     {
-      "algorithm": "spdx:checksumAlgorithm_md5",
-      "digest": "32a617360d10e3dcbfdd0885e8d64ab8"
+      "notation": "32a617360d10e3dcbfdd0885e8d64ab8",
+      "creator": "spdx:checksumAlgorithm_md5",
+      "type": "dlidentifiers:Checksum"
     },
     {
-      "algorithm": "spdx:checksumAlgorithm_sha1",
-      "digest": "c7dbac946b9860cf05a7d696b9e9591c60083859"
+      "notation": "c7dbac946b9860cf05a7d696b9e9591c60083859",
+      "creator": "spdx:checksumAlgorithm_sha1",
+      "type": "dlidentifiers:Checksum"
     }
   ],
   "date_modified": "2024-03-21",

--- a/src/distribution/unreleased/examples/Distribution-basic.yaml
+++ b/src/distribution/unreleased/examples/Distribution-basic.yaml
@@ -15,7 +15,7 @@ has_attributes:
 # Checksum information is inlined, because additional linkage
 # to a unique content checksum value is an unlikely use case
 checksum:
-  - algorithm: spdx:checksumAlgorithm_md5
-    digest: 32a617360d10e3dcbfdd0885e8d64ab8
-  - algorithm: spdx:checksumAlgorithm_sha1
-    digest: c7dbac946b9860cf05a7d696b9e9591c60083859
+  - creator: spdx:checksumAlgorithm_md5
+    notation: 32a617360d10e3dcbfdd0885e8d64ab8
+  - creator: spdx:checksumAlgorithm_sha1
+    notation: c7dbac946b9860cf05a7d696b9e9591c60083859

--- a/src/distribution/unreleased/examples/Distribution-gitblob.json
+++ b/src/distribution/unreleased/examples/Distribution-gitblob.json
@@ -4,8 +4,9 @@
   "byte_size": 63165,
   "checksum": [
     {
-      "algorithm": "spdx:checksumAlgorithm_sha1",
-      "digest": "0410b851ebd2282ac37558885db16782f31626db"
+      "notation": "0410b851ebd2282ac37558885db16782f31626db",
+      "creator": "spdx:checksumAlgorithm_sha1",
+      "type": "dlidentifiers:Checksum"
     }
   ],
   "media_type": "text/html",

--- a/src/distribution/unreleased/examples/Distribution-gitblob.yaml
+++ b/src/distribution/unreleased/examples/Distribution-gitblob.yaml
@@ -2,6 +2,6 @@ id: gitsha:e12e9505cff5417f594d719b99720b4c39d86434
 byte_size: 63165
 checksum:
   # gitsha and content sha1 are not one and the same thing
-  - algorithm: spdx:checksumAlgorithm_sha1
-    digest: 0410b851ebd2282ac37558885db16782f31626db
+  - creator: spdx:checksumAlgorithm_sha1
+    notation: 0410b851ebd2282ac37558885db16782f31626db
 media_type: text/html

--- a/src/identifiers/unreleased.yaml
+++ b/src/identifiers/unreleased.yaml
@@ -10,6 +10,10 @@ description: |
   (ADMS). The provided [`identifiers` slot](identifiers) can be used to annotate
   entities with identifiers with arbitrary scopes and issued by arbitrary agencies.
 
+  The schema also covered "content identifier" that are directly derived from
+  an entity ([`ComputedIdentifier`](ComputedIdentifier)), and a
+  [`Checksum`](Checksum) in particular.
+
   The schema definition is available as
 
   - [JSON-LD context](../unreleased.jsonld)
@@ -24,18 +28,18 @@ license: MIT
 
 prefixes:
   ADMS: http://www.w3.org/ns/adms#
-  bibo: http://purl.org/ontology/bibo/
   dcterms: http://purl.org/dc/terms/
-  dlco: https://concepts.datalad.org/
   dlschemas: https://concepts.datalad.org/s/
   dlidentifiers: https://concepts.datalad.org/s/identifiers/unreleased/
   eunal: http://publications.europa.eu/resource/authority/
   linkml: https://w3id.org/linkml/
   skos: http://www.w3.org/2004/02/skos/core#
+  spdx: http://spdx.org/rdf/terms#
 
 default_prefix: dlidentifiers
 
 imports:
+  - dlschemas:types/unreleased
   - linkml:types
 
 slots:
@@ -83,23 +87,69 @@ classes:
     description: >-
       An identifier is a label that uniquely identifies an item in a
       particular context. Some identifiers are globally unique. All
-      identifiers are unique within the scope of their issuing
-      agency.
+      identifiers are unique within their individual scope.
     slots:
       - creator
       - notation
-      - schema_agency
+      - type
     slot_usage:
       notation:
         required: true
+    close_mappings:
+      - ADMS:Identifier
+
+  IssuedIdentifier:
+    class_uri: dlidentifiers:IssuedIdentifier
+    is_a: Identifier
+    description: >-
+      An identifier that was issued by a particular agent with a notation
+      that has no (or an undefined) relation to the nature of the identified
+      entity.
+    slots:
+      - schema_agency
     exact_mappings:
       - ADMS:Identifier
     see_also:
       - https://semiceu.github.io/ADMS/releases/2.00/#Identifier
 
+  ComputedIdentifier:
+    class_uri: dlidentifiers:ComputedIdentifier
+    is_a: Identifier
+    description: >-
+      An identifier that has been derived from information on the identified
+      entity.
+    narrow_mappings:
+      - spdx:Checksum
+
+  Checksum:
+    class_uri: dlidentifiers:Checksum
+    is_a: ComputedIdentifier
+    description: >-
+      A Checksum is a value that allows to check the integrity of the contents
+      of a file. Even small changes to the content of the file will change its
+      checksum. This class allows the results of a variety of checksum and
+      cryptographic message digest algorithms to be represented.
+    exact_mappings:
+      - spdx:Checksum
+    slot_usage:
+      creator:
+        description: >-
+          Identifies the software agent (algorithm) used to produce the subject
+          `Checksum`.
+        required: true
+        exact_mappings:
+          - spdx:algorithm
+      notation:
+        description: >-
+          Lower case hexadecimal encoded checksum digest value.
+        range: HexBinary
+        required: true
+        exact_mappings:
+          - spdx:checksumValue
+
   DOI:
     class_uri: dlidentifiers:DOI
-    is_a: Identifier
+    is_a: IssuedIdentifier
     description: >-
       Digital Object Identifier (DOI; ISO 26324), an identifier system governed by the
       DOI Foundation, where individual identifiers are issued by one of several registration

--- a/src/identifiers/unreleased/examples/Checksum-01-minimal.json
+++ b/src/identifiers/unreleased/examples/Checksum-01-minimal.json
@@ -1,0 +1,6 @@
+{
+  "notation": "be32eeadb443c00c3e6ca43f2295e2ee",
+  "creator": "spdx:checksumAlgorithm_md5",
+  "type": "dlidentifiers:Checksum",
+  "@type": "Checksum"
+}

--- a/src/identifiers/unreleased/examples/Checksum-01-minimal.yaml
+++ b/src/identifiers/unreleased/examples/Checksum-01-minimal.yaml
@@ -1,0 +1,2 @@
+creator: spdx:checksumAlgorithm_md5
+notation: be32eeadb443c00c3e6ca43f2295e2ee

--- a/src/identifiers/unreleased/examples/DOI-01-minimal.json
+++ b/src/identifiers/unreleased/examples/DOI-01-minimal.json
@@ -1,6 +1,7 @@
 {
   "notation": "10.1038/s41597-022-01163-2",
   "creator": "https://doi.org",
+  "type": "dlidentifiers:DOI",
   "schema_agency": "DOI Foundation",
   "@type": "DOI"
 }

--- a/src/identifiers/unreleased/examples/DOI-02-complete.json
+++ b/src/identifiers/unreleased/examples/DOI-02-complete.json
@@ -1,6 +1,7 @@
 {
   "notation": "10.2760/271009",
   "creator": "https://op.europa.eu",
+  "type": "dlidentifiers:DOI",
   "schema_agency": "Publications Office of the European Union",
   "@type": "DOI"
 }

--- a/src/identifiers/unreleased/examples/Identifier-01-minimal.json
+++ b/src/identifiers/unreleased/examples/Identifier-01-minimal.json
@@ -1,4 +1,5 @@
 {
   "notation": "0000-0001-6398-6370",
+  "type": "dlidentifiers:Identifier",
   "@type": "Identifier"
 }

--- a/src/identifiers/unreleased/examples/Identifier-02-full.json
+++ b/src/identifiers/unreleased/examples/Identifier-02-full.json
@@ -1,6 +1,6 @@
 {
   "notation": "0000-0001-6398-6370",
   "creator": "https://orcid.org",
-  "schema_agency": "ORCID",
+  "type": "dlidentifiers:Identifier",
   "@type": "Identifier"
 }

--- a/src/identifiers/unreleased/examples/IssuedIdentifier-01-minimal.json
+++ b/src/identifiers/unreleased/examples/IssuedIdentifier-01-minimal.json
@@ -1,0 +1,5 @@
+{
+  "notation": "0000-0001-6398-6370",
+  "type": "dlidentifiers:IssuedIdentifier",
+  "@type": "IssuedIdentifier"
+}

--- a/src/identifiers/unreleased/examples/IssuedIdentifier-01-minimal.yaml
+++ b/src/identifiers/unreleased/examples/IssuedIdentifier-01-minimal.yaml
@@ -1,0 +1,2 @@
+# For any identifier, just the actual notation must be specified.
+notation: 0000-0001-6398-6370

--- a/src/identifiers/unreleased/examples/IssuedIdentifier-02-full.json
+++ b/src/identifiers/unreleased/examples/IssuedIdentifier-02-full.json
@@ -1,0 +1,7 @@
+{
+  "notation": "0000-0001-6398-6370",
+  "creator": "https://orcid.org",
+  "type": "dlidentifiers:IssuedIdentifier",
+  "schema_agency": "ORCID",
+  "@type": "IssuedIdentifier"
+}

--- a/src/identifiers/unreleased/examples/IssuedIdentifier-02-full.yaml
+++ b/src/identifiers/unreleased/examples/IssuedIdentifier-02-full.yaml
@@ -1,2 +1,3 @@
 creator: https://orcid.org
 notation: 0000-0001-6398-6370
+schema_agency: ORCID

--- a/src/identifiers/unreleased/validation/Checksum.valid.cfg.yaml
+++ b/src/identifiers/unreleased/validation/Checksum.valid.cfg.yaml
@@ -1,8 +1,7 @@
 schema: src/identifiers/unreleased.yaml
-target_class: Identifier
+target_class: Checksum
 data_sources:
-  - src/identifiers/unreleased/examples/Identifier-01-minimal.yaml
-  - src/identifiers/unreleased/examples/Identifier-02-full.yaml
+  - src/identifiers/unreleased/examples/Checksum-01-minimal.yaml
 plugins:
   JsonschemaValidationPlugin:
     closed: true

--- a/src/identifiers/unreleased/validation/IssuedIdentifier.valid.cfg.yaml
+++ b/src/identifiers/unreleased/validation/IssuedIdentifier.valid.cfg.yaml
@@ -1,8 +1,8 @@
 schema: src/identifiers/unreleased.yaml
-target_class: Identifier
+target_class: IssuedIdentifier
 data_sources:
-  - src/identifiers/unreleased/examples/Identifier-01-minimal.yaml
-  - src/identifiers/unreleased/examples/Identifier-02-full.yaml
+  - src/identifiers/unreleased/examples/IssuedIdentifier-01-minimal.yaml
+  - src/identifiers/unreleased/examples/IssuedIdentifier-02-full.yaml
 plugins:
   JsonschemaValidationPlugin:
     closed: true

--- a/src/sdd/unreleased/examples/Distribution-penguins.yaml
+++ b/src/sdd/unreleased/examples/Distribution-penguins.yaml
@@ -10,24 +10,24 @@ has_part:
   - id: exthisdsver:./adelie.csv
     byte_size: 23755
     checksum:
-      - algorithm: md5
-        digest: e7e2be6b203a221949f05e02fcefd853
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e7e2be6b203a221949f05e02fcefd853
     download_url:
       - https://portal.edirepository.org/nis/dataviewer?packageid=knb-lter-pal.219.3&entityid=002f3893385f710df69eeebe893144ff
     media_type: text/csv
   - id: exthisdsver:./gentoo.csv
     byte_size: 11263
     checksum:
-      - algorithm: md5
-        digest: 1549566fb97afa879dc9446edcf2015f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1549566fb97afa879dc9446edcf2015f
     download_url:
       - https://portal.edirepository.org/nis/dataviewer?packageid=knb-lter-pal.220.3&entityid=e03b43c924f226486f2f0ab6709d2381
     media_type: text/csv
   - id: exthisdsver:./chinstrap.csv
     byte_size: 18872
     checksum:
-      - algorithm: md5
-        digest: e4b0710c69297031d63866ce8b888f25
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e4b0710c69297031d63866ce8b888f25
     download_url:
       - https://portal.edirepository.org/nis/dataviewer?packageid=knb-lter-pal.221.2&entityid=fe853aa8f7a59aa84cdd3197619ef462
     media_type: text/csv

--- a/src/sdd/unreleased/validation/Distribution-dataverse-rtmefmri.yaml
+++ b/src/sdd/unreleased/validation/Distribution-dataverse-rtmefmri.yaml
@@ -228,16 +228,16 @@ has_part:
   - id: exthisdsver:./dataset_description.json
     byte_size: 1455
     checksum:
-      - algorithm: md5
-        digest: 7d63a6dd379b3b81574e31240433e008
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 7d63a6dd379b3b81574e31240433e008
     download_url:
       - https://dataverse.nl/api/access/datafile/46664
     media_type: application/json
   - id: exthisdsver:./derivatives/fmrwhy-dash/fmrwhy-dash.txt
     byte_size: 39
     checksum:
-      - algorithm: md5
-        digest: a88a2b8ad2cdf158c3b1ee84ecdbbbf9
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a88a2b8ad2cdf158c3b1ee84ecdbbbf9
     download_url:
       - https://dataverse.nl/api/access/datafile/46709
     media_type: text/plain
@@ -254,8 +254,8 @@ has_part:
   - id: exthisdsver:./derivatives/fmrwhy-qc/fmrwhy-qc.txt
     byte_size: 37
     checksum:
-      - algorithm: md5
-        digest: 738eead953d79c5f494795ef91b453ee
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 738eead953d79c5f494795ef91b453ee
     download_url:
       - https://dataverse.nl/api/access/datafile/46710
     media_type: text/plain
@@ -266,24 +266,24 @@ has_part:
   - id: exthisdsver:./participants.tsv
     byte_size: 238
     checksum:
-      - algorithm: md5
-        digest: 0a25e5c0225e9bd18c62a560df470980
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 0a25e5c0225e9bd18c62a560df470980
     download_url:
       - https://dataverse.nl/api/access/datafile/46663
     media_type: text/tsv
   - id: exthisdsver:./README.md
     byte_size: 1429
     checksum:
-      - algorithm: md5
-        digest: 1abb42c68887b4c075e710f0ae8ce855
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1abb42c68887b4c075e710f0ae8ce855
     download_url:
       - https://dataverse.nl/api/access/datafile/46708
     media_type: text/markdown
   - id: exthisdsver:./sub-001/anat/sub-001_T1w.nii
     byte_size: 20736352
     checksum:
-      - algorithm: md5
-        digest: 678f2832b684bbc90d501dc603868bff
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 678f2832b684bbc90d501dc603868bff
     download_url:
       - https://dataverse.nl/api/access/datafile/45615
     media_type: image/nii
@@ -300,8 +300,8 @@ has_part:
   - id: exthisdsver:./sub-001/func/sub-001_task-emotionProcessing_echo-1_bold.json
     byte_size: 1041
     checksum:
-      - algorithm: md5
-        digest: 89c161237e848b41add3ac5d2b500c75
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 89c161237e848b41add3ac5d2b500c75
     download_url:
       - https://dataverse.nl/api/access/datafile/45363
     media_type: application/json
@@ -420,48 +420,48 @@ has_part:
   - id: exthisdsver:./sub-001/func/sub-001_task-emotionProcessing_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 78fb2c0f46963569767ae895ff76f8d4
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 78fb2c0f46963569767ae895ff76f8d4
     download_url:
       - https://dataverse.nl/api/access/datafile/45312
     media_type: image/nii
   - id: exthisdsver:./sub-001/func/sub-001_task-emotionProcessing_echo-2_bold.json
     byte_size: 1041
     checksum:
-      - algorithm: md5
-        digest: 56a5078e8d1434e4da6f19b995263b63
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 56a5078e8d1434e4da6f19b995263b63
     download_url:
       - https://dataverse.nl/api/access/datafile/46262
     media_type: application/json
   - id: exthisdsver:./sub-001/func/sub-001_task-emotionProcessing_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 5760b7656006d37965ae3125490c1eaf
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5760b7656006d37965ae3125490c1eaf
     download_url:
       - https://dataverse.nl/api/access/datafile/45604
     media_type: image/nii
   - id: exthisdsver:./sub-001/func/sub-001_task-emotionProcessing_echo-3_bold.json
     byte_size: 1041
     checksum:
-      - algorithm: md5
-        digest: f30db156c93de5390c73c9b9272c58f0
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f30db156c93de5390c73c9b9272c58f0
     download_url:
       - https://dataverse.nl/api/access/datafile/46333
     media_type: application/json
   - id: exthisdsver:./sub-001/func/sub-001_task-emotionProcessing_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 797986659433a9da8ec3f7b6e46aeb54
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 797986659433a9da8ec3f7b6e46aeb54
     download_url:
       - https://dataverse.nl/api/access/datafile/45650
     media_type: image/nii
   - id: exthisdsver:./sub-001/func/sub-001_task-emotionProcessing_events.tsv.gz
     byte_size: 1880
     checksum:
-      - algorithm: md5
-        digest: a2736a06b0d65a9a7d8a8405c38bfd5d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a2736a06b0d65a9a7d8a8405c38bfd5d
     download_url:
       - https://dataverse.nl/api/access/datafile/46584
     media_type: application/gzip
@@ -469,8 +469,8 @@ has_part:
       exthisdsver:./sub-001/func/sub-001_task-emotionProcessingImagined_echo-1_bold.json
     byte_size: 1049
     checksum:
-      - algorithm: md5
-        digest: daf928b2860acd3705f08a1d44c986d7
+      - creator: spdx:checksumAlgorithm_md5
+        notation: daf928b2860acd3705f08a1d44c986d7
     download_url:
       - https://dataverse.nl/api/access/datafile/46265
     media_type: application/json
@@ -478,8 +478,8 @@ has_part:
       exthisdsver:./sub-001/func/sub-001_task-emotionProcessingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 8e5e4295a677afbe4fff1e88a44edf40
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8e5e4295a677afbe4fff1e88a44edf40
     download_url:
       - https://dataverse.nl/api/access/datafile/45505
     media_type: image/nii
@@ -487,8 +487,8 @@ has_part:
       exthisdsver:./sub-001/func/sub-001_task-emotionProcessingImagined_echo-2_bold.json
     byte_size: 1049
     checksum:
-      - algorithm: md5
-        digest: 718e2607b88161aa7da96441811bb668
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 718e2607b88161aa7da96441811bb668
     download_url:
       - https://dataverse.nl/api/access/datafile/45334
     media_type: application/json
@@ -496,8 +496,8 @@ has_part:
       exthisdsver:./sub-001/func/sub-001_task-emotionProcessingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 6a42e577d5b33591d34706aed5dab54b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6a42e577d5b33591d34706aed5dab54b
     download_url:
       - https://dataverse.nl/api/access/datafile/45456
     media_type: image/nii
@@ -505,8 +505,8 @@ has_part:
       exthisdsver:./sub-001/func/sub-001_task-emotionProcessingImagined_echo-3_bold.json
     byte_size: 1049
     checksum:
-      - algorithm: md5
-        digest: 7a667113b3daa985b748a6f8eacfb15c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 7a667113b3daa985b748a6f8eacfb15c
     download_url:
       - https://dataverse.nl/api/access/datafile/45704
     media_type: application/json
@@ -514,328 +514,328 @@ has_part:
       exthisdsver:./sub-001/func/sub-001_task-emotionProcessingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: a345b63a7f2164c7b2304c466cbab8df
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a345b63a7f2164c7b2304c466cbab8df
     download_url:
       - https://dataverse.nl/api/access/datafile/45487
     media_type: image/nii
   - id: exthisdsver:./sub-001/func/sub-001_task-emotionProcessingImagined_events.tsv.gz
     byte_size: 142
     checksum:
-      - algorithm: md5
-        digest: 80bbaaffae6ffa4103c5142fb17d7c2a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 80bbaaffae6ffa4103c5142fb17d7c2a
     download_url:
       - https://dataverse.nl/api/access/datafile/46660
     media_type: application/gzip
   - id: exthisdsver:./sub-001/func/sub-001_task-emotionProcessingImagined_physio.json
     byte_size: 142
     checksum:
-      - algorithm: md5
-        digest: c004321667c23b1902e25b22b27ae012
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c004321667c23b1902e25b22b27ae012
     download_url:
       - https://dataverse.nl/api/access/datafile/45381
     media_type: application/json
   - id: exthisdsver:./sub-001/func/sub-001_task-emotionProcessingImagined_physio.tsv.gz
     byte_size: 488347
     checksum:
-      - algorithm: md5
-        digest: cf755584ecd4e3c1f6e48fccbb30463e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: cf755584ecd4e3c1f6e48fccbb30463e
     download_url:
       - https://dataverse.nl/api/access/datafile/45767
     media_type: application/gzip
   - id: exthisdsver:./sub-001/func/sub-001_task-emotionProcessing_physio.json
     byte_size: 142
     checksum:
-      - algorithm: md5
-        digest: f6d422020cde7f1acc387ba8aa45f319
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f6d422020cde7f1acc387ba8aa45f319
     download_url:
       - https://dataverse.nl/api/access/datafile/45694
     media_type: application/json
   - id: exthisdsver:./sub-001/func/sub-001_task-emotionProcessing_physio.tsv.gz
     byte_size: 494035
     checksum:
-      - algorithm: md5
-        digest: 3e39a50cff3dae3e85b58288d9867e12
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 3e39a50cff3dae3e85b58288d9867e12
     download_url:
       - https://dataverse.nl/api/access/datafile/45996
     media_type: application/gzip
   - id: exthisdsver:./sub-001/func/sub-001_task-fingerTapping_echo-1_bold.json
     byte_size: 1036
     checksum:
-      - algorithm: md5
-        digest: 07322a7494441559e5cdd20a57a4d8cf
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 07322a7494441559e5cdd20a57a4d8cf
     download_url:
       - https://dataverse.nl/api/access/datafile/45425
     media_type: application/json
   - id: exthisdsver:./sub-001/func/sub-001_task-fingerTapping_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 8c5ded113bbccd377cefd38edd154d5b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8c5ded113bbccd377cefd38edd154d5b
     download_url:
       - https://dataverse.nl/api/access/datafile/46431
     media_type: image/nii
   - id: exthisdsver:./sub-001/func/sub-001_task-fingerTapping_echo-2_bold.json
     byte_size: 1036
     checksum:
-      - algorithm: md5
-        digest: da5ab166644f570d8fa956457a9bbf47
+      - creator: spdx:checksumAlgorithm_md5
+        notation: da5ab166644f570d8fa956457a9bbf47
     download_url:
       - https://dataverse.nl/api/access/datafile/45999
     media_type: application/json
   - id: exthisdsver:./sub-001/func/sub-001_task-fingerTapping_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: b82b687193271c8151bcbacfbe3e7626
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b82b687193271c8151bcbacfbe3e7626
     download_url:
       - https://dataverse.nl/api/access/datafile/45897
     media_type: image/nii
   - id: exthisdsver:./sub-001/func/sub-001_task-fingerTapping_echo-3_bold.json
     byte_size: 1036
     checksum:
-      - algorithm: md5
-        digest: 425e116b054dd72925d970f0fb2c3176
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 425e116b054dd72925d970f0fb2c3176
     download_url:
       - https://dataverse.nl/api/access/datafile/46441
     media_type: application/json
   - id: exthisdsver:./sub-001/func/sub-001_task-fingerTapping_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: addf94f0e75a499d1736cc63387b394d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: addf94f0e75a499d1736cc63387b394d
     download_url:
       - https://dataverse.nl/api/access/datafile/46514
     media_type: image/nii
   - id: exthisdsver:./sub-001/func/sub-001_task-fingerTapping_events.tsv.gz
     byte_size: 131
     checksum:
-      - algorithm: md5
-        digest: 43a708b1b704c30226923f2b6ab380b6
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 43a708b1b704c30226923f2b6ab380b6
     download_url:
       - https://dataverse.nl/api/access/datafile/46590
     media_type: application/gzip
   - id: exthisdsver:./sub-001/func/sub-001_task-fingerTappingImagined_echo-1_bold.json
     byte_size: 1041
     checksum:
-      - algorithm: md5
-        digest: 920db66c4c9552efbec84fb65ae9c363
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 920db66c4c9552efbec84fb65ae9c363
     download_url:
       - https://dataverse.nl/api/access/datafile/45681
     media_type: application/json
   - id: exthisdsver:./sub-001/func/sub-001_task-fingerTappingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 82f169c348b851b4ad009442086d6acd
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 82f169c348b851b4ad009442086d6acd
     download_url:
       - https://dataverse.nl/api/access/datafile/45115
     media_type: image/nii
   - id: exthisdsver:./sub-001/func/sub-001_task-fingerTappingImagined_echo-2_bold.json
     byte_size: 1041
     checksum:
-      - algorithm: md5
-        digest: 02724a22a11885cdf51dacd30b870456
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 02724a22a11885cdf51dacd30b870456
     download_url:
       - https://dataverse.nl/api/access/datafile/45991
     media_type: application/json
   - id: exthisdsver:./sub-001/func/sub-001_task-fingerTappingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 58655ea820a6fb46d19d0666b767439c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 58655ea820a6fb46d19d0666b767439c
     download_url:
       - https://dataverse.nl/api/access/datafile/45672
     media_type: image/nii
   - id: exthisdsver:./sub-001/func/sub-001_task-fingerTappingImagined_echo-3_bold.json
     byte_size: 1041
     checksum:
-      - algorithm: md5
-        digest: bec034b87f61d4e21c24209c75b25897
+      - creator: spdx:checksumAlgorithm_md5
+        notation: bec034b87f61d4e21c24209c75b25897
     download_url:
       - https://dataverse.nl/api/access/datafile/46223
     media_type: application/json
   - id: exthisdsver:./sub-001/func/sub-001_task-fingerTappingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 12d17d0ec3dc7e9d90e75516ea6a26e1
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 12d17d0ec3dc7e9d90e75516ea6a26e1
     download_url:
       - https://dataverse.nl/api/access/datafile/45860
     media_type: image/nii
   - id: exthisdsver:./sub-001/func/sub-001_task-fingerTappingImagined_events.tsv.gz
     byte_size: 146
     checksum:
-      - algorithm: md5
-        digest: 933088364ebb3346e825dd3f929bed11
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 933088364ebb3346e825dd3f929bed11
     download_url:
       - https://dataverse.nl/api/access/datafile/46646
     media_type: application/gzip
   - id: exthisdsver:./sub-001/func/sub-001_task-fingerTappingImagined_physio.json
     byte_size: 142
     checksum:
-      - algorithm: md5
-        digest: b1842207924fca982fb1fc24d76bc312
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b1842207924fca982fb1fc24d76bc312
     download_url:
       - https://dataverse.nl/api/access/datafile/46303
     media_type: application/json
   - id: exthisdsver:./sub-001/func/sub-001_task-fingerTappingImagined_physio.tsv.gz
     byte_size: 495447
     checksum:
-      - algorithm: md5
-        digest: 30cbe40f3eff986588253335007b44b1
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 30cbe40f3eff986588253335007b44b1
     download_url:
       - https://dataverse.nl/api/access/datafile/46166
     media_type: application/gzip
   - id: exthisdsver:./sub-001/func/sub-001_task-fingerTapping_physio.json
     byte_size: 142
     checksum:
-      - algorithm: md5
-        digest: 2a064003e1080fb234c6a87d301677eb
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2a064003e1080fb234c6a87d301677eb
     download_url:
       - https://dataverse.nl/api/access/datafile/45577
     media_type: application/json
   - id: exthisdsver:./sub-001/func/sub-001_task-fingerTapping_physio.tsv.gz
     byte_size: 488065
     checksum:
-      - algorithm: md5
-        digest: fd983bb7f0aacfd1c82a4cc66291ece7
+      - creator: spdx:checksumAlgorithm_md5
+        notation: fd983bb7f0aacfd1c82a4cc66291ece7
     download_url:
       - https://dataverse.nl/api/access/datafile/45746
     media_type: application/gzip
   - id: exthisdsver:./sub-001/func/sub-001_task-rest_run-1_echo-1_bold.json
     byte_size: 1028
     checksum:
-      - algorithm: md5
-        digest: 8afd88b03a88b24ecf64f84ae52e8846
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8afd88b03a88b24ecf64f84ae52e8846
     download_url:
       - https://dataverse.nl/api/access/datafile/45610
     media_type: application/json
   - id: exthisdsver:./sub-001/func/sub-001_task-rest_run-1_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 44e4f216d13068469c80e71f8527a2e6
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 44e4f216d13068469c80e71f8527a2e6
     download_url:
       - https://dataverse.nl/api/access/datafile/45273
     media_type: image/nii
   - id: exthisdsver:./sub-001/func/sub-001_task-rest_run-1_echo-2_bold.json
     byte_size: 1028
     checksum:
-      - algorithm: md5
-        digest: b72be0db59010c4ec993396099b3482c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b72be0db59010c4ec993396099b3482c
     download_url:
       - https://dataverse.nl/api/access/datafile/45228
     media_type: application/json
   - id: exthisdsver:./sub-001/func/sub-001_task-rest_run-1_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 0eaaf587c1ec3e2c62727bb1c990b46a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 0eaaf587c1ec3e2c62727bb1c990b46a
     download_url:
       - https://dataverse.nl/api/access/datafile/46020
     media_type: image/nii
   - id: exthisdsver:./sub-001/func/sub-001_task-rest_run-1_echo-3_bold.json
     byte_size: 1028
     checksum:
-      - algorithm: md5
-        digest: 0c304cbaed62715915e922fa8bb5ec2a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 0c304cbaed62715915e922fa8bb5ec2a
     download_url:
       - https://dataverse.nl/api/access/datafile/45254
     media_type: application/json
   - id: exthisdsver:./sub-001/func/sub-001_task-rest_run-1_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 9b6b87f2d7b292fb432b8b0f55c1d1a8
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 9b6b87f2d7b292fb432b8b0f55c1d1a8
     download_url:
       - https://dataverse.nl/api/access/datafile/46098
     media_type: image/nii
   - id: exthisdsver:./sub-001/func/sub-001_task-rest_run-1_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 8b1fe1885567392c664bd283bcff1d2e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8b1fe1885567392c664bd283bcff1d2e
     download_url:
       - https://dataverse.nl/api/access/datafile/45180
     media_type: application/json
   - id: exthisdsver:./sub-001/func/sub-001_task-rest_run-1_physio.tsv.gz
     byte_size: 447241
     checksum:
-      - algorithm: md5
-        digest: e5f5aae66346cc2b6eab06147ea076a6
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e5f5aae66346cc2b6eab06147ea076a6
     download_url:
       - https://dataverse.nl/api/access/datafile/45102
     media_type: application/gzip
   - id: exthisdsver:./sub-001/func/sub-001_task-rest_run-2_echo-1_bold.json
     byte_size: 1028
     checksum:
-      - algorithm: md5
-        digest: 9b028ce4d5801195fefff15bc1b5768e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 9b028ce4d5801195fefff15bc1b5768e
     download_url:
       - https://dataverse.nl/api/access/datafile/46015
     media_type: application/json
   - id: exthisdsver:./sub-001/func/sub-001_task-rest_run-2_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 31c95eed2391907357fde714b47e54d0
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 31c95eed2391907357fde714b47e54d0
     download_url:
       - https://dataverse.nl/api/access/datafile/46082
     media_type: image/nii
   - id: exthisdsver:./sub-001/func/sub-001_task-rest_run-2_echo-2_bold.json
     byte_size: 1028
     checksum:
-      - algorithm: md5
-        digest: 4a0d83ee1a3782f528eca56303895eca
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4a0d83ee1a3782f528eca56303895eca
     download_url:
       - https://dataverse.nl/api/access/datafile/46512
     media_type: application/json
   - id: exthisdsver:./sub-001/func/sub-001_task-rest_run-2_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 0058bec35f3a53a169011571dc4a8a01
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 0058bec35f3a53a169011571dc4a8a01
     download_url:
       - https://dataverse.nl/api/access/datafile/46426
     media_type: image/nii
   - id: exthisdsver:./sub-001/func/sub-001_task-rest_run-2_echo-3_bold.json
     byte_size: 1028
     checksum:
-      - algorithm: md5
-        digest: 739448e73206d3da7cd20bd564457af6
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 739448e73206d3da7cd20bd564457af6
     download_url:
       - https://dataverse.nl/api/access/datafile/46177
     media_type: application/json
   - id: exthisdsver:./sub-001/func/sub-001_task-rest_run-2_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 354671b079f219299fee7457c9d673e8
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 354671b079f219299fee7457c9d673e8
     download_url:
       - https://dataverse.nl/api/access/datafile/45119
     media_type: image/nii
   - id: exthisdsver:./sub-001/func/sub-001_task-rest_run-2_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 0ffd5218f0f1686afa4dc8143dbc7a3b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 0ffd5218f0f1686afa4dc8143dbc7a3b
     download_url:
       - https://dataverse.nl/api/access/datafile/45945
     media_type: application/json
   - id: exthisdsver:./sub-001/func/sub-001_task-rest_run-2_physio.tsv.gz
     byte_size: 489156
     checksum:
-      - algorithm: md5
-        digest: 498f80810fc869ca053aa3ee4f27d538
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 498f80810fc869ca053aa3ee4f27d538
     download_url:
       - https://dataverse.nl/api/access/datafile/46281
     media_type: application/gzip
   - id: exthisdsver:./sub-002/anat/sub-002_T1w.nii
     byte_size: 20736352
     checksum:
-      - algorithm: md5
-        digest: f97f4f4adcf76fb6d5d22c3ead8488a6
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f97f4f4adcf76fb6d5d22c3ead8488a6
     download_url:
       - https://dataverse.nl/api/access/datafile/46216
     media_type: image/nii
@@ -852,8 +852,8 @@ has_part:
   - id: exthisdsver:./sub-002/func/sub-002_task-emotionProcessing_echo-1_bold.json
     byte_size: 1039
     checksum:
-      - algorithm: md5
-        digest: cf7d2a3f3e619ec6608d54e76f95df61
+      - creator: spdx:checksumAlgorithm_md5
+        notation: cf7d2a3f3e619ec6608d54e76f95df61
     download_url:
       - https://dataverse.nl/api/access/datafile/45495
     media_type: application/json
@@ -972,48 +972,48 @@ has_part:
   - id: exthisdsver:./sub-002/func/sub-002_task-emotionProcessing_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: d4242276c9dee9f7e7971bba128270ad
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d4242276c9dee9f7e7971bba128270ad
     download_url:
       - https://dataverse.nl/api/access/datafile/45238
     media_type: image/nii
   - id: exthisdsver:./sub-002/func/sub-002_task-emotionProcessing_echo-2_bold.json
     byte_size: 1039
     checksum:
-      - algorithm: md5
-        digest: 9c7736a4a9e4222eec3c03a5f9aa1549
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 9c7736a4a9e4222eec3c03a5f9aa1549
     download_url:
       - https://dataverse.nl/api/access/datafile/45879
     media_type: application/json
   - id: exthisdsver:./sub-002/func/sub-002_task-emotionProcessing_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 2ecebc86b99f59b0bed9377a09516955
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2ecebc86b99f59b0bed9377a09516955
     download_url:
       - https://dataverse.nl/api/access/datafile/45411
     media_type: image/nii
   - id: exthisdsver:./sub-002/func/sub-002_task-emotionProcessing_echo-3_bold.json
     byte_size: 1039
     checksum:
-      - algorithm: md5
-        digest: 0a080ec8ad2f4941fd8b8104a4ea0370
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 0a080ec8ad2f4941fd8b8104a4ea0370
     download_url:
       - https://dataverse.nl/api/access/datafile/46342
     media_type: application/json
   - id: exthisdsver:./sub-002/func/sub-002_task-emotionProcessing_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 647534a55fd905146ba11e854be1b527
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 647534a55fd905146ba11e854be1b527
     download_url:
       - https://dataverse.nl/api/access/datafile/45836
     media_type: image/nii
   - id: exthisdsver:./sub-002/func/sub-002_task-emotionProcessing_events.tsv.gz
     byte_size: 1896
     checksum:
-      - algorithm: md5
-        digest: 33e05c7294222071648be193f2c8e658
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 33e05c7294222071648be193f2c8e658
     download_url:
       - https://dataverse.nl/api/access/datafile/46552
     media_type: application/gzip
@@ -1021,8 +1021,8 @@ has_part:
       exthisdsver:./sub-002/func/sub-002_task-emotionProcessingImagined_echo-1_bold.json
     byte_size: 1048
     checksum:
-      - algorithm: md5
-        digest: 35cd1eee55bbc9c48667230c83d8b415
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 35cd1eee55bbc9c48667230c83d8b415
     download_url:
       - https://dataverse.nl/api/access/datafile/46021
     media_type: application/json
@@ -1030,8 +1030,8 @@ has_part:
       exthisdsver:./sub-002/func/sub-002_task-emotionProcessingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 5406f3e37283de3226136a4848fb8e92
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5406f3e37283de3226136a4848fb8e92
     download_url:
       - https://dataverse.nl/api/access/datafile/46121
     media_type: image/nii
@@ -1039,8 +1039,8 @@ has_part:
       exthisdsver:./sub-002/func/sub-002_task-emotionProcessingImagined_echo-2_bold.json
     byte_size: 1048
     checksum:
-      - algorithm: md5
-        digest: e202428748d8dc5f95d1081f9a1408ab
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e202428748d8dc5f95d1081f9a1408ab
     download_url:
       - https://dataverse.nl/api/access/datafile/45741
     media_type: application/json
@@ -1048,8 +1048,8 @@ has_part:
       exthisdsver:./sub-002/func/sub-002_task-emotionProcessingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 3b570804931e64328f99f1d95fec8aef
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 3b570804931e64328f99f1d95fec8aef
     download_url:
       - https://dataverse.nl/api/access/datafile/45437
     media_type: image/nii
@@ -1057,8 +1057,8 @@ has_part:
       exthisdsver:./sub-002/func/sub-002_task-emotionProcessingImagined_echo-3_bold.json
     byte_size: 1048
     checksum:
-      - algorithm: md5
-        digest: 66da6541ad9ee098040d6a5cc2b8ca12
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 66da6541ad9ee098040d6a5cc2b8ca12
     download_url:
       - https://dataverse.nl/api/access/datafile/46314
     media_type: application/json
@@ -1066,328 +1066,328 @@ has_part:
       exthisdsver:./sub-002/func/sub-002_task-emotionProcessingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 3bc569cbc0a2f29c913bc9578899cc0c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 3bc569cbc0a2f29c913bc9578899cc0c
     download_url:
       - https://dataverse.nl/api/access/datafile/45094
     media_type: image/nii
   - id: exthisdsver:./sub-002/func/sub-002_task-emotionProcessingImagined_events.tsv.gz
     byte_size: 176
     checksum:
-      - algorithm: md5
-        digest: db82d76d3330ec3990c4af83e938d87c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: db82d76d3330ec3990c4af83e938d87c
     download_url:
       - https://dataverse.nl/api/access/datafile/46595
     media_type: application/gzip
   - id: exthisdsver:./sub-002/func/sub-002_task-emotionProcessingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 80adcff0f946010d4b877fb4efc8caef
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 80adcff0f946010d4b877fb4efc8caef
     download_url:
       - https://dataverse.nl/api/access/datafile/45889
     media_type: application/json
   - id: exthisdsver:./sub-002/func/sub-002_task-emotionProcessingImagined_physio.tsv.gz
     byte_size: 485217
     checksum:
-      - algorithm: md5
-        digest: e6ef5142cec6da41a411e0a89d97d824
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e6ef5142cec6da41a411e0a89d97d824
     download_url:
       - https://dataverse.nl/api/access/datafile/45485
     media_type: application/gzip
   - id: exthisdsver:./sub-002/func/sub-002_task-emotionProcessing_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: d74e8747cc4889f1de5df37aab11c55f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d74e8747cc4889f1de5df37aab11c55f
     download_url:
       - https://dataverse.nl/api/access/datafile/45420
     media_type: application/json
   - id: exthisdsver:./sub-002/func/sub-002_task-emotionProcessing_physio.tsv.gz
     byte_size: 498781
     checksum:
-      - algorithm: md5
-        digest: 187c2fba563a2fa2b941de43f70dd61a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 187c2fba563a2fa2b941de43f70dd61a
     download_url:
       - https://dataverse.nl/api/access/datafile/46124
     media_type: application/gzip
   - id: exthisdsver:./sub-002/func/sub-002_task-fingerTapping_echo-1_bold.json
     byte_size: 1035
     checksum:
-      - algorithm: md5
-        digest: 21709237f7b3492a22c8b7ab28f7e19b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 21709237f7b3492a22c8b7ab28f7e19b
     download_url:
       - https://dataverse.nl/api/access/datafile/45415
     media_type: application/json
   - id: exthisdsver:./sub-002/func/sub-002_task-fingerTapping_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: fc63662a4dc71495b97f7de2dd2c8a0f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: fc63662a4dc71495b97f7de2dd2c8a0f
     download_url:
       - https://dataverse.nl/api/access/datafile/45660
     media_type: image/nii
   - id: exthisdsver:./sub-002/func/sub-002_task-fingerTapping_echo-2_bold.json
     byte_size: 1035
     checksum:
-      - algorithm: md5
-        digest: 57c2423318daf74f152041ef0781b26a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 57c2423318daf74f152041ef0781b26a
     download_url:
       - https://dataverse.nl/api/access/datafile/45975
     media_type: application/json
   - id: exthisdsver:./sub-002/func/sub-002_task-fingerTapping_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 031af3d3b88dc94e5118bdd92363290d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 031af3d3b88dc94e5118bdd92363290d
     download_url:
       - https://dataverse.nl/api/access/datafile/46503
     media_type: image/nii
   - id: exthisdsver:./sub-002/func/sub-002_task-fingerTapping_echo-3_bold.json
     byte_size: 1035
     checksum:
-      - algorithm: md5
-        digest: 83f8efcda5d35afcf51caa1bdf235f28
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 83f8efcda5d35afcf51caa1bdf235f28
     download_url:
       - https://dataverse.nl/api/access/datafile/45339
     media_type: application/json
   - id: exthisdsver:./sub-002/func/sub-002_task-fingerTapping_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 2d1663374ca312b50e3a0c3382787c48
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2d1663374ca312b50e3a0c3382787c48
     download_url:
       - https://dataverse.nl/api/access/datafile/45380
     media_type: image/nii
   - id: exthisdsver:./sub-002/func/sub-002_task-fingerTapping_events.tsv.gz
     byte_size: 165
     checksum:
-      - algorithm: md5
-        digest: f888ebecc08f0a7b3bfcb3fd74e59e65
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f888ebecc08f0a7b3bfcb3fd74e59e65
     download_url:
       - https://dataverse.nl/api/access/datafile/46617
     media_type: application/gzip
   - id: exthisdsver:./sub-002/func/sub-002_task-fingerTappingImagined_echo-1_bold.json
     byte_size: 1044
     checksum:
-      - algorithm: md5
-        digest: 4936ee6da36541314819583b3da319b4
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4936ee6da36541314819583b3da319b4
     download_url:
       - https://dataverse.nl/api/access/datafile/45253
     media_type: application/json
   - id: exthisdsver:./sub-002/func/sub-002_task-fingerTappingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: beab4fec941e693a8059141ab16ee6eb
+      - creator: spdx:checksumAlgorithm_md5
+        notation: beab4fec941e693a8059141ab16ee6eb
     download_url:
       - https://dataverse.nl/api/access/datafile/45622
     media_type: image/nii
   - id: exthisdsver:./sub-002/func/sub-002_task-fingerTappingImagined_echo-2_bold.json
     byte_size: 1044
     checksum:
-      - algorithm: md5
-        digest: 958c43a8868b916df6ad06a35d0871ef
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 958c43a8868b916df6ad06a35d0871ef
     download_url:
       - https://dataverse.nl/api/access/datafile/45605
     media_type: application/json
   - id: exthisdsver:./sub-002/func/sub-002_task-fingerTappingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: dcc7227a72c483e546ed72567decd240
+      - creator: spdx:checksumAlgorithm_md5
+        notation: dcc7227a72c483e546ed72567decd240
     download_url:
       - https://dataverse.nl/api/access/datafile/46293
     media_type: image/nii
   - id: exthisdsver:./sub-002/func/sub-002_task-fingerTappingImagined_echo-3_bold.json
     byte_size: 1044
     checksum:
-      - algorithm: md5
-        digest: ac1d6b1751abccbe064ecc2eaa72b91e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ac1d6b1751abccbe064ecc2eaa72b91e
     download_url:
       - https://dataverse.nl/api/access/datafile/45107
     media_type: application/json
   - id: exthisdsver:./sub-002/func/sub-002_task-fingerTappingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: d52160b2aca2cbd22144a3c76ab2c5a4
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d52160b2aca2cbd22144a3c76ab2c5a4
     download_url:
       - https://dataverse.nl/api/access/datafile/46154
     media_type: image/nii
   - id: exthisdsver:./sub-002/func/sub-002_task-fingerTappingImagined_events.tsv.gz
     byte_size: 178
     checksum:
-      - algorithm: md5
-        digest: ba6099cd9c3ba2ea89c6e01e47e7a1b6
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ba6099cd9c3ba2ea89c6e01e47e7a1b6
     download_url:
       - https://dataverse.nl/api/access/datafile/46607
     media_type: application/gzip
   - id: exthisdsver:./sub-002/func/sub-002_task-fingerTappingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 455ab639907f79b81120e9bb5e262c51
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 455ab639907f79b81120e9bb5e262c51
     download_url:
       - https://dataverse.nl/api/access/datafile/45705
     media_type: application/json
   - id: exthisdsver:./sub-002/func/sub-002_task-fingerTappingImagined_physio.tsv.gz
     byte_size: 507693
     checksum:
-      - algorithm: md5
-        digest: 0e703d0254167656d9fd8319eda8631a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 0e703d0254167656d9fd8319eda8631a
     download_url:
       - https://dataverse.nl/api/access/datafile/45330
     media_type: application/gzip
   - id: exthisdsver:./sub-002/func/sub-002_task-fingerTapping_physio.json
     byte_size: 142
     checksum:
-      - algorithm: md5
-        digest: 623fd32c3abaf5045866a9f257041a24
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 623fd32c3abaf5045866a9f257041a24
     download_url:
       - https://dataverse.nl/api/access/datafile/45159
     media_type: application/json
   - id: exthisdsver:./sub-002/func/sub-002_task-fingerTapping_physio.tsv.gz
     byte_size: 506416
     checksum:
-      - algorithm: md5
-        digest: 221ab54e3cd08b6f9036ec41b083d336
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 221ab54e3cd08b6f9036ec41b083d336
     download_url:
       - https://dataverse.nl/api/access/datafile/45496
     media_type: application/gzip
   - id: exthisdsver:./sub-002/func/sub-002_task-rest_run-1_echo-1_bold.json
     byte_size: 1027
     checksum:
-      - algorithm: md5
-        digest: 3761f3d617dd7ba60e81d2601ef59947
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 3761f3d617dd7ba60e81d2601ef59947
     download_url:
       - https://dataverse.nl/api/access/datafile/46470
     media_type: application/json
   - id: exthisdsver:./sub-002/func/sub-002_task-rest_run-1_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: ecb90665078449c064d070accf6cd7e8
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ecb90665078449c064d070accf6cd7e8
     download_url:
       - https://dataverse.nl/api/access/datafile/45757
     media_type: image/nii
   - id: exthisdsver:./sub-002/func/sub-002_task-rest_run-1_echo-2_bold.json
     byte_size: 1027
     checksum:
-      - algorithm: md5
-        digest: 3fc98b2caa94ee94cd2ad78c9aa3f78c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 3fc98b2caa94ee94cd2ad78c9aa3f78c
     download_url:
       - https://dataverse.nl/api/access/datafile/45327
     media_type: application/json
   - id: exthisdsver:./sub-002/func/sub-002_task-rest_run-1_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 8b8690d3f6d670bf191eadd8e01119dd
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8b8690d3f6d670bf191eadd8e01119dd
     download_url:
       - https://dataverse.nl/api/access/datafile/46288
     media_type: image/nii
   - id: exthisdsver:./sub-002/func/sub-002_task-rest_run-1_echo-3_bold.json
     byte_size: 1027
     checksum:
-      - algorithm: md5
-        digest: 36354f68d03ea100abfa17db08d24e07
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 36354f68d03ea100abfa17db08d24e07
     download_url:
       - https://dataverse.nl/api/access/datafile/45708
     media_type: application/json
   - id: exthisdsver:./sub-002/func/sub-002_task-rest_run-1_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: b690270b545ea0fdf0ff5327fa10b8b9
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b690270b545ea0fdf0ff5327fa10b8b9
     download_url:
       - https://dataverse.nl/api/access/datafile/46159
     media_type: image/nii
   - id: exthisdsver:./sub-002/func/sub-002_task-rest_run-1_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 2cd78841361d665f5661ca7678500942
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2cd78841361d665f5661ca7678500942
     download_url:
       - https://dataverse.nl/api/access/datafile/45160
     media_type: application/json
   - id: exthisdsver:./sub-002/func/sub-002_task-rest_run-1_physio.tsv.gz
     byte_size: 450745
     checksum:
-      - algorithm: md5
-        digest: 9ee6308ef60143c844e94849b76b811d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 9ee6308ef60143c844e94849b76b811d
     download_url:
       - https://dataverse.nl/api/access/datafile/45256
     media_type: application/gzip
   - id: exthisdsver:./sub-002/func/sub-002_task-rest_run-2_echo-1_bold.json
     byte_size: 1027
     checksum:
-      - algorithm: md5
-        digest: 69f53a4bedb42b1f612883b8afd7497b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 69f53a4bedb42b1f612883b8afd7497b
     download_url:
       - https://dataverse.nl/api/access/datafile/45661
     media_type: application/json
   - id: exthisdsver:./sub-002/func/sub-002_task-rest_run-2_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 7138afaaa1a1d3a6d816621d832799b1
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 7138afaaa1a1d3a6d816621d832799b1
     download_url:
       - https://dataverse.nl/api/access/datafile/45110
     media_type: image/nii
   - id: exthisdsver:./sub-002/func/sub-002_task-rest_run-2_echo-2_bold.json
     byte_size: 1027
     checksum:
-      - algorithm: md5
-        digest: 22cb9852e9c9d955d7365b1448728357
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 22cb9852e9c9d955d7365b1448728357
     download_url:
       - https://dataverse.nl/api/access/datafile/46277
     media_type: application/json
   - id: exthisdsver:./sub-002/func/sub-002_task-rest_run-2_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 79fa20148b1630ffb08992beab303b2b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 79fa20148b1630ffb08992beab303b2b
     download_url:
       - https://dataverse.nl/api/access/datafile/46128
     media_type: image/nii
   - id: exthisdsver:./sub-002/func/sub-002_task-rest_run-2_echo-3_bold.json
     byte_size: 1027
     checksum:
-      - algorithm: md5
-        digest: 27ae4e73617361c270ecc71101f3cddd
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 27ae4e73617361c270ecc71101f3cddd
     download_url:
       - https://dataverse.nl/api/access/datafile/45164
     media_type: application/json
   - id: exthisdsver:./sub-002/func/sub-002_task-rest_run-2_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 005456b77cd14cd08bd60b082f35b26d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 005456b77cd14cd08bd60b082f35b26d
     download_url:
       - https://dataverse.nl/api/access/datafile/45981
     media_type: image/nii
   - id: exthisdsver:./sub-002/func/sub-002_task-rest_run-2_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 1f75cd2288e414151a8e07e2efa99a5d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1f75cd2288e414151a8e07e2efa99a5d
     download_url:
       - https://dataverse.nl/api/access/datafile/45553
     media_type: application/json
   - id: exthisdsver:./sub-002/func/sub-002_task-rest_run-2_physio.tsv.gz
     byte_size: 467796
     checksum:
-      - algorithm: md5
-        digest: 2853087ae72d9e2dc2ac40e4c7d8231c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2853087ae72d9e2dc2ac40e4c7d8231c
     download_url:
       - https://dataverse.nl/api/access/datafile/45992
     media_type: application/gzip
   - id: exthisdsver:./sub-003/anat/sub-003_T1w.nii
     byte_size: 20736352
     checksum:
-      - algorithm: md5
-        digest: a525adfda11e7a413d064b83351014f7
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a525adfda11e7a413d064b83351014f7
     download_url:
       - https://dataverse.nl/api/access/datafile/45171
     media_type: image/nii
@@ -1404,8 +1404,8 @@ has_part:
   - id: exthisdsver:./sub-003/func/sub-003_task-emotionProcessing_echo-1_bold.json
     byte_size: 1039
     checksum:
-      - algorithm: md5
-        digest: 4518a04d528ff9af69b75633417073c4
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4518a04d528ff9af69b75633417073c4
     download_url:
       - https://dataverse.nl/api/access/datafile/46311
     media_type: application/json
@@ -1524,48 +1524,48 @@ has_part:
   - id: exthisdsver:./sub-003/func/sub-003_task-emotionProcessing_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: f41afd8250988c7601d688addb9b7102
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f41afd8250988c7601d688addb9b7102
     download_url:
       - https://dataverse.nl/api/access/datafile/46493
     media_type: image/nii
   - id: exthisdsver:./sub-003/func/sub-003_task-emotionProcessing_echo-2_bold.json
     byte_size: 1039
     checksum:
-      - algorithm: md5
-        digest: 2050d7c945bee0a6caad609e7b74dac9
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2050d7c945bee0a6caad609e7b74dac9
     download_url:
       - https://dataverse.nl/api/access/datafile/45149
     media_type: application/json
   - id: exthisdsver:./sub-003/func/sub-003_task-emotionProcessing_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 75efa8502c5c44e3912929c0b57565d7
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 75efa8502c5c44e3912929c0b57565d7
     download_url:
       - https://dataverse.nl/api/access/datafile/45435
     media_type: image/nii
   - id: exthisdsver:./sub-003/func/sub-003_task-emotionProcessing_echo-3_bold.json
     byte_size: 1039
     checksum:
-      - algorithm: md5
-        digest: 0608ebbb657942ffc976be8dbbb931fc
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 0608ebbb657942ffc976be8dbbb931fc
     download_url:
       - https://dataverse.nl/api/access/datafile/45566
     media_type: application/json
   - id: exthisdsver:./sub-003/func/sub-003_task-emotionProcessing_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 44c62c76a20eba67bf4787d00a4531e6
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 44c62c76a20eba67bf4787d00a4531e6
     download_url:
       - https://dataverse.nl/api/access/datafile/45834
     media_type: image/nii
   - id: exthisdsver:./sub-003/func/sub-003_task-emotionProcessing_events.tsv.gz
     byte_size: 1858
     checksum:
-      - algorithm: md5
-        digest: 01db1c4a5194d11f29dcf290cde45ef1
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 01db1c4a5194d11f29dcf290cde45ef1
     download_url:
       - https://dataverse.nl/api/access/datafile/46626
     media_type: application/gzip
@@ -1573,8 +1573,8 @@ has_part:
       exthisdsver:./sub-003/func/sub-003_task-emotionProcessingImagined_echo-1_bold.json
     byte_size: 1049
     checksum:
-      - algorithm: md5
-        digest: e4dd082be4ec8c3c60c1a0baf5b61bf7
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e4dd082be4ec8c3c60c1a0baf5b61bf7
     download_url:
       - https://dataverse.nl/api/access/datafile/46097
     media_type: application/json
@@ -1582,8 +1582,8 @@ has_part:
       exthisdsver:./sub-003/func/sub-003_task-emotionProcessingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 4176db44d86095450d06d787ce620b2b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4176db44d86095450d06d787ce620b2b
     download_url:
       - https://dataverse.nl/api/access/datafile/45633
     media_type: image/nii
@@ -1591,8 +1591,8 @@ has_part:
       exthisdsver:./sub-003/func/sub-003_task-emotionProcessingImagined_echo-2_bold.json
     byte_size: 1049
     checksum:
-      - algorithm: md5
-        digest: 198f071835eb54f9a23d4ab8019c2a37
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 198f071835eb54f9a23d4ab8019c2a37
     download_url:
       - https://dataverse.nl/api/access/datafile/45412
     media_type: application/json
@@ -1600,8 +1600,8 @@ has_part:
       exthisdsver:./sub-003/func/sub-003_task-emotionProcessingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 4694b2571463007ae3cc175a3cc7eb17
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4694b2571463007ae3cc175a3cc7eb17
     download_url:
       - https://dataverse.nl/api/access/datafile/45646
     media_type: image/nii
@@ -1609,8 +1609,8 @@ has_part:
       exthisdsver:./sub-003/func/sub-003_task-emotionProcessingImagined_echo-3_bold.json
     byte_size: 1049
     checksum:
-      - algorithm: md5
-        digest: 25f2bdb1dcf0a366013718a654a3504a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 25f2bdb1dcf0a366013718a654a3504a
     download_url:
       - https://dataverse.nl/api/access/datafile/45282
     media_type: application/json
@@ -1618,328 +1618,328 @@ has_part:
       exthisdsver:./sub-003/func/sub-003_task-emotionProcessingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 4d5b995c9938fbe15bdd2c49fbff6c61
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4d5b995c9938fbe15bdd2c49fbff6c61
     download_url:
       - https://dataverse.nl/api/access/datafile/45783
     media_type: image/nii
   - id: exthisdsver:./sub-003/func/sub-003_task-emotionProcessingImagined_events.tsv.gz
     byte_size: 176
     checksum:
-      - algorithm: md5
-        digest: 46cb2364d901e50f1364f9e96d37d972
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 46cb2364d901e50f1364f9e96d37d972
     download_url:
       - https://dataverse.nl/api/access/datafile/46620
     media_type: application/gzip
   - id: exthisdsver:./sub-003/func/sub-003_task-emotionProcessingImagined_physio.json
     byte_size: 142
     checksum:
-      - algorithm: md5
-        digest: 9d39fcc727462332da8bf2677ac02842
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 9d39fcc727462332da8bf2677ac02842
     download_url:
       - https://dataverse.nl/api/access/datafile/46060
     media_type: application/json
   - id: exthisdsver:./sub-003/func/sub-003_task-emotionProcessingImagined_physio.tsv.gz
     byte_size: 493322
     checksum:
-      - algorithm: md5
-        digest: 25cfd7f2e211d2182d54007c2133058d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 25cfd7f2e211d2182d54007c2133058d
     download_url:
       - https://dataverse.nl/api/access/datafile/45599
     media_type: application/gzip
   - id: exthisdsver:./sub-003/func/sub-003_task-emotionProcessing_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 7671d986969005f3924a49b68375ffb8
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 7671d986969005f3924a49b68375ffb8
     download_url:
       - https://dataverse.nl/api/access/datafile/45883
     media_type: application/json
   - id: exthisdsver:./sub-003/func/sub-003_task-emotionProcessing_physio.tsv.gz
     byte_size: 512614
     checksum:
-      - algorithm: md5
-        digest: ecb4728f450c6dded958d78386553632
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ecb4728f450c6dded958d78386553632
     download_url:
       - https://dataverse.nl/api/access/datafile/45872
     media_type: application/gzip
   - id: exthisdsver:./sub-003/func/sub-003_task-fingerTapping_echo-1_bold.json
     byte_size: 1037
     checksum:
-      - algorithm: md5
-        digest: da47e50192f9bc1ff023b1298ab6c4c1
+      - creator: spdx:checksumAlgorithm_md5
+        notation: da47e50192f9bc1ff023b1298ab6c4c1
     download_url:
       - https://dataverse.nl/api/access/datafile/45990
     media_type: application/json
   - id: exthisdsver:./sub-003/func/sub-003_task-fingerTapping_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: e011d174c5ef1c6a243b69866d76acbc
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e011d174c5ef1c6a243b69866d76acbc
     download_url:
       - https://dataverse.nl/api/access/datafile/45432
     media_type: image/nii
   - id: exthisdsver:./sub-003/func/sub-003_task-fingerTapping_echo-2_bold.json
     byte_size: 1037
     checksum:
-      - algorithm: md5
-        digest: 2f9ee78f5ed4b03f3093558524ed7977
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2f9ee78f5ed4b03f3093558524ed7977
     download_url:
       - https://dataverse.nl/api/access/datafile/45732
     media_type: application/json
   - id: exthisdsver:./sub-003/func/sub-003_task-fingerTapping_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: c5dc421a2ce1cdf989da7c282db5ec0c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c5dc421a2ce1cdf989da7c282db5ec0c
     download_url:
       - https://dataverse.nl/api/access/datafile/45423
     media_type: image/nii
   - id: exthisdsver:./sub-003/func/sub-003_task-fingerTapping_echo-3_bold.json
     byte_size: 1037
     checksum:
-      - algorithm: md5
-        digest: a6a3e3505d46a8cdc0760ffa179fc7e4
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a6a3e3505d46a8cdc0760ffa179fc7e4
     download_url:
       - https://dataverse.nl/api/access/datafile/46075
     media_type: application/json
   - id: exthisdsver:./sub-003/func/sub-003_task-fingerTapping_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: b06d2d248db37901b035e19e9a560fa9
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b06d2d248db37901b035e19e9a560fa9
     download_url:
       - https://dataverse.nl/api/access/datafile/45245
     media_type: image/nii
   - id: exthisdsver:./sub-003/func/sub-003_task-fingerTapping_events.tsv.gz
     byte_size: 164
     checksum:
-      - algorithm: md5
-        digest: 1b2fd317345b898fa22d1ab9e44c2dad
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1b2fd317345b898fa22d1ab9e44c2dad
     download_url:
       - https://dataverse.nl/api/access/datafile/46659
     media_type: application/gzip
   - id: exthisdsver:./sub-003/func/sub-003_task-fingerTappingImagined_echo-1_bold.json
     byte_size: 1045
     checksum:
-      - algorithm: md5
-        digest: 6dc91b045886ce1681b5dcf11d07e0f3
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6dc91b045886ce1681b5dcf11d07e0f3
     download_url:
       - https://dataverse.nl/api/access/datafile/46385
     media_type: application/json
   - id: exthisdsver:./sub-003/func/sub-003_task-fingerTappingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: c54e7e640293282594de0d16cfe2d813
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c54e7e640293282594de0d16cfe2d813
     download_url:
       - https://dataverse.nl/api/access/datafile/45558
     media_type: image/nii
   - id: exthisdsver:./sub-003/func/sub-003_task-fingerTappingImagined_echo-2_bold.json
     byte_size: 1045
     checksum:
-      - algorithm: md5
-        digest: fa1e47cf0f9b847994d20ece5d4b8c1b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: fa1e47cf0f9b847994d20ece5d4b8c1b
     download_url:
       - https://dataverse.nl/api/access/datafile/46412
     media_type: application/json
   - id: exthisdsver:./sub-003/func/sub-003_task-fingerTappingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 20f42887282f4bf87fc9d76aa1578102
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 20f42887282f4bf87fc9d76aa1578102
     download_url:
       - https://dataverse.nl/api/access/datafile/46028
     media_type: image/nii
   - id: exthisdsver:./sub-003/func/sub-003_task-fingerTappingImagined_echo-3_bold.json
     byte_size: 1045
     checksum:
-      - algorithm: md5
-        digest: 4eaffe9798a630e7f7b35d94adc5681e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4eaffe9798a630e7f7b35d94adc5681e
     download_url:
       - https://dataverse.nl/api/access/datafile/45095
     media_type: application/json
   - id: exthisdsver:./sub-003/func/sub-003_task-fingerTappingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 7408815811cc6083fcf63a2417e1bec2
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 7408815811cc6083fcf63a2417e1bec2
     download_url:
       - https://dataverse.nl/api/access/datafile/45737
     media_type: image/nii
   - id: exthisdsver:./sub-003/func/sub-003_task-fingerTappingImagined_events.tsv.gz
     byte_size: 179
     checksum:
-      - algorithm: md5
-        digest: d5a6c6f4589c8b5db4625150aec8c27e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d5a6c6f4589c8b5db4625150aec8c27e
     download_url:
       - https://dataverse.nl/api/access/datafile/46594
     media_type: application/gzip
   - id: exthisdsver:./sub-003/func/sub-003_task-fingerTappingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 0e4d96ff2b8b767e68f04bc62a704b4c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 0e4d96ff2b8b767e68f04bc62a704b4c
     download_url:
       - https://dataverse.nl/api/access/datafile/46299
     media_type: application/json
   - id: exthisdsver:./sub-003/func/sub-003_task-fingerTappingImagined_physio.tsv.gz
     byte_size: 489887
     checksum:
-      - algorithm: md5
-        digest: 3be50c6940c311ae26c2dc7f4c7df108
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 3be50c6940c311ae26c2dc7f4c7df108
     download_url:
       - https://dataverse.nl/api/access/datafile/45104
     media_type: application/gzip
   - id: exthisdsver:./sub-003/func/sub-003_task-fingerTapping_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 4f920e3548a8b17edcf2c5cd02393156
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4f920e3548a8b17edcf2c5cd02393156
     download_url:
       - https://dataverse.nl/api/access/datafile/45642
     media_type: application/json
   - id: exthisdsver:./sub-003/func/sub-003_task-fingerTapping_physio.tsv.gz
     byte_size: 523737
     checksum:
-      - algorithm: md5
-        digest: b1c827674e51653497a3a54541e36313
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b1c827674e51653497a3a54541e36313
     download_url:
       - https://dataverse.nl/api/access/datafile/45462
     media_type: application/gzip
   - id: exthisdsver:./sub-003/func/sub-003_task-rest_run-1_echo-1_bold.json
     byte_size: 1028
     checksum:
-      - algorithm: md5
-        digest: 17ae93a36f0bc5af4b6d6e0634864632
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 17ae93a36f0bc5af4b6d6e0634864632
     download_url:
       - https://dataverse.nl/api/access/datafile/46531
     media_type: application/json
   - id: exthisdsver:./sub-003/func/sub-003_task-rest_run-1_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: db701d264ea88dffe4a47a207ab850a2
+      - creator: spdx:checksumAlgorithm_md5
+        notation: db701d264ea88dffe4a47a207ab850a2
     download_url:
       - https://dataverse.nl/api/access/datafile/45893
     media_type: image/nii
   - id: exthisdsver:./sub-003/func/sub-003_task-rest_run-1_echo-2_bold.json
     byte_size: 1028
     checksum:
-      - algorithm: md5
-        digest: 36be4c278f402df7ee8f7a3724d9e010
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 36be4c278f402df7ee8f7a3724d9e010
     download_url:
       - https://dataverse.nl/api/access/datafile/45824
     media_type: application/json
   - id: exthisdsver:./sub-003/func/sub-003_task-rest_run-1_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 2d4f35a104e2be5af5ce8a15519e9aac
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2d4f35a104e2be5af5ce8a15519e9aac
     download_url:
       - https://dataverse.nl/api/access/datafile/45603
     media_type: image/nii
   - id: exthisdsver:./sub-003/func/sub-003_task-rest_run-1_echo-3_bold.json
     byte_size: 1028
     checksum:
-      - algorithm: md5
-        digest: 50ad11f44d3f985bfe270667b6b093b9
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 50ad11f44d3f985bfe270667b6b093b9
     download_url:
       - https://dataverse.nl/api/access/datafile/45711
     media_type: application/json
   - id: exthisdsver:./sub-003/func/sub-003_task-rest_run-1_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 038053e3e4ddf25cf8576219507dfaa3
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 038053e3e4ddf25cf8576219507dfaa3
     download_url:
       - https://dataverse.nl/api/access/datafile/46394
     media_type: image/nii
   - id: exthisdsver:./sub-003/func/sub-003_task-rest_run-1_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 10a7e7a80ed4aab38196fad3ff89c291
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 10a7e7a80ed4aab38196fad3ff89c291
     download_url:
       - https://dataverse.nl/api/access/datafile/45398
     media_type: application/json
   - id: exthisdsver:./sub-003/func/sub-003_task-rest_run-1_physio.tsv.gz
     byte_size: 444600
     checksum:
-      - algorithm: md5
-        digest: c53d254a96bd5c6f8b6229ae8e5a4417
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c53d254a96bd5c6f8b6229ae8e5a4417
     download_url:
       - https://dataverse.nl/api/access/datafile/46379
     media_type: application/gzip
   - id: exthisdsver:./sub-003/func/sub-003_task-rest_run-2_echo-1_bold.json
     byte_size: 1028
     checksum:
-      - algorithm: md5
-        digest: 08472211cbfcf501142274f13c8eb449
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 08472211cbfcf501142274f13c8eb449
     download_url:
       - https://dataverse.nl/api/access/datafile/46199
     media_type: application/json
   - id: exthisdsver:./sub-003/func/sub-003_task-rest_run-2_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: fab75720328ab13511b6d397b211b948
+      - creator: spdx:checksumAlgorithm_md5
+        notation: fab75720328ab13511b6d397b211b948
     download_url:
       - https://dataverse.nl/api/access/datafile/45949
     media_type: image/nii
   - id: exthisdsver:./sub-003/func/sub-003_task-rest_run-2_echo-2_bold.json
     byte_size: 1028
     checksum:
-      - algorithm: md5
-        digest: 5179d897d306c52b209d691c35415f5c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5179d897d306c52b209d691c35415f5c
     download_url:
       - https://dataverse.nl/api/access/datafile/46440
     media_type: application/json
   - id: exthisdsver:./sub-003/func/sub-003_task-rest_run-2_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 2c6b0d65245c1f5955ce5ccb6b5ec789
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2c6b0d65245c1f5955ce5ccb6b5ec789
     download_url:
       - https://dataverse.nl/api/access/datafile/45444
     media_type: image/nii
   - id: exthisdsver:./sub-003/func/sub-003_task-rest_run-2_echo-3_bold.json
     byte_size: 1028
     checksum:
-      - algorithm: md5
-        digest: 2a98a2e0a158a9af593918d54340973c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2a98a2e0a158a9af593918d54340973c
     download_url:
       - https://dataverse.nl/api/access/datafile/45158
     media_type: application/json
   - id: exthisdsver:./sub-003/func/sub-003_task-rest_run-2_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 51a412ffa50f35b4eddc4784d392814c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 51a412ffa50f35b4eddc4784d392814c
     download_url:
       - https://dataverse.nl/api/access/datafile/45653
     media_type: image/nii
   - id: exthisdsver:./sub-003/func/sub-003_task-rest_run-2_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 6ac1a20148d2ae8984c099e033fd0c35
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6ac1a20148d2ae8984c099e033fd0c35
     download_url:
       - https://dataverse.nl/api/access/datafile/45601
     media_type: application/json
   - id: exthisdsver:./sub-003/func/sub-003_task-rest_run-2_physio.tsv.gz
     byte_size: 472280
     checksum:
-      - algorithm: md5
-        digest: 80f50906952e9c32795e83eb0cb3abaf
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 80f50906952e9c32795e83eb0cb3abaf
     download_url:
       - https://dataverse.nl/api/access/datafile/45155
     media_type: application/gzip
   - id: exthisdsver:./sub-004/anat/sub-004_T1w.nii
     byte_size: 20736352
     checksum:
-      - algorithm: md5
-        digest: 58d8367944bf28848557da5fa9a42cbf
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 58d8367944bf28848557da5fa9a42cbf
     download_url:
       - https://dataverse.nl/api/access/datafile/45910
     media_type: image/nii
@@ -1956,8 +1956,8 @@ has_part:
   - id: exthisdsver:./sub-004/func/sub-004_task-emotionProcessing_echo-1_bold.json
     byte_size: 1042
     checksum:
-      - algorithm: md5
-        digest: 34a35e002060107f9d015e47e337ab30
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 34a35e002060107f9d015e47e337ab30
     download_url:
       - https://dataverse.nl/api/access/datafile/45136
     media_type: application/json
@@ -2076,48 +2076,48 @@ has_part:
   - id: exthisdsver:./sub-004/func/sub-004_task-emotionProcessing_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 1966f9963c3cce7b182cd15e5fd6b247
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1966f9963c3cce7b182cd15e5fd6b247
     download_url:
       - https://dataverse.nl/api/access/datafile/45861
     media_type: image/nii
   - id: exthisdsver:./sub-004/func/sub-004_task-emotionProcessing_echo-2_bold.json
     byte_size: 1042
     checksum:
-      - algorithm: md5
-        digest: 5a59e89c7d19e229a2813067e8e61f71
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5a59e89c7d19e229a2813067e8e61f71
     download_url:
       - https://dataverse.nl/api/access/datafile/45843
     media_type: application/json
   - id: exthisdsver:./sub-004/func/sub-004_task-emotionProcessing_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 8899bd49d48c71c57e602f5048be4ac6
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8899bd49d48c71c57e602f5048be4ac6
     download_url:
       - https://dataverse.nl/api/access/datafile/46511
     media_type: image/nii
   - id: exthisdsver:./sub-004/func/sub-004_task-emotionProcessing_echo-3_bold.json
     byte_size: 1042
     checksum:
-      - algorithm: md5
-        digest: 4fa63ab16201e215019dda3cac213e2a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4fa63ab16201e215019dda3cac213e2a
     download_url:
       - https://dataverse.nl/api/access/datafile/46148
     media_type: application/json
   - id: exthisdsver:./sub-004/func/sub-004_task-emotionProcessing_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 8c6d259a6aba141794311f476d629b3e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8c6d259a6aba141794311f476d629b3e
     download_url:
       - https://dataverse.nl/api/access/datafile/45304
     media_type: image/nii
   - id: exthisdsver:./sub-004/func/sub-004_task-emotionProcessing_events.tsv.gz
     byte_size: 1868
     checksum:
-      - algorithm: md5
-        digest: 44479a7e0853ae4448577db9d59ad4fd
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 44479a7e0853ae4448577db9d59ad4fd
     download_url:
       - https://dataverse.nl/api/access/datafile/46578
     media_type: application/gzip
@@ -2125,8 +2125,8 @@ has_part:
       exthisdsver:./sub-004/func/sub-004_task-emotionProcessingImagined_echo-1_bold.json
     byte_size: 1050
     checksum:
-      - algorithm: md5
-        digest: f36ef17a4f775994cc72f6c477617d2a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f36ef17a4f775994cc72f6c477617d2a
     download_url:
       - https://dataverse.nl/api/access/datafile/45189
     media_type: application/json
@@ -2134,8 +2134,8 @@ has_part:
       exthisdsver:./sub-004/func/sub-004_task-emotionProcessingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 43cfc6023dfa200ff0e406ba59b45c34
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 43cfc6023dfa200ff0e406ba59b45c34
     download_url:
       - https://dataverse.nl/api/access/datafile/46089
     media_type: image/nii
@@ -2143,8 +2143,8 @@ has_part:
       exthisdsver:./sub-004/func/sub-004_task-emotionProcessingImagined_echo-2_bold.json
     byte_size: 1050
     checksum:
-      - algorithm: md5
-        digest: 49f053634b6e9efc7f6c75d8a27c0203
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 49f053634b6e9efc7f6c75d8a27c0203
     download_url:
       - https://dataverse.nl/api/access/datafile/45971
     media_type: application/json
@@ -2152,8 +2152,8 @@ has_part:
       exthisdsver:./sub-004/func/sub-004_task-emotionProcessingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 74477f9caf0a44d593a03311120868de
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 74477f9caf0a44d593a03311120868de
     download_url:
       - https://dataverse.nl/api/access/datafile/45846
     media_type: image/nii
@@ -2161,8 +2161,8 @@ has_part:
       exthisdsver:./sub-004/func/sub-004_task-emotionProcessingImagined_echo-3_bold.json
     byte_size: 1050
     checksum:
-      - algorithm: md5
-        digest: 58394a3751a16d3489d7184a3c028a48
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 58394a3751a16d3489d7184a3c028a48
     download_url:
       - https://dataverse.nl/api/access/datafile/45712
     media_type: application/json
@@ -2170,328 +2170,328 @@ has_part:
       exthisdsver:./sub-004/func/sub-004_task-emotionProcessingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 1e6626678c8869bdf81d9c086f30f2dc
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1e6626678c8869bdf81d9c086f30f2dc
     download_url:
       - https://dataverse.nl/api/access/datafile/46428
     media_type: image/nii
   - id: exthisdsver:./sub-004/func/sub-004_task-emotionProcessingImagined_events.tsv.gz
     byte_size: 175
     checksum:
-      - algorithm: md5
-        digest: 07d6079dae864f78200f7952d9c4e4c6
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 07d6079dae864f78200f7952d9c4e4c6
     download_url:
       - https://dataverse.nl/api/access/datafile/46652
     media_type: application/gzip
   - id: exthisdsver:./sub-004/func/sub-004_task-emotionProcessingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 8305718c9f660f7a56ff7a1d20baf70d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8305718c9f660f7a56ff7a1d20baf70d
     download_url:
       - https://dataverse.nl/api/access/datafile/46063
     media_type: application/json
   - id: exthisdsver:./sub-004/func/sub-004_task-emotionProcessingImagined_physio.tsv.gz
     byte_size: 485821
     checksum:
-      - algorithm: md5
-        digest: c996e6b7c02de87e8aa4557c8e1f3768
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c996e6b7c02de87e8aa4557c8e1f3768
     download_url:
       - https://dataverse.nl/api/access/datafile/46192
     media_type: application/gzip
   - id: exthisdsver:./sub-004/func/sub-004_task-emotionProcessing_physio.json
     byte_size: 142
     checksum:
-      - algorithm: md5
-        digest: dab7cb3e67b101ca05a9a508215f8dd0
+      - creator: spdx:checksumAlgorithm_md5
+        notation: dab7cb3e67b101ca05a9a508215f8dd0
     download_url:
       - https://dataverse.nl/api/access/datafile/46444
     media_type: application/json
   - id: exthisdsver:./sub-004/func/sub-004_task-emotionProcessing_physio.tsv.gz
     byte_size: 508552
     checksum:
-      - algorithm: md5
-        digest: ceea28302989820975135a9c614dd540
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ceea28302989820975135a9c614dd540
     download_url:
       - https://dataverse.nl/api/access/datafile/46376
     media_type: application/gzip
   - id: exthisdsver:./sub-004/func/sub-004_task-fingerTapping_echo-1_bold.json
     byte_size: 1038
     checksum:
-      - algorithm: md5
-        digest: 8a5131e167a16243ea24d0be2e50d088
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8a5131e167a16243ea24d0be2e50d088
     download_url:
       - https://dataverse.nl/api/access/datafile/46086
     media_type: application/json
   - id: exthisdsver:./sub-004/func/sub-004_task-fingerTapping_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 6f08635a0f32a98a2f79a0fa8d24535e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6f08635a0f32a98a2f79a0fa8d24535e
     download_url:
       - https://dataverse.nl/api/access/datafile/46326
     media_type: image/nii
   - id: exthisdsver:./sub-004/func/sub-004_task-fingerTapping_echo-2_bold.json
     byte_size: 1038
     checksum:
-      - algorithm: md5
-        digest: e2a4369dd2f8a003a7875e5ad0575be1
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e2a4369dd2f8a003a7875e5ad0575be1
     download_url:
       - https://dataverse.nl/api/access/datafile/46419
     media_type: application/json
   - id: exthisdsver:./sub-004/func/sub-004_task-fingerTapping_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: c63ac9ab0f47be10beeecbd6994b3011
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c63ac9ab0f47be10beeecbd6994b3011
     download_url:
       - https://dataverse.nl/api/access/datafile/45294
     media_type: image/nii
   - id: exthisdsver:./sub-004/func/sub-004_task-fingerTapping_echo-3_bold.json
     byte_size: 1038
     checksum:
-      - algorithm: md5
-        digest: e7f2903e14bdb420ecf97e9d4c390da3
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e7f2903e14bdb420ecf97e9d4c390da3
     download_url:
       - https://dataverse.nl/api/access/datafile/45926
     media_type: application/json
   - id: exthisdsver:./sub-004/func/sub-004_task-fingerTapping_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 40c2011540513e0feaaccf63b81b690e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 40c2011540513e0feaaccf63b81b690e
     download_url:
       - https://dataverse.nl/api/access/datafile/45710
     media_type: image/nii
   - id: exthisdsver:./sub-004/func/sub-004_task-fingerTapping_events.tsv.gz
     byte_size: 165
     checksum:
-      - algorithm: md5
-        digest: cc4b52c7e9b24d4c5d83ea093200d98b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: cc4b52c7e9b24d4c5d83ea093200d98b
     download_url:
       - https://dataverse.nl/api/access/datafile/46629
     media_type: application/gzip
   - id: exthisdsver:./sub-004/func/sub-004_task-fingerTappingImagined_echo-1_bold.json
     byte_size: 1046
     checksum:
-      - algorithm: md5
-        digest: a5ca44b8a3d361b1fe1b3567be9adea6
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a5ca44b8a3d361b1fe1b3567be9adea6
     download_url:
       - https://dataverse.nl/api/access/datafile/46222
     media_type: application/json
   - id: exthisdsver:./sub-004/func/sub-004_task-fingerTappingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 683f476deac7c52b45a1246b2e1ffb35
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 683f476deac7c52b45a1246b2e1ffb35
     download_url:
       - https://dataverse.nl/api/access/datafile/45911
     media_type: image/nii
   - id: exthisdsver:./sub-004/func/sub-004_task-fingerTappingImagined_echo-2_bold.json
     byte_size: 1046
     checksum:
-      - algorithm: md5
-        digest: d0af5398225d1082e6c1af5eed463db9
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d0af5398225d1082e6c1af5eed463db9
     download_url:
       - https://dataverse.nl/api/access/datafile/45226
     media_type: application/json
   - id: exthisdsver:./sub-004/func/sub-004_task-fingerTappingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 9cc07e3893057ca6cdfd206828d16194
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 9cc07e3893057ca6cdfd206828d16194
     download_url:
       - https://dataverse.nl/api/access/datafile/45393
     media_type: image/nii
   - id: exthisdsver:./sub-004/func/sub-004_task-fingerTappingImagined_echo-3_bold.json
     byte_size: 1046
     checksum:
-      - algorithm: md5
-        digest: 4a18cf99e492cf5c14e7639fb31842e7
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4a18cf99e492cf5c14e7639fb31842e7
     download_url:
       - https://dataverse.nl/api/access/datafile/46491
     media_type: application/json
   - id: exthisdsver:./sub-004/func/sub-004_task-fingerTappingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: c80b6124c2c5b4fad41bb398416d86a4
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c80b6124c2c5b4fad41bb398416d86a4
     download_url:
       - https://dataverse.nl/api/access/datafile/45318
     media_type: image/nii
   - id: exthisdsver:./sub-004/func/sub-004_task-fingerTappingImagined_events.tsv.gz
     byte_size: 179
     checksum:
-      - algorithm: md5
-        digest: ba23264ce250a919463ac1c88740217e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ba23264ce250a919463ac1c88740217e
     download_url:
       - https://dataverse.nl/api/access/datafile/46615
     media_type: application/gzip
   - id: exthisdsver:./sub-004/func/sub-004_task-fingerTappingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: d2c6e3310ed7ef5d21f969b30244f520
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d2c6e3310ed7ef5d21f969b30244f520
     download_url:
       - https://dataverse.nl/api/access/datafile/45402
     media_type: application/json
   - id: exthisdsver:./sub-004/func/sub-004_task-fingerTappingImagined_physio.tsv.gz
     byte_size: 487009
     checksum:
-      - algorithm: md5
-        digest: 94966adddec90ba26e94b32be4eebc61
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 94966adddec90ba26e94b32be4eebc61
     download_url:
       - https://dataverse.nl/api/access/datafile/46367
     media_type: application/gzip
   - id: exthisdsver:./sub-004/func/sub-004_task-fingerTapping_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: ee153b04600e381b86f0543a33f91a6f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ee153b04600e381b86f0543a33f91a6f
     download_url:
       - https://dataverse.nl/api/access/datafile/46014
     media_type: application/json
   - id: exthisdsver:./sub-004/func/sub-004_task-fingerTapping_physio.tsv.gz
     byte_size: 489124
     checksum:
-      - algorithm: md5
-        digest: 82b693bd13603114e1366bcd7451a2ce
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 82b693bd13603114e1366bcd7451a2ce
     download_url:
       - https://dataverse.nl/api/access/datafile/46533
     media_type: application/gzip
   - id: exthisdsver:./sub-004/func/sub-004_task-rest_run-1_echo-1_bold.json
     byte_size: 1029
     checksum:
-      - algorithm: md5
-        digest: ca28f098501f7d6279f2643df7a809ed
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ca28f098501f7d6279f2643df7a809ed
     download_url:
       - https://dataverse.nl/api/access/datafile/45765
     media_type: application/json
   - id: exthisdsver:./sub-004/func/sub-004_task-rest_run-1_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: b4fc16017fc34696bad6b292e90ee274
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b4fc16017fc34696bad6b292e90ee274
     download_url:
       - https://dataverse.nl/api/access/datafile/45257
     media_type: image/nii
   - id: exthisdsver:./sub-004/func/sub-004_task-rest_run-1_echo-2_bold.json
     byte_size: 1029
     checksum:
-      - algorithm: md5
-        digest: 01e1290eb404eccf4520e1dab01c24bb
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 01e1290eb404eccf4520e1dab01c24bb
     download_url:
       - https://dataverse.nl/api/access/datafile/46427
     media_type: application/json
   - id: exthisdsver:./sub-004/func/sub-004_task-rest_run-1_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 5e911175e9c452cca2d6f25436a9bfb8
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5e911175e9c452cca2d6f25436a9bfb8
     download_url:
       - https://dataverse.nl/api/access/datafile/45390
     media_type: image/nii
   - id: exthisdsver:./sub-004/func/sub-004_task-rest_run-1_echo-3_bold.json
     byte_size: 1029
     checksum:
-      - algorithm: md5
-        digest: 2ca75787822c8e4f03ca5b67a60531a9
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2ca75787822c8e4f03ca5b67a60531a9
     download_url:
       - https://dataverse.nl/api/access/datafile/46110
     media_type: application/json
   - id: exthisdsver:./sub-004/func/sub-004_task-rest_run-1_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 561457fa892cbdd65220c6e3128e1f49
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 561457fa892cbdd65220c6e3128e1f49
     download_url:
       - https://dataverse.nl/api/access/datafile/45326
     media_type: image/nii
   - id: exthisdsver:./sub-004/func/sub-004_task-rest_run-1_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 285431e80fa96a66ecb6e37f4fb414cf
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 285431e80fa96a66ecb6e37f4fb414cf
     download_url:
       - https://dataverse.nl/api/access/datafile/45959
     media_type: application/json
   - id: exthisdsver:./sub-004/func/sub-004_task-rest_run-1_physio.tsv.gz
     byte_size: 452268
     checksum:
-      - algorithm: md5
-        digest: 956ca5c8a5d40a90cf1504da247c6b4c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 956ca5c8a5d40a90cf1504da247c6b4c
     download_url:
       - https://dataverse.nl/api/access/datafile/45366
     media_type: application/gzip
   - id: exthisdsver:./sub-004/func/sub-004_task-rest_run-2_echo-1_bold.json
     byte_size: 1029
     checksum:
-      - algorithm: md5
-        digest: 5cde587fccae4ea2bbfac89fe90762e5
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5cde587fccae4ea2bbfac89fe90762e5
     download_url:
       - https://dataverse.nl/api/access/datafile/45700
     media_type: application/json
   - id: exthisdsver:./sub-004/func/sub-004_task-rest_run-2_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: afebe2e9412da20fabb39983ad8bf4e4
+      - creator: spdx:checksumAlgorithm_md5
+        notation: afebe2e9412da20fabb39983ad8bf4e4
     download_url:
       - https://dataverse.nl/api/access/datafile/45543
     media_type: image/nii
   - id: exthisdsver:./sub-004/func/sub-004_task-rest_run-2_echo-2_bold.json
     byte_size: 1029
     checksum:
-      - algorithm: md5
-        digest: 22021c29436d8dd41bdcc4d623767287
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 22021c29436d8dd41bdcc4d623767287
     download_url:
       - https://dataverse.nl/api/access/datafile/45994
     media_type: application/json
   - id: exthisdsver:./sub-004/func/sub-004_task-rest_run-2_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: c8470d6102b3ae3d8cbaa5cba22c0470
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c8470d6102b3ae3d8cbaa5cba22c0470
     download_url:
       - https://dataverse.nl/api/access/datafile/45614
     media_type: image/nii
   - id: exthisdsver:./sub-004/func/sub-004_task-rest_run-2_echo-3_bold.json
     byte_size: 1029
     checksum:
-      - algorithm: md5
-        digest: 8e0eb4c3371a930c04845b7eb889d1a2
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8e0eb4c3371a930c04845b7eb889d1a2
     download_url:
       - https://dataverse.nl/api/access/datafile/46519
     media_type: application/json
   - id: exthisdsver:./sub-004/func/sub-004_task-rest_run-2_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: e124551b127db0efc5489510daf2f037
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e124551b127db0efc5489510daf2f037
     download_url:
       - https://dataverse.nl/api/access/datafile/45572
     media_type: image/nii
   - id: exthisdsver:./sub-004/func/sub-004_task-rest_run-2_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 4f5d46a7566d1a7bbfbd5be7ad026956
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4f5d46a7566d1a7bbfbd5be7ad026956
     download_url:
       - https://dataverse.nl/api/access/datafile/45449
     media_type: application/json
   - id: exthisdsver:./sub-004/func/sub-004_task-rest_run-2_physio.tsv.gz
     byte_size: 466721
     checksum:
-      - algorithm: md5
-        digest: 6c03087b2beb9db957ef5988fb253057
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6c03087b2beb9db957ef5988fb253057
     download_url:
       - https://dataverse.nl/api/access/datafile/45537
     media_type: application/gzip
   - id: exthisdsver:./sub-005/anat/sub-005_T1w.nii
     byte_size: 20736352
     checksum:
-      - algorithm: md5
-        digest: ba7215ae4a975c77d06363cc23455895
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ba7215ae4a975c77d06363cc23455895
     download_url:
       - https://dataverse.nl/api/access/datafile/45156
     media_type: image/nii
@@ -2508,8 +2508,8 @@ has_part:
   - id: exthisdsver:./sub-005/func/sub-005_task-emotionProcessing_echo-1_bold.json
     byte_size: 1036
     checksum:
-      - algorithm: md5
-        digest: 5620260863482ac69a3d880b3cc5d4d5
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5620260863482ac69a3d880b3cc5d4d5
     download_url:
       - https://dataverse.nl/api/access/datafile/45239
     media_type: application/json
@@ -2628,48 +2628,48 @@ has_part:
   - id: exthisdsver:./sub-005/func/sub-005_task-emotionProcessing_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: e8597ab384391f88368f92df85528228
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e8597ab384391f88368f92df85528228
     download_url:
       - https://dataverse.nl/api/access/datafile/46232
     media_type: image/nii
   - id: exthisdsver:./sub-005/func/sub-005_task-emotionProcessing_echo-2_bold.json
     byte_size: 1036
     checksum:
-      - algorithm: md5
-        digest: 06a41d823bf94b4e474e61bdb7c600f7
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 06a41d823bf94b4e474e61bdb7c600f7
     download_url:
       - https://dataverse.nl/api/access/datafile/46042
     media_type: application/json
   - id: exthisdsver:./sub-005/func/sub-005_task-emotionProcessing_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: d8886eae9e8b52724ac1b3a739f845fd
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d8886eae9e8b52724ac1b3a739f845fd
     download_url:
       - https://dataverse.nl/api/access/datafile/46361
     media_type: image/nii
   - id: exthisdsver:./sub-005/func/sub-005_task-emotionProcessing_echo-3_bold.json
     byte_size: 1036
     checksum:
-      - algorithm: md5
-        digest: 857942be9fae2be22771e0fa3e6c0596
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 857942be9fae2be22771e0fa3e6c0596
     download_url:
       - https://dataverse.nl/api/access/datafile/45904
     media_type: application/json
   - id: exthisdsver:./sub-005/func/sub-005_task-emotionProcessing_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 2463012f8847a959bcc923302e446034
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2463012f8847a959bcc923302e446034
     download_url:
       - https://dataverse.nl/api/access/datafile/45237
     media_type: image/nii
   - id: exthisdsver:./sub-005/func/sub-005_task-emotionProcessing_events.tsv.gz
     byte_size: 1906
     checksum:
-      - algorithm: md5
-        digest: 8591fb9d4b80fe2e976d8556478965eb
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8591fb9d4b80fe2e976d8556478965eb
     download_url:
       - https://dataverse.nl/api/access/datafile/46647
     media_type: application/gzip
@@ -2677,8 +2677,8 @@ has_part:
       exthisdsver:./sub-005/func/sub-005_task-emotionProcessingImagined_echo-1_bold.json
     byte_size: 1043
     checksum:
-      - algorithm: md5
-        digest: cf85da54869c203e5227cd2e678827be
+      - creator: spdx:checksumAlgorithm_md5
+        notation: cf85da54869c203e5227cd2e678827be
     download_url:
       - https://dataverse.nl/api/access/datafile/45588
     media_type: application/json
@@ -2686,8 +2686,8 @@ has_part:
       exthisdsver:./sub-005/func/sub-005_task-emotionProcessingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 1827f157a2ea364d9d0d4a91b8f4e9e8
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1827f157a2ea364d9d0d4a91b8f4e9e8
     download_url:
       - https://dataverse.nl/api/access/datafile/45292
     media_type: image/nii
@@ -2695,8 +2695,8 @@ has_part:
       exthisdsver:./sub-005/func/sub-005_task-emotionProcessingImagined_echo-2_bold.json
     byte_size: 1043
     checksum:
-      - algorithm: md5
-        digest: a26bcd77739bb9a39b6a097a50927e9e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a26bcd77739bb9a39b6a097a50927e9e
     download_url:
       - https://dataverse.nl/api/access/datafile/45629
     media_type: application/json
@@ -2704,8 +2704,8 @@ has_part:
       exthisdsver:./sub-005/func/sub-005_task-emotionProcessingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 86d61fffd5f9bfe8985687ca25db1b3d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 86d61fffd5f9bfe8985687ca25db1b3d
     download_url:
       - https://dataverse.nl/api/access/datafile/45323
     media_type: image/nii
@@ -2713,8 +2713,8 @@ has_part:
       exthisdsver:./sub-005/func/sub-005_task-emotionProcessingImagined_echo-3_bold.json
     byte_size: 1043
     checksum:
-      - algorithm: md5
-        digest: 2e6bb2a54113f9b4bfa0db68bbbd9582
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2e6bb2a54113f9b4bfa0db68bbbd9582
     download_url:
       - https://dataverse.nl/api/access/datafile/45418
     media_type: application/json
@@ -2722,328 +2722,328 @@ has_part:
       exthisdsver:./sub-005/func/sub-005_task-emotionProcessingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 560c581bd2dd79e4e515a5b8fc684e16
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 560c581bd2dd79e4e515a5b8fc684e16
     download_url:
       - https://dataverse.nl/api/access/datafile/46049
     media_type: image/nii
   - id: exthisdsver:./sub-005/func/sub-005_task-emotionProcessingImagined_events.tsv.gz
     byte_size: 174
     checksum:
-      - algorithm: md5
-        digest: 1b2cccc690fa0fb1292b34051d0fd921
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1b2cccc690fa0fb1292b34051d0fd921
     download_url:
       - https://dataverse.nl/api/access/datafile/46593
     media_type: application/gzip
   - id: exthisdsver:./sub-005/func/sub-005_task-emotionProcessingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: e34ca6bef05662b16f9dcbd5ecf59898
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e34ca6bef05662b16f9dcbd5ecf59898
     download_url:
       - https://dataverse.nl/api/access/datafile/45436
     media_type: application/json
   - id: exthisdsver:./sub-005/func/sub-005_task-emotionProcessingImagined_physio.tsv.gz
     byte_size: 476888
     checksum:
-      - algorithm: md5
-        digest: 4ae203ccaed175f79ff01003f8a19bb7
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4ae203ccaed175f79ff01003f8a19bb7
     download_url:
       - https://dataverse.nl/api/access/datafile/46164
     media_type: application/gzip
   - id: exthisdsver:./sub-005/func/sub-005_task-emotionProcessing_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 57d9656db263d6740b1b3c842db67bd8
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 57d9656db263d6740b1b3c842db67bd8
     download_url:
       - https://dataverse.nl/api/access/datafile/45484
     media_type: application/json
   - id: exthisdsver:./sub-005/func/sub-005_task-emotionProcessing_physio.tsv.gz
     byte_size: 488391
     checksum:
-      - algorithm: md5
-        digest: 076bdc3f561911acb07eab3dd1f5df9a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 076bdc3f561911acb07eab3dd1f5df9a
     download_url:
       - https://dataverse.nl/api/access/datafile/46064
     media_type: application/gzip
   - id: exthisdsver:./sub-005/func/sub-005_task-fingerTapping_echo-1_bold.json
     byte_size: 1031
     checksum:
-      - algorithm: md5
-        digest: 1058863a0b9ac9305ca3eaa205c8e482
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1058863a0b9ac9305ca3eaa205c8e482
     download_url:
       - https://dataverse.nl/api/access/datafile/45465
     media_type: application/json
   - id: exthisdsver:./sub-005/func/sub-005_task-fingerTapping_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: c4c158f389337815f03dd442323170cd
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c4c158f389337815f03dd442323170cd
     download_url:
       - https://dataverse.nl/api/access/datafile/46119
     media_type: image/nii
   - id: exthisdsver:./sub-005/func/sub-005_task-fingerTapping_echo-2_bold.json
     byte_size: 1031
     checksum:
-      - algorithm: md5
-        digest: f7b81b0343d8bcd0037c42715e479aae
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f7b81b0343d8bcd0037c42715e479aae
     download_url:
       - https://dataverse.nl/api/access/datafile/45664
     media_type: application/json
   - id: exthisdsver:./sub-005/func/sub-005_task-fingerTapping_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 61d9111af78acb7fbfc9f1c953e393d1
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 61d9111af78acb7fbfc9f1c953e393d1
     download_url:
       - https://dataverse.nl/api/access/datafile/45637
     media_type: image/nii
   - id: exthisdsver:./sub-005/func/sub-005_task-fingerTapping_echo-3_bold.json
     byte_size: 1031
     checksum:
-      - algorithm: md5
-        digest: b838da26f4982a9055838095cd42edb8
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b838da26f4982a9055838095cd42edb8
     download_url:
       - https://dataverse.nl/api/access/datafile/45590
     media_type: application/json
   - id: exthisdsver:./sub-005/func/sub-005_task-fingerTapping_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 559c1c151f4130bc52190576ada7a1e0
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 559c1c151f4130bc52190576ada7a1e0
     download_url:
       - https://dataverse.nl/api/access/datafile/46421
     media_type: image/nii
   - id: exthisdsver:./sub-005/func/sub-005_task-fingerTapping_events.tsv.gz
     byte_size: 164
     checksum:
-      - algorithm: md5
-        digest: 2dc9bdf268f8ee5f6660b6079d347ae6
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2dc9bdf268f8ee5f6660b6079d347ae6
     download_url:
       - https://dataverse.nl/api/access/datafile/46624
     media_type: application/gzip
   - id: exthisdsver:./sub-005/func/sub-005_task-fingerTappingImagined_echo-1_bold.json
     byte_size: 1040
     checksum:
-      - algorithm: md5
-        digest: 0ca76203dbb3231b05d4c28cacf8deb5
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 0ca76203dbb3231b05d4c28cacf8deb5
     download_url:
       - https://dataverse.nl/api/access/datafile/45091
     media_type: application/json
   - id: exthisdsver:./sub-005/func/sub-005_task-fingerTappingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 242cef3e49f0361bcf7ee7337ad42f9e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 242cef3e49f0361bcf7ee7337ad42f9e
     download_url:
       - https://dataverse.nl/api/access/datafile/45467
     media_type: image/nii
   - id: exthisdsver:./sub-005/func/sub-005_task-fingerTappingImagined_echo-2_bold.json
     byte_size: 1040
     checksum:
-      - algorithm: md5
-        digest: acb9906cfe54b0a07753784ceebe36d1
+      - creator: spdx:checksumAlgorithm_md5
+        notation: acb9906cfe54b0a07753784ceebe36d1
     download_url:
       - https://dataverse.nl/api/access/datafile/46534
     media_type: application/json
   - id: exthisdsver:./sub-005/func/sub-005_task-fingerTappingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: cf58f27bec609869d3e1223ec0928040
+      - creator: spdx:checksumAlgorithm_md5
+        notation: cf58f27bec609869d3e1223ec0928040
     download_url:
       - https://dataverse.nl/api/access/datafile/46451
     media_type: image/nii
   - id: exthisdsver:./sub-005/func/sub-005_task-fingerTappingImagined_echo-3_bold.json
     byte_size: 1040
     checksum:
-      - algorithm: md5
-        digest: 6d3d0a49ce28df559814f25c3f56249d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6d3d0a49ce28df559814f25c3f56249d
     download_url:
       - https://dataverse.nl/api/access/datafile/45480
     media_type: application/json
   - id: exthisdsver:./sub-005/func/sub-005_task-fingerTappingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: fb5d2a49b1fa43561b3893c705f20a37
+      - creator: spdx:checksumAlgorithm_md5
+        notation: fb5d2a49b1fa43561b3893c705f20a37
     download_url:
       - https://dataverse.nl/api/access/datafile/45271
     media_type: image/nii
   - id: exthisdsver:./sub-005/func/sub-005_task-fingerTappingImagined_events.tsv.gz
     byte_size: 178
     checksum:
-      - algorithm: md5
-        digest: 5511a9bdf9b4bc31847a527f09b1dc0e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5511a9bdf9b4bc31847a527f09b1dc0e
     download_url:
       - https://dataverse.nl/api/access/datafile/46553
     media_type: application/gzip
   - id: exthisdsver:./sub-005/func/sub-005_task-fingerTappingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 534405ecb32f76a2885211190f10fb72
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 534405ecb32f76a2885211190f10fb72
     download_url:
       - https://dataverse.nl/api/access/datafile/46509
     media_type: application/json
   - id: exthisdsver:./sub-005/func/sub-005_task-fingerTappingImagined_physio.tsv.gz
     byte_size: 477047
     checksum:
-      - algorithm: md5
-        digest: 4e38eaee3bca1fe437c028cddbc84a58
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4e38eaee3bca1fe437c028cddbc84a58
     download_url:
       - https://dataverse.nl/api/access/datafile/45342
     media_type: application/gzip
   - id: exthisdsver:./sub-005/func/sub-005_task-fingerTapping_physio.json
     byte_size: 142
     checksum:
-      - algorithm: md5
-        digest: 1b95897a4ff499880e19e33c1d9063e1
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1b95897a4ff499880e19e33c1d9063e1
     download_url:
       - https://dataverse.nl/api/access/datafile/45293
     media_type: application/json
   - id: exthisdsver:./sub-005/func/sub-005_task-fingerTapping_physio.tsv.gz
     byte_size: 494630
     checksum:
-      - algorithm: md5
-        digest: cb614443d3b1a376ff71023ef5762224
+      - creator: spdx:checksumAlgorithm_md5
+        notation: cb614443d3b1a376ff71023ef5762224
     download_url:
       - https://dataverse.nl/api/access/datafile/45865
     media_type: application/gzip
   - id: exthisdsver:./sub-005/func/sub-005_task-rest_run-1_echo-1_bold.json
     byte_size: 1023
     checksum:
-      - algorithm: md5
-        digest: fd7a04bc9095b203ce07810848951508
+      - creator: spdx:checksumAlgorithm_md5
+        notation: fd7a04bc9095b203ce07810848951508
     download_url:
       - https://dataverse.nl/api/access/datafile/45275
     media_type: application/json
   - id: exthisdsver:./sub-005/func/sub-005_task-rest_run-1_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: f27c8fa8553a3105635841347685da9e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f27c8fa8553a3105635841347685da9e
     download_url:
       - https://dataverse.nl/api/access/datafile/45787
     media_type: image/nii
   - id: exthisdsver:./sub-005/func/sub-005_task-rest_run-1_echo-2_bold.json
     byte_size: 1023
     checksum:
-      - algorithm: md5
-        digest: 503939b3eacaf49259ed9f0485fbb169
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 503939b3eacaf49259ed9f0485fbb169
     download_url:
       - https://dataverse.nl/api/access/datafile/46073
     media_type: application/json
   - id: exthisdsver:./sub-005/func/sub-005_task-rest_run-1_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 826254d83065c0461428cf7a1c7bcbfb
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 826254d83065c0461428cf7a1c7bcbfb
     download_url:
       - https://dataverse.nl/api/access/datafile/45227
     media_type: image/nii
   - id: exthisdsver:./sub-005/func/sub-005_task-rest_run-1_echo-3_bold.json
     byte_size: 1023
     checksum:
-      - algorithm: md5
-        digest: efb5d489c01003958d3b3f84ef85bf49
+      - creator: spdx:checksumAlgorithm_md5
+        notation: efb5d489c01003958d3b3f84ef85bf49
     download_url:
       - https://dataverse.nl/api/access/datafile/46474
     media_type: application/json
   - id: exthisdsver:./sub-005/func/sub-005_task-rest_run-1_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 4908d85ca4e3b0a0d5e354107329c93d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4908d85ca4e3b0a0d5e354107329c93d
     download_url:
       - https://dataverse.nl/api/access/datafile/45396
     media_type: image/nii
   - id: exthisdsver:./sub-005/func/sub-005_task-rest_run-1_physio.json
     byte_size: 142
     checksum:
-      - algorithm: md5
-        digest: a13d5b27089b27005943abc68e90c2d5
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a13d5b27089b27005943abc68e90c2d5
     download_url:
       - https://dataverse.nl/api/access/datafile/46302
     media_type: application/json
   - id: exthisdsver:./sub-005/func/sub-005_task-rest_run-1_physio.tsv.gz
     byte_size: 451182
     checksum:
-      - algorithm: md5
-        digest: 800ebe464c7dc49deb06e557e0f29ea7
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 800ebe464c7dc49deb06e557e0f29ea7
     download_url:
       - https://dataverse.nl/api/access/datafile/45778
     media_type: application/gzip
   - id: exthisdsver:./sub-005/func/sub-005_task-rest_run-2_echo-1_bold.json
     byte_size: 1021
     checksum:
-      - algorithm: md5
-        digest: 8b7812f78a276e261df17d3b221a066a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8b7812f78a276e261df17d3b221a066a
     download_url:
       - https://dataverse.nl/api/access/datafile/45490
     media_type: application/json
   - id: exthisdsver:./sub-005/func/sub-005_task-rest_run-2_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: fea0858e750b27aa46e3c8a3b411f10f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: fea0858e750b27aa46e3c8a3b411f10f
     download_url:
       - https://dataverse.nl/api/access/datafile/46130
     media_type: image/nii
   - id: exthisdsver:./sub-005/func/sub-005_task-rest_run-2_echo-2_bold.json
     byte_size: 1021
     checksum:
-      - algorithm: md5
-        digest: e011cc059bd77e9c19a5e38584eb5628
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e011cc059bd77e9c19a5e38584eb5628
     download_url:
       - https://dataverse.nl/api/access/datafile/45740
     media_type: application/json
   - id: exthisdsver:./sub-005/func/sub-005_task-rest_run-2_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 35fdfa50f2d36c0ac4d329e5012369ad
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 35fdfa50f2d36c0ac4d329e5012369ad
     download_url:
       - https://dataverse.nl/api/access/datafile/45154
     media_type: image/nii
   - id: exthisdsver:./sub-005/func/sub-005_task-rest_run-2_echo-3_bold.json
     byte_size: 1021
     checksum:
-      - algorithm: md5
-        digest: 6611683433437ac176de1c263a2f4ecc
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6611683433437ac176de1c263a2f4ecc
     download_url:
       - https://dataverse.nl/api/access/datafile/46541
     media_type: application/json
   - id: exthisdsver:./sub-005/func/sub-005_task-rest_run-2_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: b3c11c643a12d6acb7dd626b963ad193
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b3c11c643a12d6acb7dd626b963ad193
     download_url:
       - https://dataverse.nl/api/access/datafile/45277
     media_type: image/nii
   - id: exthisdsver:./sub-005/func/sub-005_task-rest_run-2_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: d66328032fd3fbc635bd564170bc8671
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d66328032fd3fbc635bd564170bc8671
     download_url:
       - https://dataverse.nl/api/access/datafile/45451
     media_type: application/json
   - id: exthisdsver:./sub-005/func/sub-005_task-rest_run-2_physio.tsv.gz
     byte_size: 455634
     checksum:
-      - algorithm: md5
-        digest: b7338170f7583bc97fbc2140052f28c2
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b7338170f7583bc97fbc2140052f28c2
     download_url:
       - https://dataverse.nl/api/access/datafile/45723
     media_type: application/gzip
   - id: exthisdsver:./sub-006/anat/sub-006_T1w.nii
     byte_size: 20736352
     checksum:
-      - algorithm: md5
-        digest: 9d3c80f922108f4f4b0a509b48f19215
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 9d3c80f922108f4f4b0a509b48f19215
     download_url:
       - https://dataverse.nl/api/access/datafile/46481
     media_type: image/nii
@@ -3060,8 +3060,8 @@ has_part:
   - id: exthisdsver:./sub-006/func/sub-006_task-emotionProcessing_echo-1_bold.json
     byte_size: 1040
     checksum:
-      - algorithm: md5
-        digest: 19d730e7f95456220e9a207e24aeb85c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 19d730e7f95456220e9a207e24aeb85c
     download_url:
       - https://dataverse.nl/api/access/datafile/46010
     media_type: application/json
@@ -3180,48 +3180,48 @@ has_part:
   - id: exthisdsver:./sub-006/func/sub-006_task-emotionProcessing_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 790c9551fe64f5bf1505f57c08a41752
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 790c9551fe64f5bf1505f57c08a41752
     download_url:
       - https://dataverse.nl/api/access/datafile/46107
     media_type: image/nii
   - id: exthisdsver:./sub-006/func/sub-006_task-emotionProcessing_echo-2_bold.json
     byte_size: 1040
     checksum:
-      - algorithm: md5
-        digest: 27b0d9091824e35ec179f26bae10ac3b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 27b0d9091824e35ec179f26bae10ac3b
     download_url:
       - https://dataverse.nl/api/access/datafile/45488
     media_type: application/json
   - id: exthisdsver:./sub-006/func/sub-006_task-emotionProcessing_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 133c94bb368ecdaea7f44b7516487173
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 133c94bb368ecdaea7f44b7516487173
     download_url:
       - https://dataverse.nl/api/access/datafile/45208
     media_type: image/nii
   - id: exthisdsver:./sub-006/func/sub-006_task-emotionProcessing_echo-3_bold.json
     byte_size: 1040
     checksum:
-      - algorithm: md5
-        digest: 753ef08256365e77b156a2253826019b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 753ef08256365e77b156a2253826019b
     download_url:
       - https://dataverse.nl/api/access/datafile/45213
     media_type: application/json
   - id: exthisdsver:./sub-006/func/sub-006_task-emotionProcessing_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 2b0c6daf7d033cbd6aa50e33643e3a55
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2b0c6daf7d033cbd6aa50e33643e3a55
     download_url:
       - https://dataverse.nl/api/access/datafile/45810
     media_type: image/nii
   - id: exthisdsver:./sub-006/func/sub-006_task-emotionProcessing_events.tsv.gz
     byte_size: 1939
     checksum:
-      - algorithm: md5
-        digest: cc467164073fc96d80c0acffd443393e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: cc467164073fc96d80c0acffd443393e
     download_url:
       - https://dataverse.nl/api/access/datafile/46577
     media_type: application/gzip
@@ -3229,8 +3229,8 @@ has_part:
       exthisdsver:./sub-006/func/sub-006_task-emotionProcessingImagined_echo-1_bold.json
     byte_size: 1048
     checksum:
-      - algorithm: md5
-        digest: 7dd90f3e0b89cecf35ee80581c470b24
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 7dd90f3e0b89cecf35ee80581c470b24
     download_url:
       - https://dataverse.nl/api/access/datafile/45299
     media_type: application/json
@@ -3238,8 +3238,8 @@ has_part:
       exthisdsver:./sub-006/func/sub-006_task-emotionProcessingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 6ffda225a2031c373c9d20043c2bc95c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6ffda225a2031c373c9d20043c2bc95c
     download_url:
       - https://dataverse.nl/api/access/datafile/46377
     media_type: image/nii
@@ -3247,8 +3247,8 @@ has_part:
       exthisdsver:./sub-006/func/sub-006_task-emotionProcessingImagined_echo-2_bold.json
     byte_size: 1048
     checksum:
-      - algorithm: md5
-        digest: 8c4c9cbdf880b4835108bcb06f12fc65
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8c4c9cbdf880b4835108bcb06f12fc65
     download_url:
       - https://dataverse.nl/api/access/datafile/46295
     media_type: application/json
@@ -3256,8 +3256,8 @@ has_part:
       exthisdsver:./sub-006/func/sub-006_task-emotionProcessingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: d951cc8d496ef3ab6de4ef5aeb781a82
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d951cc8d496ef3ab6de4ef5aeb781a82
     download_url:
       - https://dataverse.nl/api/access/datafile/45631
     media_type: image/nii
@@ -3265,8 +3265,8 @@ has_part:
       exthisdsver:./sub-006/func/sub-006_task-emotionProcessingImagined_echo-3_bold.json
     byte_size: 1048
     checksum:
-      - algorithm: md5
-        digest: 00fd2c769d3635aaa5316175f80c1809
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 00fd2c769d3635aaa5316175f80c1809
     download_url:
       - https://dataverse.nl/api/access/datafile/45139
     media_type: application/json
@@ -3274,328 +3274,328 @@ has_part:
       exthisdsver:./sub-006/func/sub-006_task-emotionProcessingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 11b60cd08709c18a081020f900068d20
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 11b60cd08709c18a081020f900068d20
     download_url:
       - https://dataverse.nl/api/access/datafile/45308
     media_type: image/nii
   - id: exthisdsver:./sub-006/func/sub-006_task-emotionProcessingImagined_events.tsv.gz
     byte_size: 177
     checksum:
-      - algorithm: md5
-        digest: 9b728f7556d453898be3d4af32fb1547
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 9b728f7556d453898be3d4af32fb1547
     download_url:
       - https://dataverse.nl/api/access/datafile/46587
     media_type: application/gzip
   - id: exthisdsver:./sub-006/func/sub-006_task-emotionProcessingImagined_physio.json
     byte_size: 142
     checksum:
-      - algorithm: md5
-        digest: 75bd732c9458524aace0ea22711c60c5
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 75bd732c9458524aace0ea22711c60c5
     download_url:
       - https://dataverse.nl/api/access/datafile/45205
     media_type: application/json
   - id: exthisdsver:./sub-006/func/sub-006_task-emotionProcessingImagined_physio.tsv.gz
     byte_size: 477953
     checksum:
-      - algorithm: md5
-        digest: 6e10a0278d083ca6429de64a22b39171
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6e10a0278d083ca6429de64a22b39171
     download_url:
       - https://dataverse.nl/api/access/datafile/46356
     media_type: application/gzip
   - id: exthisdsver:./sub-006/func/sub-006_task-emotionProcessing_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 475357635c0286f20fbf29453815fb81
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 475357635c0286f20fbf29453815fb81
     download_url:
       - https://dataverse.nl/api/access/datafile/45520
     media_type: application/json
   - id: exthisdsver:./sub-006/func/sub-006_task-emotionProcessing_physio.tsv.gz
     byte_size: 487297
     checksum:
-      - algorithm: md5
-        digest: ed554922d2b3f7f717bbc8284e4ea27b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ed554922d2b3f7f717bbc8284e4ea27b
     download_url:
       - https://dataverse.nl/api/access/datafile/45538
     media_type: application/gzip
   - id: exthisdsver:./sub-006/func/sub-006_task-fingerTapping_echo-1_bold.json
     byte_size: 1035
     checksum:
-      - algorithm: md5
-        digest: dad55e717902bc97813aae0d69004b7d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: dad55e717902bc97813aae0d69004b7d
     download_url:
       - https://dataverse.nl/api/access/datafile/46436
     media_type: application/json
   - id: exthisdsver:./sub-006/func/sub-006_task-fingerTapping_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 46a2ac4ea03adc8f2aa8139f49151177
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 46a2ac4ea03adc8f2aa8139f49151177
     download_url:
       - https://dataverse.nl/api/access/datafile/46347
     media_type: image/nii
   - id: exthisdsver:./sub-006/func/sub-006_task-fingerTapping_echo-2_bold.json
     byte_size: 1035
     checksum:
-      - algorithm: md5
-        digest: bd248b0b225157cb9faa47f231b7687b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: bd248b0b225157cb9faa47f231b7687b
     download_url:
       - https://dataverse.nl/api/access/datafile/46178
     media_type: application/json
   - id: exthisdsver:./sub-006/func/sub-006_task-fingerTapping_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: e6f261aced80375d6485eb6a0591c46f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e6f261aced80375d6485eb6a0591c46f
     download_url:
       - https://dataverse.nl/api/access/datafile/46006
     media_type: image/nii
   - id: exthisdsver:./sub-006/func/sub-006_task-fingerTapping_echo-3_bold.json
     byte_size: 1035
     checksum:
-      - algorithm: md5
-        digest: ffaea300a145bb2d8f41179f24f6095c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ffaea300a145bb2d8f41179f24f6095c
     download_url:
       - https://dataverse.nl/api/access/datafile/46417
     media_type: application/json
   - id: exthisdsver:./sub-006/func/sub-006_task-fingerTapping_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 1ee36d37a637953c423827d3593a68fe
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1ee36d37a637953c423827d3593a68fe
     download_url:
       - https://dataverse.nl/api/access/datafile/46390
     media_type: image/nii
   - id: exthisdsver:./sub-006/func/sub-006_task-fingerTapping_events.tsv.gz
     byte_size: 164
     checksum:
-      - algorithm: md5
-        digest: 97cda8e7a0ccb7735140f207f0fac941
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 97cda8e7a0ccb7735140f207f0fac941
     download_url:
       - https://dataverse.nl/api/access/datafile/46580
     media_type: application/gzip
   - id: exthisdsver:./sub-006/func/sub-006_task-fingerTappingImagined_echo-1_bold.json
     byte_size: 1043
     checksum:
-      - algorithm: md5
-        digest: 838a300357bb8c8f7b7ef7b713e77505
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 838a300357bb8c8f7b7ef7b713e77505
     download_url:
       - https://dataverse.nl/api/access/datafile/45738
     media_type: application/json
   - id: exthisdsver:./sub-006/func/sub-006_task-fingerTappingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 25b554d3c728a1eaee9742af3ee2f04c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 25b554d3c728a1eaee9742af3ee2f04c
     download_url:
       - https://dataverse.nl/api/access/datafile/45666
     media_type: image/nii
   - id: exthisdsver:./sub-006/func/sub-006_task-fingerTappingImagined_echo-2_bold.json
     byte_size: 1043
     checksum:
-      - algorithm: md5
-        digest: f790dcfe4fdfbbc880afb29c4ab97e2a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f790dcfe4fdfbbc880afb29c4ab97e2a
     download_url:
       - https://dataverse.nl/api/access/datafile/46141
     media_type: application/json
   - id: exthisdsver:./sub-006/func/sub-006_task-fingerTappingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 84e86baec637e4f1056ef8b4d9c43f8c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 84e86baec637e4f1056ef8b4d9c43f8c
     download_url:
       - https://dataverse.nl/api/access/datafile/45841
     media_type: image/nii
   - id: exthisdsver:./sub-006/func/sub-006_task-fingerTappingImagined_echo-3_bold.json
     byte_size: 1043
     checksum:
-      - algorithm: md5
-        digest: 874c40b78895b1a4d0ef778e2d7e2f0e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 874c40b78895b1a4d0ef778e2d7e2f0e
     download_url:
       - https://dataverse.nl/api/access/datafile/46095
     media_type: application/json
   - id: exthisdsver:./sub-006/func/sub-006_task-fingerTappingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 0d0257625e969fdf73b3435f0b62b672
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 0d0257625e969fdf73b3435f0b62b672
     download_url:
       - https://dataverse.nl/api/access/datafile/46487
     media_type: image/nii
   - id: exthisdsver:./sub-006/func/sub-006_task-fingerTappingImagined_events.tsv.gz
     byte_size: 178
     checksum:
-      - algorithm: md5
-        digest: 34513c7eb841d2d29b30d3afb9a6fb8a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 34513c7eb841d2d29b30d3afb9a6fb8a
     download_url:
       - https://dataverse.nl/api/access/datafile/46574
     media_type: application/gzip
   - id: exthisdsver:./sub-006/func/sub-006_task-fingerTappingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: a97a5b4ee2a2ceb39548b97747c5f4ef
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a97a5b4ee2a2ceb39548b97747c5f4ef
     download_url:
       - https://dataverse.nl/api/access/datafile/45852
     media_type: application/json
   - id: exthisdsver:./sub-006/func/sub-006_task-fingerTappingImagined_physio.tsv.gz
     byte_size: 495320
     checksum:
-      - algorithm: md5
-        digest: 489ade52cee2ab077ab53960f14e8879
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 489ade52cee2ab077ab53960f14e8879
     download_url:
       - https://dataverse.nl/api/access/datafile/46002
     media_type: application/gzip
   - id: exthisdsver:./sub-006/func/sub-006_task-fingerTapping_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 54e018529ba4432aa63cb13717f61cde
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 54e018529ba4432aa63cb13717f61cde
     download_url:
       - https://dataverse.nl/api/access/datafile/46461
     media_type: application/json
   - id: exthisdsver:./sub-006/func/sub-006_task-fingerTapping_physio.tsv.gz
     byte_size: 481816
     checksum:
-      - algorithm: md5
-        digest: 189a945abfc4f3585f040ace44a19f20
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 189a945abfc4f3585f040ace44a19f20
     download_url:
       - https://dataverse.nl/api/access/datafile/45167
     media_type: application/gzip
   - id: exthisdsver:./sub-006/func/sub-006_task-rest_run-1_echo-1_bold.json
     byte_size: 1027
     checksum:
-      - algorithm: md5
-        digest: 669a562f9541700c11b9f570cf642776
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 669a562f9541700c11b9f570cf642776
     download_url:
       - https://dataverse.nl/api/access/datafile/45354
     media_type: application/json
   - id: exthisdsver:./sub-006/func/sub-006_task-rest_run-1_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: e34bca7c50a48aeb3bc133a4a3ad9609
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e34bca7c50a48aeb3bc133a4a3ad9609
     download_url:
       - https://dataverse.nl/api/access/datafile/46453
     media_type: image/nii
   - id: exthisdsver:./sub-006/func/sub-006_task-rest_run-1_echo-2_bold.json
     byte_size: 1027
     checksum:
-      - algorithm: md5
-        digest: abea61313a4f682180a67d01e9f537b2
+      - creator: spdx:checksumAlgorithm_md5
+        notation: abea61313a4f682180a67d01e9f537b2
     download_url:
       - https://dataverse.nl/api/access/datafile/45498
     media_type: application/json
   - id: exthisdsver:./sub-006/func/sub-006_task-rest_run-1_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: abd127f75e7f44c47c560a049d9d1859
+      - creator: spdx:checksumAlgorithm_md5
+        notation: abd127f75e7f44c47c560a049d9d1859
     download_url:
       - https://dataverse.nl/api/access/datafile/46051
     media_type: image/nii
   - id: exthisdsver:./sub-006/func/sub-006_task-rest_run-1_echo-3_bold.json
     byte_size: 1027
     checksum:
-      - algorithm: md5
-        digest: bb93a09ac4d604d2c37428e24e271f97
+      - creator: spdx:checksumAlgorithm_md5
+        notation: bb93a09ac4d604d2c37428e24e271f97
     download_url:
       - https://dataverse.nl/api/access/datafile/45138
     media_type: application/json
   - id: exthisdsver:./sub-006/func/sub-006_task-rest_run-1_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 819a2c8cc4d45feed5fc8a6d9fe19f1d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 819a2c8cc4d45feed5fc8a6d9fe19f1d
     download_url:
       - https://dataverse.nl/api/access/datafile/46244
     media_type: image/nii
   - id: exthisdsver:./sub-006/func/sub-006_task-rest_run-1_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 8c28268a70a2208a8596249381e2d5b0
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8c28268a70a2208a8596249381e2d5b0
     download_url:
       - https://dataverse.nl/api/access/datafile/45983
     media_type: application/json
   - id: exthisdsver:./sub-006/func/sub-006_task-rest_run-1_physio.tsv.gz
     byte_size: 470282
     checksum:
-      - algorithm: md5
-        digest: 6ed25207a1fd7daeb1b0d92d8b1290c2
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6ed25207a1fd7daeb1b0d92d8b1290c2
     download_url:
       - https://dataverse.nl/api/access/datafile/45594
     media_type: application/gzip
   - id: exthisdsver:./sub-006/func/sub-006_task-rest_run-2_echo-1_bold.json
     byte_size: 1027
     checksum:
-      - algorithm: md5
-        digest: a32ed609bc7ae23d5b0ea2d64e101f42
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a32ed609bc7ae23d5b0ea2d64e101f42
     download_url:
       - https://dataverse.nl/api/access/datafile/45430
     media_type: application/json
   - id: exthisdsver:./sub-006/func/sub-006_task-rest_run-2_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: e251adeba1d8f17ceadc117659d5f50c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e251adeba1d8f17ceadc117659d5f50c
     download_url:
       - https://dataverse.nl/api/access/datafile/45200
     media_type: image/nii
   - id: exthisdsver:./sub-006/func/sub-006_task-rest_run-2_echo-2_bold.json
     byte_size: 1027
     checksum:
-      - algorithm: md5
-        digest: 32c38c5ea5a8a4944fbb7e58c389b06c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 32c38c5ea5a8a4944fbb7e58c389b06c
     download_url:
       - https://dataverse.nl/api/access/datafile/46516
     media_type: application/json
   - id: exthisdsver:./sub-006/func/sub-006_task-rest_run-2_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: a49a7475acc48e3a8c541d28de3ac89d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a49a7475acc48e3a8c541d28de3ac89d
     download_url:
       - https://dataverse.nl/api/access/datafile/46176
     media_type: image/nii
   - id: exthisdsver:./sub-006/func/sub-006_task-rest_run-2_echo-3_bold.json
     byte_size: 1027
     checksum:
-      - algorithm: md5
-        digest: da5c5f6183f155557598ef18cafee90d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: da5c5f6183f155557598ef18cafee90d
     download_url:
       - https://dataverse.nl/api/access/datafile/46515
     media_type: application/json
   - id: exthisdsver:./sub-006/func/sub-006_task-rest_run-2_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: ec8d899551a623c7cd5234b66578c893
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ec8d899551a623c7cd5234b66578c893
     download_url:
       - https://dataverse.nl/api/access/datafile/46266
     media_type: image/nii
   - id: exthisdsver:./sub-006/func/sub-006_task-rest_run-2_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 8aa7cae04a66c8841494937ec2ca77ef
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8aa7cae04a66c8841494937ec2ca77ef
     download_url:
       - https://dataverse.nl/api/access/datafile/46341
     media_type: application/json
   - id: exthisdsver:./sub-006/func/sub-006_task-rest_run-2_physio.tsv.gz
     byte_size: 476201
     checksum:
-      - algorithm: md5
-        digest: bef7ae13fdf5c01e6b16c281ec653db7
+      - creator: spdx:checksumAlgorithm_md5
+        notation: bef7ae13fdf5c01e6b16c281ec653db7
     download_url:
       - https://dataverse.nl/api/access/datafile/45286
     media_type: application/gzip
   - id: exthisdsver:./sub-007/anat/sub-007_T1w.nii
     byte_size: 20736352
     checksum:
-      - algorithm: md5
-        digest: fbc1e0cadc88e77c902c3957d3697ff8
+      - creator: spdx:checksumAlgorithm_md5
+        notation: fbc1e0cadc88e77c902c3957d3697ff8
     download_url:
       - https://dataverse.nl/api/access/datafile/45827
     media_type: image/nii
@@ -3612,8 +3612,8 @@ has_part:
   - id: exthisdsver:./sub-007/func/sub-007_task-emotionProcessing_echo-1_bold.json
     byte_size: 1043
     checksum:
-      - algorithm: md5
-        digest: 546bfbdc9eb9e8d4fdd72f7f2a2855bc
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 546bfbdc9eb9e8d4fdd72f7f2a2855bc
     download_url:
       - https://dataverse.nl/api/access/datafile/45251
     media_type: application/json
@@ -3732,48 +3732,48 @@ has_part:
   - id: exthisdsver:./sub-007/func/sub-007_task-emotionProcessing_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: ff85dbedbb45279bb3f3fdd7c23012e7
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ff85dbedbb45279bb3f3fdd7c23012e7
     download_url:
       - https://dataverse.nl/api/access/datafile/46209
     media_type: image/nii
   - id: exthisdsver:./sub-007/func/sub-007_task-emotionProcessing_echo-2_bold.json
     byte_size: 1043
     checksum:
-      - algorithm: md5
-        digest: f6745fa00ca7d991f6a1028d7dc587bf
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f6745fa00ca7d991f6a1028d7dc587bf
     download_url:
       - https://dataverse.nl/api/access/datafile/45212
     media_type: application/json
   - id: exthisdsver:./sub-007/func/sub-007_task-emotionProcessing_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: cf7167081c0ae6e886080eea50e45e5f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: cf7167081c0ae6e886080eea50e45e5f
     download_url:
       - https://dataverse.nl/api/access/datafile/45779
     media_type: image/nii
   - id: exthisdsver:./sub-007/func/sub-007_task-emotionProcessing_echo-3_bold.json
     byte_size: 1043
     checksum:
-      - algorithm: md5
-        digest: 01560fd90928f842b4fece30ecccef6f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 01560fd90928f842b4fece30ecccef6f
     download_url:
       - https://dataverse.nl/api/access/datafile/45881
     media_type: application/json
   - id: exthisdsver:./sub-007/func/sub-007_task-emotionProcessing_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 8784a8244173581831f8c154b94f8077
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8784a8244173581831f8c154b94f8077
     download_url:
       - https://dataverse.nl/api/access/datafile/45562
     media_type: image/nii
   - id: exthisdsver:./sub-007/func/sub-007_task-emotionProcessing_events.tsv.gz
     byte_size: 1901
     checksum:
-      - algorithm: md5
-        digest: 9f87561b465acf40c79a9c2d3a8319b6
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 9f87561b465acf40c79a9c2d3a8319b6
     download_url:
       - https://dataverse.nl/api/access/datafile/46554
     media_type: application/gzip
@@ -3781,8 +3781,8 @@ has_part:
       exthisdsver:./sub-007/func/sub-007_task-emotionProcessingImagined_echo-1_bold.json
     byte_size: 1051
     checksum:
-      - algorithm: md5
-        digest: 7011c67d20cfdfe41797613299b4ad0f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 7011c67d20cfdfe41797613299b4ad0f
     download_url:
       - https://dataverse.nl/api/access/datafile/46454
     media_type: application/json
@@ -3790,8 +3790,8 @@ has_part:
       exthisdsver:./sub-007/func/sub-007_task-emotionProcessingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 9c1f6a85f118a8c1b511be62b57b3789
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 9c1f6a85f118a8c1b511be62b57b3789
     download_url:
       - https://dataverse.nl/api/access/datafile/45274
     media_type: image/nii
@@ -3799,8 +3799,8 @@ has_part:
       exthisdsver:./sub-007/func/sub-007_task-emotionProcessingImagined_echo-2_bold.json
     byte_size: 1051
     checksum:
-      - algorithm: md5
-        digest: 181e1d723e5107c1bf52f314403ce2f7
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 181e1d723e5107c1bf52f314403ce2f7
     download_url:
       - https://dataverse.nl/api/access/datafile/45283
     media_type: application/json
@@ -3808,8 +3808,8 @@ has_part:
       exthisdsver:./sub-007/func/sub-007_task-emotionProcessingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 1d7028d89cdde68515286a63ebc47ae7
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1d7028d89cdde68515286a63ebc47ae7
     download_url:
       - https://dataverse.nl/api/access/datafile/45331
     media_type: image/nii
@@ -3817,8 +3817,8 @@ has_part:
       exthisdsver:./sub-007/func/sub-007_task-emotionProcessingImagined_echo-3_bold.json
     byte_size: 1051
     checksum:
-      - algorithm: md5
-        digest: f94a966d01fbb37b3804b43233b09228
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f94a966d01fbb37b3804b43233b09228
     download_url:
       - https://dataverse.nl/api/access/datafile/45146
     media_type: application/json
@@ -3826,328 +3826,328 @@ has_part:
       exthisdsver:./sub-007/func/sub-007_task-emotionProcessingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: c9af8f55d26f56477b0b42d647c75538
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c9af8f55d26f56477b0b42d647c75538
     download_url:
       - https://dataverse.nl/api/access/datafile/46044
     media_type: image/nii
   - id: exthisdsver:./sub-007/func/sub-007_task-emotionProcessingImagined_events.tsv.gz
     byte_size: 173
     checksum:
-      - algorithm: md5
-        digest: a14595a04fa570203ff5a200bf6b4f42
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a14595a04fa570203ff5a200bf6b4f42
     download_url:
       - https://dataverse.nl/api/access/datafile/46645
     media_type: application/gzip
   - id: exthisdsver:./sub-007/func/sub-007_task-emotionProcessingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 2bd463332c59abb455e544e5b926b075
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2bd463332c59abb455e544e5b926b075
     download_url:
       - https://dataverse.nl/api/access/datafile/45873
     media_type: application/json
   - id: exthisdsver:./sub-007/func/sub-007_task-emotionProcessingImagined_physio.tsv.gz
     byte_size: 505783
     checksum:
-      - algorithm: md5
-        digest: 8d61be093569285fe4d0ccba7b8d4066
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8d61be093569285fe4d0ccba7b8d4066
     download_url:
       - https://dataverse.nl/api/access/datafile/45284
     media_type: application/gzip
   - id: exthisdsver:./sub-007/func/sub-007_task-emotionProcessing_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: ebd4c5024fc2c63829cd66705135c047
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ebd4c5024fc2c63829cd66705135c047
     download_url:
       - https://dataverse.nl/api/access/datafile/46005
     media_type: application/json
   - id: exthisdsver:./sub-007/func/sub-007_task-emotionProcessing_physio.tsv.gz
     byte_size: 465952
     checksum:
-      - algorithm: md5
-        digest: b4e5d718da2c84444e15c191d680f756
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b4e5d718da2c84444e15c191d680f756
     download_url:
       - https://dataverse.nl/api/access/datafile/46050
     media_type: application/gzip
   - id: exthisdsver:./sub-007/func/sub-007_task-fingerTapping_echo-1_bold.json
     byte_size: 1039
     checksum:
-      - algorithm: md5
-        digest: b8aa0235d1518b988e3a07f658738226
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b8aa0235d1518b988e3a07f658738226
     download_url:
       - https://dataverse.nl/api/access/datafile/46245
     media_type: application/json
   - id: exthisdsver:./sub-007/func/sub-007_task-fingerTapping_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 19292eaa783f4d0598a87cd1ca7b0563
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 19292eaa783f4d0598a87cd1ca7b0563
     download_url:
       - https://dataverse.nl/api/access/datafile/46007
     media_type: image/nii
   - id: exthisdsver:./sub-007/func/sub-007_task-fingerTapping_echo-2_bold.json
     byte_size: 1039
     checksum:
-      - algorithm: md5
-        digest: 361961f4bc30ec4eaa1bfe9a36e270dc
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 361961f4bc30ec4eaa1bfe9a36e270dc
     download_url:
       - https://dataverse.nl/api/access/datafile/45116
     media_type: application/json
   - id: exthisdsver:./sub-007/func/sub-007_task-fingerTapping_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 472188cbd9b951f8ccca6f236151395b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 472188cbd9b951f8ccca6f236151395b
     download_url:
       - https://dataverse.nl/api/access/datafile/45232
     media_type: image/nii
   - id: exthisdsver:./sub-007/func/sub-007_task-fingerTapping_echo-3_bold.json
     byte_size: 1039
     checksum:
-      - algorithm: md5
-        digest: 33a478f431f41fd183c58c138c6b57a9
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 33a478f431f41fd183c58c138c6b57a9
     download_url:
       - https://dataverse.nl/api/access/datafile/45585
     media_type: application/json
   - id: exthisdsver:./sub-007/func/sub-007_task-fingerTapping_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 522e173aa201ab2270c7adb597c97105
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 522e173aa201ab2270c7adb597c97105
     download_url:
       - https://dataverse.nl/api/access/datafile/45476
     media_type: image/nii
   - id: exthisdsver:./sub-007/func/sub-007_task-fingerTapping_events.tsv.gz
     byte_size: 162
     checksum:
-      - algorithm: md5
-        digest: 80f803f4d5795a7ac16a0fece568730d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 80f803f4d5795a7ac16a0fece568730d
     download_url:
       - https://dataverse.nl/api/access/datafile/46582
     media_type: application/gzip
   - id: exthisdsver:./sub-007/func/sub-007_task-fingerTappingImagined_echo-1_bold.json
     byte_size: 1047
     checksum:
-      - algorithm: md5
-        digest: 1da6abda2407618e0df5c408f656f030
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1da6abda2407618e0df5c408f656f030
     download_url:
       - https://dataverse.nl/api/access/datafile/45524
     media_type: application/json
   - id: exthisdsver:./sub-007/func/sub-007_task-fingerTappingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 6782618324fef13f1889ab44b53774ec
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6782618324fef13f1889ab44b53774ec
     download_url:
       - https://dataverse.nl/api/access/datafile/46297
     media_type: image/nii
   - id: exthisdsver:./sub-007/func/sub-007_task-fingerTappingImagined_echo-2_bold.json
     byte_size: 1047
     checksum:
-      - algorithm: md5
-        digest: bef00992f80fbca5c89dec95e7e29962
+      - creator: spdx:checksumAlgorithm_md5
+        notation: bef00992f80fbca5c89dec95e7e29962
     download_url:
       - https://dataverse.nl/api/access/datafile/45570
     media_type: application/json
   - id: exthisdsver:./sub-007/func/sub-007_task-fingerTappingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: d16a3909c93e1b5fabe5fcb0d94a124b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d16a3909c93e1b5fabe5fcb0d94a124b
     download_url:
       - https://dataverse.nl/api/access/datafile/45867
     media_type: image/nii
   - id: exthisdsver:./sub-007/func/sub-007_task-fingerTappingImagined_echo-3_bold.json
     byte_size: 1047
     checksum:
-      - algorithm: md5
-        digest: 8469140ce87ef9f4060a88bbed4439be
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8469140ce87ef9f4060a88bbed4439be
     download_url:
       - https://dataverse.nl/api/access/datafile/45878
     media_type: application/json
   - id: exthisdsver:./sub-007/func/sub-007_task-fingerTappingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: b08e9141daca5df31278b472b2080608
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b08e9141daca5df31278b472b2080608
     download_url:
       - https://dataverse.nl/api/access/datafile/46304
     media_type: image/nii
   - id: exthisdsver:./sub-007/func/sub-007_task-fingerTappingImagined_events.tsv.gz
     byte_size: 175
     checksum:
-      - algorithm: md5
-        digest: 9046a531aa50523795d30ead98aa3efa
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 9046a531aa50523795d30ead98aa3efa
     download_url:
       - https://dataverse.nl/api/access/datafile/46589
     media_type: application/gzip
   - id: exthisdsver:./sub-007/func/sub-007_task-fingerTappingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: f90f2c7f8d0d8658759199e1bce75aa5
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f90f2c7f8d0d8658759199e1bce75aa5
     download_url:
       - https://dataverse.nl/api/access/datafile/46396
     media_type: application/json
   - id: exthisdsver:./sub-007/func/sub-007_task-fingerTappingImagined_physio.tsv.gz
     byte_size: 460170
     checksum:
-      - algorithm: md5
-        digest: df7af70a068b02d5093813ef3e034ef9
+      - creator: spdx:checksumAlgorithm_md5
+        notation: df7af70a068b02d5093813ef3e034ef9
     download_url:
       - https://dataverse.nl/api/access/datafile/45539
     media_type: application/gzip
   - id: exthisdsver:./sub-007/func/sub-007_task-fingerTapping_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 20a6d9fec97d01da69ff7b1063e151d8
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 20a6d9fec97d01da69ff7b1063e151d8
     download_url:
       - https://dataverse.nl/api/access/datafile/45627
     media_type: application/json
   - id: exthisdsver:./sub-007/func/sub-007_task-fingerTapping_physio.tsv.gz
     byte_size: 479042
     checksum:
-      - algorithm: md5
-        digest: d74a7e3e51b82463356492dded1fd888
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d74a7e3e51b82463356492dded1fd888
     download_url:
       - https://dataverse.nl/api/access/datafile/45438
     media_type: application/gzip
   - id: exthisdsver:./sub-007/func/sub-007_task-rest_run-1_echo-1_bold.json
     byte_size: 1030
     checksum:
-      - algorithm: md5
-        digest: 4959a08e00f5f4648e2d61f408cc0b38
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4959a08e00f5f4648e2d61f408cc0b38
     download_url:
       - https://dataverse.nl/api/access/datafile/45887
     media_type: application/json
   - id: exthisdsver:./sub-007/func/sub-007_task-rest_run-1_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 7e6e883dcd5dcb54cbbc00404009989a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 7e6e883dcd5dcb54cbbc00404009989a
     download_url:
       - https://dataverse.nl/api/access/datafile/46413
     media_type: image/nii
   - id: exthisdsver:./sub-007/func/sub-007_task-rest_run-1_echo-2_bold.json
     byte_size: 1030
     checksum:
-      - algorithm: md5
-        digest: 034b7fa7cf9975f5bf5acab99af751c5
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 034b7fa7cf9975f5bf5acab99af751c5
     download_url:
       - https://dataverse.nl/api/access/datafile/45389
     media_type: application/json
   - id: exthisdsver:./sub-007/func/sub-007_task-rest_run-1_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 1109e59c036b13ed6f9d40aa275e650f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1109e59c036b13ed6f9d40aa275e650f
     download_url:
       - https://dataverse.nl/api/access/datafile/45942
     media_type: image/nii
   - id: exthisdsver:./sub-007/func/sub-007_task-rest_run-1_echo-3_bold.json
     byte_size: 1030
     checksum:
-      - algorithm: md5
-        digest: 901312b94dcad0754bfa7c01b96ace98
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 901312b94dcad0754bfa7c01b96ace98
     download_url:
       - https://dataverse.nl/api/access/datafile/45800
     media_type: application/json
   - id: exthisdsver:./sub-007/func/sub-007_task-rest_run-1_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: b75defef6758d046883ac46f7fe718f6
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b75defef6758d046883ac46f7fe718f6
     download_url:
       - https://dataverse.nl/api/access/datafile/46497
     media_type: image/nii
   - id: exthisdsver:./sub-007/func/sub-007_task-rest_run-1_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 2c05d7ffba904b20acf7f8d798e56f1a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2c05d7ffba904b20acf7f8d798e56f1a
     download_url:
       - https://dataverse.nl/api/access/datafile/46142
     media_type: application/json
   - id: exthisdsver:./sub-007/func/sub-007_task-rest_run-1_physio.tsv.gz
     byte_size: 453559
     checksum:
-      - algorithm: md5
-        digest: 26bdaee0f8531fba3f072d0de0dafdff
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 26bdaee0f8531fba3f072d0de0dafdff
     download_url:
       - https://dataverse.nl/api/access/datafile/46008
     media_type: application/gzip
   - id: exthisdsver:./sub-007/func/sub-007_task-rest_run-2_echo-1_bold.json
     byte_size: 1030
     checksum:
-      - algorithm: md5
-        digest: f870b8885b5f5777c880004242ada96c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f870b8885b5f5777c880004242ada96c
     download_url:
       - https://dataverse.nl/api/access/datafile/45163
     media_type: application/json
   - id: exthisdsver:./sub-007/func/sub-007_task-rest_run-2_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 135abe8207577cc86e46e70c541a095e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 135abe8207577cc86e46e70c541a095e
     download_url:
       - https://dataverse.nl/api/access/datafile/45674
     media_type: image/nii
   - id: exthisdsver:./sub-007/func/sub-007_task-rest_run-2_echo-2_bold.json
     byte_size: 1030
     checksum:
-      - algorithm: md5
-        digest: 0cea8aabf50a08cf40064469989c7a24
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 0cea8aabf50a08cf40064469989c7a24
     download_url:
       - https://dataverse.nl/api/access/datafile/45832
     media_type: application/json
   - id: exthisdsver:./sub-007/func/sub-007_task-rest_run-2_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 62b37f39c8e730772e07d76cd7f883ff
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 62b37f39c8e730772e07d76cd7f883ff
     download_url:
       - https://dataverse.nl/api/access/datafile/46317
     media_type: image/nii
   - id: exthisdsver:./sub-007/func/sub-007_task-rest_run-2_echo-3_bold.json
     byte_size: 1030
     checksum:
-      - algorithm: md5
-        digest: 2528930ba2cb1ee93762bbf4d2b6cf88
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2528930ba2cb1ee93762bbf4d2b6cf88
     download_url:
       - https://dataverse.nl/api/access/datafile/46537
     media_type: application/json
   - id: exthisdsver:./sub-007/func/sub-007_task-rest_run-2_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 92cbee685bec54eea7b58fab9cfa87be
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 92cbee685bec54eea7b58fab9cfa87be
     download_url:
       - https://dataverse.nl/api/access/datafile/45668
     media_type: image/nii
   - id: exthisdsver:./sub-007/func/sub-007_task-rest_run-2_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: e2b861e80af7998037002ea748928567
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e2b861e80af7998037002ea748928567
     download_url:
       - https://dataverse.nl/api/access/datafile/46230
     media_type: application/json
   - id: exthisdsver:./sub-007/func/sub-007_task-rest_run-2_physio.tsv.gz
     byte_size: 444758
     checksum:
-      - algorithm: md5
-        digest: 55a951fd7252a67fad44cf4a2d4d2c36
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 55a951fd7252a67fad44cf4a2d4d2c36
     download_url:
       - https://dataverse.nl/api/access/datafile/46184
     media_type: application/gzip
   - id: exthisdsver:./sub-010/anat/sub-010_T1w.nii
     byte_size: 20736352
     checksum:
-      - algorithm: md5
-        digest: b3077aed8b42c7b913990adb014c3048
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b3077aed8b42c7b913990adb014c3048
     download_url:
       - https://dataverse.nl/api/access/datafile/46471
     media_type: image/nii
@@ -4164,8 +4164,8 @@ has_part:
   - id: exthisdsver:./sub-010/func/sub-010_task-emotionProcessing_echo-1_bold.json
     byte_size: 1042
     checksum:
-      - algorithm: md5
-        digest: d7902ae5755e22be8fa2d6b8d0884caa
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d7902ae5755e22be8fa2d6b8d0884caa
     download_url:
       - https://dataverse.nl/api/access/datafile/45248
     media_type: application/json
@@ -4284,48 +4284,48 @@ has_part:
   - id: exthisdsver:./sub-010/func/sub-010_task-emotionProcessing_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 3d565ac576fdae0bccaf91a945b4e6e0
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 3d565ac576fdae0bccaf91a945b4e6e0
     download_url:
       - https://dataverse.nl/api/access/datafile/46438
     media_type: image/nii
   - id: exthisdsver:./sub-010/func/sub-010_task-emotionProcessing_echo-2_bold.json
     byte_size: 1042
     checksum:
-      - algorithm: md5
-        digest: 2737d5e2127911240a0668c1ee439f71
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2737d5e2127911240a0668c1ee439f71
     download_url:
       - https://dataverse.nl/api/access/datafile/45984
     media_type: application/json
   - id: exthisdsver:./sub-010/func/sub-010_task-emotionProcessing_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 35c37986da86c0212ff6293e50bba0dc
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 35c37986da86c0212ff6293e50bba0dc
     download_url:
       - https://dataverse.nl/api/access/datafile/46338
     media_type: image/nii
   - id: exthisdsver:./sub-010/func/sub-010_task-emotionProcessing_echo-3_bold.json
     byte_size: 1042
     checksum:
-      - algorithm: md5
-        digest: 32066bc8ff38a2d996177efeeacece1a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 32066bc8ff38a2d996177efeeacece1a
     download_url:
       - https://dataverse.nl/api/access/datafile/46136
     media_type: application/json
   - id: exthisdsver:./sub-010/func/sub-010_task-emotionProcessing_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 304fc0316cd8bdc94d86c0cdf0fffc6d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 304fc0316cd8bdc94d86c0cdf0fffc6d
     download_url:
       - https://dataverse.nl/api/access/datafile/45448
     media_type: image/nii
   - id: exthisdsver:./sub-010/func/sub-010_task-emotionProcessing_events.tsv.gz
     byte_size: 1918
     checksum:
-      - algorithm: md5
-        digest: b9b914b29a4a98a38f3687d506ff1382
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b9b914b29a4a98a38f3687d506ff1382
     download_url:
       - https://dataverse.nl/api/access/datafile/46656
     media_type: application/gzip
@@ -4333,8 +4333,8 @@ has_part:
       exthisdsver:./sub-010/func/sub-010_task-emotionProcessingImagined_echo-1_bold.json
     byte_size: 1050
     checksum:
-      - algorithm: md5
-        digest: 7e2ebc1a862896ec2c579d602c90ecf4
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 7e2ebc1a862896ec2c579d602c90ecf4
     download_url:
       - https://dataverse.nl/api/access/datafile/46539
     media_type: application/json
@@ -4342,8 +4342,8 @@ has_part:
       exthisdsver:./sub-010/func/sub-010_task-emotionProcessingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 92fc1ca8f032ad7ad4cf6a38d5bd83b6
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 92fc1ca8f032ad7ad4cf6a38d5bd83b6
     download_url:
       - https://dataverse.nl/api/access/datafile/45431
     media_type: image/nii
@@ -4351,8 +4351,8 @@ has_part:
       exthisdsver:./sub-010/func/sub-010_task-emotionProcessingImagined_echo-2_bold.json
     byte_size: 1050
     checksum:
-      - algorithm: md5
-        digest: ed835fe6ac5c46db6a78becb00b9a6b3
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ed835fe6ac5c46db6a78becb00b9a6b3
     download_url:
       - https://dataverse.nl/api/access/datafile/46088
     media_type: application/json
@@ -4360,8 +4360,8 @@ has_part:
       exthisdsver:./sub-010/func/sub-010_task-emotionProcessingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 6a1cb1c4be9e0bc6372c50abf0e475ff
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6a1cb1c4be9e0bc6372c50abf0e475ff
     download_url:
       - https://dataverse.nl/api/access/datafile/45216
     media_type: image/nii
@@ -4369,8 +4369,8 @@ has_part:
       exthisdsver:./sub-010/func/sub-010_task-emotionProcessingImagined_echo-3_bold.json
     byte_size: 1050
     checksum:
-      - algorithm: md5
-        digest: f25f858d4fb92f3782ed330a8246988a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f25f858d4fb92f3782ed330a8246988a
     download_url:
       - https://dataverse.nl/api/access/datafile/46156
     media_type: application/json
@@ -4378,328 +4378,328 @@ has_part:
       exthisdsver:./sub-010/func/sub-010_task-emotionProcessingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 834e21e666bf2b6fd0a9d91da6496033
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 834e21e666bf2b6fd0a9d91da6496033
     download_url:
       - https://dataverse.nl/api/access/datafile/46397
     media_type: image/nii
   - id: exthisdsver:./sub-010/func/sub-010_task-emotionProcessingImagined_events.tsv.gz
     byte_size: 178
     checksum:
-      - algorithm: md5
-        digest: 90fe04ee120c67a7736e7d57e494b3a7
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 90fe04ee120c67a7736e7d57e494b3a7
     download_url:
       - https://dataverse.nl/api/access/datafile/46631
     media_type: application/gzip
   - id: exthisdsver:./sub-010/func/sub-010_task-emotionProcessingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 4c0258f56ab2d5b9c849a907fbe99370
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4c0258f56ab2d5b9c849a907fbe99370
     download_url:
       - https://dataverse.nl/api/access/datafile/46301
     media_type: application/json
   - id: exthisdsver:./sub-010/func/sub-010_task-emotionProcessingImagined_physio.tsv.gz
     byte_size: 608637
     checksum:
-      - algorithm: md5
-        digest: d8a6822cee54e4f25fa51962ac919f16
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d8a6822cee54e4f25fa51962ac919f16
     download_url:
       - https://dataverse.nl/api/access/datafile/45161
     media_type: application/gzip
   - id: exthisdsver:./sub-010/func/sub-010_task-emotionProcessing_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 1b303daf14c578e9af688ffe870d007e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1b303daf14c578e9af688ffe870d007e
     download_url:
       - https://dataverse.nl/api/access/datafile/46087
     media_type: application/json
   - id: exthisdsver:./sub-010/func/sub-010_task-emotionProcessing_physio.tsv.gz
     byte_size: 474961
     checksum:
-      - algorithm: md5
-        digest: 719ea8f9d5b8da93a26e672b28903983
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 719ea8f9d5b8da93a26e672b28903983
     download_url:
       - https://dataverse.nl/api/access/datafile/46415
     media_type: application/gzip
   - id: exthisdsver:./sub-010/func/sub-010_task-fingerTapping_echo-1_bold.json
     byte_size: 1038
     checksum:
-      - algorithm: md5
-        digest: 41f79f2307ebac763f7a4130024a1ad5
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 41f79f2307ebac763f7a4130024a1ad5
     download_url:
       - https://dataverse.nl/api/access/datafile/46267
     media_type: application/json
   - id: exthisdsver:./sub-010/func/sub-010_task-fingerTapping_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 85bfb3b996a3e363341e71a3cd9fae42
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 85bfb3b996a3e363341e71a3cd9fae42
     download_url:
       - https://dataverse.nl/api/access/datafile/45855
     media_type: image/nii
   - id: exthisdsver:./sub-010/func/sub-010_task-fingerTapping_echo-2_bold.json
     byte_size: 1038
     checksum:
-      - algorithm: md5
-        digest: 3b54a011c9dc6999fa71ed00da1c7b02
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 3b54a011c9dc6999fa71ed00da1c7b02
     download_url:
       - https://dataverse.nl/api/access/datafile/46181
     media_type: application/json
   - id: exthisdsver:./sub-010/func/sub-010_task-fingerTapping_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: b48377a889536602e998ee678696daec
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b48377a889536602e998ee678696daec
     download_url:
       - https://dataverse.nl/api/access/datafile/45719
     media_type: image/nii
   - id: exthisdsver:./sub-010/func/sub-010_task-fingerTapping_echo-3_bold.json
     byte_size: 1038
     checksum:
-      - algorithm: md5
-        digest: 925a84e91f2ba11ea6d7e1bfa6ea32aa
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 925a84e91f2ba11ea6d7e1bfa6ea32aa
     download_url:
       - https://dataverse.nl/api/access/datafile/45862
     media_type: application/json
   - id: exthisdsver:./sub-010/func/sub-010_task-fingerTapping_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 7b6a9bbaf03466614419c88ead447c63
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 7b6a9bbaf03466614419c88ead447c63
     download_url:
       - https://dataverse.nl/api/access/datafile/45928
     media_type: image/nii
   - id: exthisdsver:./sub-010/func/sub-010_task-fingerTapping_events.tsv.gz
     byte_size: 162
     checksum:
-      - algorithm: md5
-        digest: 13eecaf8e5d96e416ecc8d9f9d741dbb
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 13eecaf8e5d96e416ecc8d9f9d741dbb
     download_url:
       - https://dataverse.nl/api/access/datafile/46623
     media_type: application/gzip
   - id: exthisdsver:./sub-010/func/sub-010_task-fingerTappingImagined_echo-1_bold.json
     byte_size: 1045
     checksum:
-      - algorithm: md5
-        digest: 0c664901323404e22f267dcb240647d8
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 0c664901323404e22f267dcb240647d8
     download_url:
       - https://dataverse.nl/api/access/datafile/46081
     media_type: application/json
   - id: exthisdsver:./sub-010/func/sub-010_task-fingerTappingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: ce3af5c2a3f18df9ee255e0752dee7d0
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ce3af5c2a3f18df9ee255e0752dee7d0
     download_url:
       - https://dataverse.nl/api/access/datafile/46476
     media_type: image/nii
   - id: exthisdsver:./sub-010/func/sub-010_task-fingerTappingImagined_echo-2_bold.json
     byte_size: 1045
     checksum:
-      - algorithm: md5
-        digest: 74af5cbb23fe19b5e0b77b6c1cf400b8
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 74af5cbb23fe19b5e0b77b6c1cf400b8
     download_url:
       - https://dataverse.nl/api/access/datafile/45825
     media_type: application/json
   - id: exthisdsver:./sub-010/func/sub-010_task-fingerTappingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 3c40888bc656e6497dcb1bcdd0576f44
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 3c40888bc656e6497dcb1bcdd0576f44
     download_url:
       - https://dataverse.nl/api/access/datafile/45869
     media_type: image/nii
   - id: exthisdsver:./sub-010/func/sub-010_task-fingerTappingImagined_echo-3_bold.json
     byte_size: 1045
     checksum:
-      - algorithm: md5
-        digest: dc2b090512113f82d5606d3adc06f616
+      - creator: spdx:checksumAlgorithm_md5
+        notation: dc2b090512113f82d5606d3adc06f616
     download_url:
       - https://dataverse.nl/api/access/datafile/46494
     media_type: application/json
   - id: exthisdsver:./sub-010/func/sub-010_task-fingerTappingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: af351919e3f9eb6b8ae1b6648f4ed9c4
+      - creator: spdx:checksumAlgorithm_md5
+        notation: af351919e3f9eb6b8ae1b6648f4ed9c4
     download_url:
       - https://dataverse.nl/api/access/datafile/45986
     media_type: image/nii
   - id: exthisdsver:./sub-010/func/sub-010_task-fingerTappingImagined_events.tsv.gz
     byte_size: 178
     checksum:
-      - algorithm: md5
-        digest: d32cce9233e1ec88d65e121fe1d46bf5
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d32cce9233e1ec88d65e121fe1d46bf5
     download_url:
       - https://dataverse.nl/api/access/datafile/46640
     media_type: application/gzip
   - id: exthisdsver:./sub-010/func/sub-010_task-fingerTappingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 40496512d9d271d8d4777a5ba8a45020
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 40496512d9d271d8d4777a5ba8a45020
     download_url:
       - https://dataverse.nl/api/access/datafile/45305
     media_type: application/json
   - id: exthisdsver:./sub-010/func/sub-010_task-fingerTappingImagined_physio.tsv.gz
     byte_size: 502922
     checksum:
-      - algorithm: md5
-        digest: b7ddc4eab27aea3d811b52302b447c3d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b7ddc4eab27aea3d811b52302b447c3d
     download_url:
       - https://dataverse.nl/api/access/datafile/45956
     media_type: application/gzip
   - id: exthisdsver:./sub-010/func/sub-010_task-fingerTapping_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 01f363feb27b24b1d987ceebff33c223
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 01f363feb27b24b1d987ceebff33c223
     download_url:
       - https://dataverse.nl/api/access/datafile/46215
     media_type: application/json
   - id: exthisdsver:./sub-010/func/sub-010_task-fingerTapping_physio.tsv.gz
     byte_size: 524308
     checksum:
-      - algorithm: md5
-        digest: d93c77119a2e47f583488fe26339e20a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d93c77119a2e47f583488fe26339e20a
     download_url:
       - https://dataverse.nl/api/access/datafile/45185
     media_type: application/gzip
   - id: exthisdsver:./sub-010/func/sub-010_task-rest_run-1_echo-1_bold.json
     byte_size: 1027
     checksum:
-      - algorithm: md5
-        digest: 8b40a3a3357d881c508208473509c5f3
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8b40a3a3357d881c508208473509c5f3
     download_url:
       - https://dataverse.nl/api/access/datafile/45098
     media_type: application/json
   - id: exthisdsver:./sub-010/func/sub-010_task-rest_run-1_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 782e1f1a21fa2241d559e7c3283ffa39
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 782e1f1a21fa2241d559e7c3283ffa39
     download_url:
       - https://dataverse.nl/api/access/datafile/45598
     media_type: image/nii
   - id: exthisdsver:./sub-010/func/sub-010_task-rest_run-1_echo-2_bold.json
     byte_size: 1027
     checksum:
-      - algorithm: md5
-        digest: 10fa6a7d96f3792f52e375350918ee86
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 10fa6a7d96f3792f52e375350918ee86
     download_url:
       - https://dataverse.nl/api/access/datafile/45530
     media_type: application/json
   - id: exthisdsver:./sub-010/func/sub-010_task-rest_run-1_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: fa62a534801a97ae30eb84c3394e7dcd
+      - creator: spdx:checksumAlgorithm_md5
+        notation: fa62a534801a97ae30eb84c3394e7dcd
     download_url:
       - https://dataverse.nl/api/access/datafile/45995
     media_type: image/nii
   - id: exthisdsver:./sub-010/func/sub-010_task-rest_run-1_echo-3_bold.json
     byte_size: 1027
     checksum:
-      - algorithm: md5
-        digest: 763295aba2ac0ba5bf10fea22c41f404
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 763295aba2ac0ba5bf10fea22c41f404
     download_url:
       - https://dataverse.nl/api/access/datafile/46056
     media_type: application/json
   - id: exthisdsver:./sub-010/func/sub-010_task-rest_run-1_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 663fb57530eef754952991dec16af2b3
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 663fb57530eef754952991dec16af2b3
     download_url:
       - https://dataverse.nl/api/access/datafile/46284
     media_type: image/nii
   - id: exthisdsver:./sub-010/func/sub-010_task-rest_run-1_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: b3c24aa9b3f9b5e8addebc27680ca61c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b3c24aa9b3f9b5e8addebc27680ca61c
     download_url:
       - https://dataverse.nl/api/access/datafile/46158
     media_type: application/json
   - id: exthisdsver:./sub-010/func/sub-010_task-rest_run-1_physio.tsv.gz
     byte_size: 461533
     checksum:
-      - algorithm: md5
-        digest: 517b4d76691685dd772eeaf35023c8a5
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 517b4d76691685dd772eeaf35023c8a5
     download_url:
       - https://dataverse.nl/api/access/datafile/45177
     media_type: application/gzip
   - id: exthisdsver:./sub-010/func/sub-010_task-rest_run-2_echo-1_bold.json
     byte_size: 1027
     checksum:
-      - algorithm: md5
-        digest: 849ddca842961f33bd2a508b4b66243e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 849ddca842961f33bd2a508b4b66243e
     download_url:
       - https://dataverse.nl/api/access/datafile/45118
     media_type: application/json
   - id: exthisdsver:./sub-010/func/sub-010_task-rest_run-2_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: b772fa7627a2c78cbf6bbc7aa8e15fc5
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b772fa7627a2c78cbf6bbc7aa8e15fc5
     download_url:
       - https://dataverse.nl/api/access/datafile/45387
     media_type: image/nii
   - id: exthisdsver:./sub-010/func/sub-010_task-rest_run-2_echo-2_bold.json
     byte_size: 1027
     checksum:
-      - algorithm: md5
-        digest: e181c7d8e19289a06d9d934cbec46373
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e181c7d8e19289a06d9d934cbec46373
     download_url:
       - https://dataverse.nl/api/access/datafile/46001
     media_type: application/json
   - id: exthisdsver:./sub-010/func/sub-010_task-rest_run-2_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 061f466079bc706ddb09c4dc7f1f7ec8
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 061f466079bc706ddb09c4dc7f1f7ec8
     download_url:
       - https://dataverse.nl/api/access/datafile/46398
     media_type: image/nii
   - id: exthisdsver:./sub-010/func/sub-010_task-rest_run-2_echo-3_bold.json
     byte_size: 1027
     checksum:
-      - algorithm: md5
-        digest: da466649c5100e5c28b525ef4bbed378
+      - creator: spdx:checksumAlgorithm_md5
+        notation: da466649c5100e5c28b525ef4bbed378
     download_url:
       - https://dataverse.nl/api/access/datafile/45689
     media_type: application/json
   - id: exthisdsver:./sub-010/func/sub-010_task-rest_run-2_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 2ad6ec828be8d507d6a9f96050cb024d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2ad6ec828be8d507d6a9f96050cb024d
     download_url:
       - https://dataverse.nl/api/access/datafile/45404
     media_type: image/nii
   - id: exthisdsver:./sub-010/func/sub-010_task-rest_run-2_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: cd63bc3de6119017f97434fcefd06cd6
+      - creator: spdx:checksumAlgorithm_md5
+        notation: cd63bc3de6119017f97434fcefd06cd6
     download_url:
       - https://dataverse.nl/api/access/datafile/45527
     media_type: application/json
   - id: exthisdsver:./sub-010/func/sub-010_task-rest_run-2_physio.tsv.gz
     byte_size: 469789
     checksum:
-      - algorithm: md5
-        digest: 1763774e3b11a68c20653f60dbbfc9ea
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1763774e3b11a68c20653f60dbbfc9ea
     download_url:
       - https://dataverse.nl/api/access/datafile/45509
     media_type: application/gzip
   - id: exthisdsver:./sub-011/anat/sub-011_T1w.nii
     byte_size: 20736352
     checksum:
-      - algorithm: md5
-        digest: d79a9ccb0fb162198b466b5fdd3eb48a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d79a9ccb0fb162198b466b5fdd3eb48a
     download_url:
       - https://dataverse.nl/api/access/datafile/45153
     media_type: image/nii
@@ -4716,8 +4716,8 @@ has_part:
   - id: exthisdsver:./sub-011/func/sub-011_task-emotionProcessing_echo-1_bold.json
     byte_size: 1039
     checksum:
-      - algorithm: md5
-        digest: b1ee64a3d382b49939d138dd4f44449a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b1ee64a3d382b49939d138dd4f44449a
     download_url:
       - https://dataverse.nl/api/access/datafile/46084
     media_type: application/json
@@ -4836,48 +4836,48 @@ has_part:
   - id: exthisdsver:./sub-011/func/sub-011_task-emotionProcessing_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 9721f67b8fef76ba6a0330c0556cf4d7
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 9721f67b8fef76ba6a0330c0556cf4d7
     download_url:
       - https://dataverse.nl/api/access/datafile/46043
     media_type: image/nii
   - id: exthisdsver:./sub-011/func/sub-011_task-emotionProcessing_echo-2_bold.json
     byte_size: 1039
     checksum:
-      - algorithm: md5
-        digest: 92ae7f4d53aaa1dfcb6b1aa4831e2b01
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 92ae7f4d53aaa1dfcb6b1aa4831e2b01
     download_url:
       - https://dataverse.nl/api/access/datafile/45758
     media_type: application/json
   - id: exthisdsver:./sub-011/func/sub-011_task-emotionProcessing_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: cd28ad527b17d01fdb165a8187f9edd0
+      - creator: spdx:checksumAlgorithm_md5
+        notation: cd28ad527b17d01fdb165a8187f9edd0
     download_url:
       - https://dataverse.nl/api/access/datafile/45818
     media_type: image/nii
   - id: exthisdsver:./sub-011/func/sub-011_task-emotionProcessing_echo-3_bold.json
     byte_size: 1039
     checksum:
-      - algorithm: md5
-        digest: 1a6854b2757b610ba1cd38e38052807a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1a6854b2757b610ba1cd38e38052807a
     download_url:
       - https://dataverse.nl/api/access/datafile/46455
     media_type: application/json
   - id: exthisdsver:./sub-011/func/sub-011_task-emotionProcessing_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 6b54bde4edbc9783b4fec3f4ff5dbf99
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6b54bde4edbc9783b4fec3f4ff5dbf99
     download_url:
       - https://dataverse.nl/api/access/datafile/45816
     media_type: image/nii
   - id: exthisdsver:./sub-011/func/sub-011_task-emotionProcessing_events.tsv.gz
     byte_size: 1915
     checksum:
-      - algorithm: md5
-        digest: 44a21e171d72d65a62e26533d1c13c35
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 44a21e171d72d65a62e26533d1c13c35
     download_url:
       - https://dataverse.nl/api/access/datafile/46644
     media_type: application/gzip
@@ -4885,8 +4885,8 @@ has_part:
       exthisdsver:./sub-011/func/sub-011_task-emotionProcessingImagined_echo-1_bold.json
     byte_size: 1047
     checksum:
-      - algorithm: md5
-        digest: d5c1c4ed0bcb9763c953698de001df64
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d5c1c4ed0bcb9763c953698de001df64
     download_url:
       - https://dataverse.nl/api/access/datafile/45837
     media_type: application/json
@@ -4894,8 +4894,8 @@ has_part:
       exthisdsver:./sub-011/func/sub-011_task-emotionProcessingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 251cda48fe3fc0ff19a7bb7aaf832a27
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 251cda48fe3fc0ff19a7bb7aaf832a27
     download_url:
       - https://dataverse.nl/api/access/datafile/45433
     media_type: image/nii
@@ -4903,8 +4903,8 @@ has_part:
       exthisdsver:./sub-011/func/sub-011_task-emotionProcessingImagined_echo-2_bold.json
     byte_size: 1047
     checksum:
-      - algorithm: md5
-        digest: bfe715ec7a82f1ee4af69387207bed99
+      - creator: spdx:checksumAlgorithm_md5
+        notation: bfe715ec7a82f1ee4af69387207bed99
     download_url:
       - https://dataverse.nl/api/access/datafile/46409
     media_type: application/json
@@ -4912,8 +4912,8 @@ has_part:
       exthisdsver:./sub-011/func/sub-011_task-emotionProcessingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 75fe1c10b3ea1ff1215e64d3e08b441e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 75fe1c10b3ea1ff1215e64d3e08b441e
     download_url:
       - https://dataverse.nl/api/access/datafile/46425
     media_type: image/nii
@@ -4921,8 +4921,8 @@ has_part:
       exthisdsver:./sub-011/func/sub-011_task-emotionProcessingImagined_echo-3_bold.json
     byte_size: 1047
     checksum:
-      - algorithm: md5
-        digest: da20dd65ebd552dff0227a15340490db
+      - creator: spdx:checksumAlgorithm_md5
+        notation: da20dd65ebd552dff0227a15340490db
     download_url:
       - https://dataverse.nl/api/access/datafile/45713
     media_type: application/json
@@ -4930,328 +4930,328 @@ has_part:
       exthisdsver:./sub-011/func/sub-011_task-emotionProcessingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 41ce6c032b35b7ad8416302af406668f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 41ce6c032b35b7ad8416302af406668f
     download_url:
       - https://dataverse.nl/api/access/datafile/45969
     media_type: image/nii
   - id: exthisdsver:./sub-011/func/sub-011_task-emotionProcessingImagined_events.tsv.gz
     byte_size: 178
     checksum:
-      - algorithm: md5
-        digest: bcb0401f7c891a209243d32ef16f439a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: bcb0401f7c891a209243d32ef16f439a
     download_url:
       - https://dataverse.nl/api/access/datafile/46608
     media_type: application/gzip
   - id: exthisdsver:./sub-011/func/sub-011_task-emotionProcessingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 4dc4089ecb97f39170ea2d120a5c93e5
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4dc4089ecb97f39170ea2d120a5c93e5
     download_url:
       - https://dataverse.nl/api/access/datafile/46432
     media_type: application/json
   - id: exthisdsver:./sub-011/func/sub-011_task-emotionProcessingImagined_physio.tsv.gz
     byte_size: 598103
     checksum:
-      - algorithm: md5
-        digest: 46b5fb70b031ce15fb5e7b60188cece3
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 46b5fb70b031ce15fb5e7b60188cece3
     download_url:
       - https://dataverse.nl/api/access/datafile/45231
     media_type: application/gzip
   - id: exthisdsver:./sub-011/func/sub-011_task-emotionProcessing_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 67f253b34a9bae8537f3bcdbafe722de
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 67f253b34a9bae8537f3bcdbafe722de
     download_url:
       - https://dataverse.nl/api/access/datafile/46372
     media_type: application/json
   - id: exthisdsver:./sub-011/func/sub-011_task-emotionProcessing_physio.tsv.gz
     byte_size: 512048
     checksum:
-      - algorithm: md5
-        digest: f78c15f33b5a48a9dd7dc7646ce379f6
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f78c15f33b5a48a9dd7dc7646ce379f6
     download_url:
       - https://dataverse.nl/api/access/datafile/45297
     media_type: application/gzip
   - id: exthisdsver:./sub-011/func/sub-011_task-fingerTapping_echo-1_bold.json
     byte_size: 1035
     checksum:
-      - algorithm: md5
-        digest: f68613335edd1800b81176499103cf90
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f68613335edd1800b81176499103cf90
     download_url:
       - https://dataverse.nl/api/access/datafile/45241
     media_type: application/json
   - id: exthisdsver:./sub-011/func/sub-011_task-fingerTapping_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 5a16b498dcaccd3dcc624918af24a44c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5a16b498dcaccd3dcc624918af24a44c
     download_url:
       - https://dataverse.nl/api/access/datafile/46011
     media_type: image/nii
   - id: exthisdsver:./sub-011/func/sub-011_task-fingerTapping_echo-2_bold.json
     byte_size: 1035
     checksum:
-      - algorithm: md5
-        digest: 67493d53087a90ed9a788b156c7156f7
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 67493d53087a90ed9a788b156c7156f7
     download_url:
       - https://dataverse.nl/api/access/datafile/46464
     media_type: application/json
   - id: exthisdsver:./sub-011/func/sub-011_task-fingerTapping_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 2c2acd45644590194b1cf8e73ad92783
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2c2acd45644590194b1cf8e73ad92783
     download_url:
       - https://dataverse.nl/api/access/datafile/45235
     media_type: image/nii
   - id: exthisdsver:./sub-011/func/sub-011_task-fingerTapping_echo-3_bold.json
     byte_size: 1035
     checksum:
-      - algorithm: md5
-        digest: 55555dc1b04e4999a286e7533504c00c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 55555dc1b04e4999a286e7533504c00c
     download_url:
       - https://dataverse.nl/api/access/datafile/45578
     media_type: application/json
   - id: exthisdsver:./sub-011/func/sub-011_task-fingerTapping_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 879269a51ef784261e097fca08e77c91
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 879269a51ef784261e097fca08e77c91
     download_url:
       - https://dataverse.nl/api/access/datafile/45698
     media_type: image/nii
   - id: exthisdsver:./sub-011/func/sub-011_task-fingerTapping_events.tsv.gz
     byte_size: 164
     checksum:
-      - algorithm: md5
-        digest: 67e6b607675a3b5675a20c0593b0ba2e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 67e6b607675a3b5675a20c0593b0ba2e
     download_url:
       - https://dataverse.nl/api/access/datafile/46596
     media_type: application/gzip
   - id: exthisdsver:./sub-011/func/sub-011_task-fingerTappingImagined_echo-1_bold.json
     byte_size: 1043
     checksum:
-      - algorithm: md5
-        digest: 62152681cf9c628c2e244f6a4c54806a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 62152681cf9c628c2e244f6a4c54806a
     download_url:
       - https://dataverse.nl/api/access/datafile/46155
     media_type: application/json
   - id: exthisdsver:./sub-011/func/sub-011_task-fingerTappingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 7df91aa22b60c6e5fd5db9f55108b860
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 7df91aa22b60c6e5fd5db9f55108b860
     download_url:
       - https://dataverse.nl/api/access/datafile/46139
     media_type: image/nii
   - id: exthisdsver:./sub-011/func/sub-011_task-fingerTappingImagined_echo-2_bold.json
     byte_size: 1043
     checksum:
-      - algorithm: md5
-        digest: 8db4cdcd06a3a3d5414e024ab6150ea0
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8db4cdcd06a3a3d5414e024ab6150ea0
     download_url:
       - https://dataverse.nl/api/access/datafile/45811
     media_type: application/json
   - id: exthisdsver:./sub-011/func/sub-011_task-fingerTappingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: c8a4081202b2d5d174b3d294d1ba5612
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c8a4081202b2d5d174b3d294d1ba5612
     download_url:
       - https://dataverse.nl/api/access/datafile/45382
     media_type: image/nii
   - id: exthisdsver:./sub-011/func/sub-011_task-fingerTappingImagined_echo-3_bold.json
     byte_size: 1043
     checksum:
-      - algorithm: md5
-        digest: d9cf03c8282508c2bf3eec29b63bd178
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d9cf03c8282508c2bf3eec29b63bd178
     download_url:
       - https://dataverse.nl/api/access/datafile/46017
     media_type: application/json
   - id: exthisdsver:./sub-011/func/sub-011_task-fingerTappingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: c9f183132721513e629b5e1b52f348a9
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c9f183132721513e629b5e1b52f348a9
     download_url:
       - https://dataverse.nl/api/access/datafile/45914
     media_type: image/nii
   - id: exthisdsver:./sub-011/func/sub-011_task-fingerTappingImagined_events.tsv.gz
     byte_size: 179
     checksum:
-      - algorithm: md5
-        digest: b99b1551578390d5d9370833fe4dfd57
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b99b1551578390d5d9370833fe4dfd57
     download_url:
       - https://dataverse.nl/api/access/datafile/46570
     media_type: application/gzip
   - id: exthisdsver:./sub-011/func/sub-011_task-fingerTappingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 3869cd5c408fe7d4931ddef3af2c9034
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 3869cd5c408fe7d4931ddef3af2c9034
     download_url:
       - https://dataverse.nl/api/access/datafile/46331
     media_type: application/json
   - id: exthisdsver:./sub-011/func/sub-011_task-fingerTappingImagined_physio.tsv.gz
     byte_size: 582479
     checksum:
-      - algorithm: md5
-        digest: 6b89f5151428bdcebabdf1213eaf0d0a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6b89f5151428bdcebabdf1213eaf0d0a
     download_url:
       - https://dataverse.nl/api/access/datafile/45574
     media_type: application/gzip
   - id: exthisdsver:./sub-011/func/sub-011_task-fingerTapping_physio.json
     byte_size: 142
     checksum:
-      - algorithm: md5
-        digest: 345716ebcc9747689b51775cba0a324f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 345716ebcc9747689b51775cba0a324f
     download_url:
       - https://dataverse.nl/api/access/datafile/45920
     media_type: application/json
   - id: exthisdsver:./sub-011/func/sub-011_task-fingerTapping_physio.tsv.gz
     byte_size: 525437
     checksum:
-      - algorithm: md5
-        digest: 01c001d27101079d5192a3cd9a73030f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 01c001d27101079d5192a3cd9a73030f
     download_url:
       - https://dataverse.nl/api/access/datafile/45628
     media_type: application/gzip
   - id: exthisdsver:./sub-011/func/sub-011_task-rest_run-1_echo-1_bold.json
     byte_size: 1026
     checksum:
-      - algorithm: md5
-        digest: b10520e2662633d333bd9241847ef6cc
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b10520e2662633d333bd9241847ef6cc
     download_url:
       - https://dataverse.nl/api/access/datafile/45561
     media_type: application/json
   - id: exthisdsver:./sub-011/func/sub-011_task-rest_run-1_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: ce39533f0e6735ce343fcc97213b078e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ce39533f0e6735ce343fcc97213b078e
     download_url:
       - https://dataverse.nl/api/access/datafile/45890
     media_type: image/nii
   - id: exthisdsver:./sub-011/func/sub-011_task-rest_run-1_echo-2_bold.json
     byte_size: 1026
     checksum:
-      - algorithm: md5
-        digest: 9d15b7e87a5b0b54898f81593d98bc56
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 9d15b7e87a5b0b54898f81593d98bc56
     download_url:
       - https://dataverse.nl/api/access/datafile/45714
     media_type: application/json
   - id: exthisdsver:./sub-011/func/sub-011_task-rest_run-1_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 9853e26d852f88d0fb0671632098ebc5
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 9853e26d852f88d0fb0671632098ebc5
     download_url:
       - https://dataverse.nl/api/access/datafile/45392
     media_type: image/nii
   - id: exthisdsver:./sub-011/func/sub-011_task-rest_run-1_echo-3_bold.json
     byte_size: 1026
     checksum:
-      - algorithm: md5
-        digest: 87f69b8909f5f31e28a899052c77c232
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 87f69b8909f5f31e28a899052c77c232
     download_url:
       - https://dataverse.nl/api/access/datafile/45287
     media_type: application/json
   - id: exthisdsver:./sub-011/func/sub-011_task-rest_run-1_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: cf5370cc14cbeb0e6eeb053c2f2be559
+      - creator: spdx:checksumAlgorithm_md5
+        notation: cf5370cc14cbeb0e6eeb053c2f2be559
     download_url:
       - https://dataverse.nl/api/access/datafile/46150
     media_type: image/nii
   - id: exthisdsver:./sub-011/func/sub-011_task-rest_run-1_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 06ccf364a78119afd801ef5870a3b5ce
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 06ccf364a78119afd801ef5870a3b5ce
     download_url:
       - https://dataverse.nl/api/access/datafile/45365
     media_type: application/json
   - id: exthisdsver:./sub-011/func/sub-011_task-rest_run-1_physio.tsv.gz
     byte_size: 469520
     checksum:
-      - algorithm: md5
-        digest: 9036b3c81432071b57427b4731cbe612
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 9036b3c81432071b57427b4731cbe612
     download_url:
       - https://dataverse.nl/api/access/datafile/46032
     media_type: application/gzip
   - id: exthisdsver:./sub-011/func/sub-011_task-rest_run-2_echo-1_bold.json
     byte_size: 1026
     checksum:
-      - algorithm: md5
-        digest: 734ec463c1346a0649d5aabbd3e66492
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 734ec463c1346a0649d5aabbd3e66492
     download_url:
       - https://dataverse.nl/api/access/datafile/46384
     media_type: application/json
   - id: exthisdsver:./sub-011/func/sub-011_task-rest_run-2_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 8a2a4ccec405b9f83b593449a467b6b0
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8a2a4ccec405b9f83b593449a467b6b0
     download_url:
       - https://dataverse.nl/api/access/datafile/45608
     media_type: image/nii
   - id: exthisdsver:./sub-011/func/sub-011_task-rest_run-2_echo-2_bold.json
     byte_size: 1026
     checksum:
-      - algorithm: md5
-        digest: 8856f20a4bb61095e41153ebfb24856a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8856f20a4bb61095e41153ebfb24856a
     download_url:
       - https://dataverse.nl/api/access/datafile/46229
     media_type: application/json
   - id: exthisdsver:./sub-011/func/sub-011_task-rest_run-2_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 36bae91c122a3ce04df9bcee2a583d15
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 36bae91c122a3ce04df9bcee2a583d15
     download_url:
       - https://dataverse.nl/api/access/datafile/46359
     media_type: image/nii
   - id: exthisdsver:./sub-011/func/sub-011_task-rest_run-2_echo-3_bold.json
     byte_size: 1026
     checksum:
-      - algorithm: md5
-        digest: cb9cf3f1a210b9e2a3ba359fea0c2779
+      - creator: spdx:checksumAlgorithm_md5
+        notation: cb9cf3f1a210b9e2a3ba359fea0c2779
     download_url:
       - https://dataverse.nl/api/access/datafile/46066
     media_type: application/json
   - id: exthisdsver:./sub-011/func/sub-011_task-rest_run-2_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 577b270c64d285540992f988d5aa4e8d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 577b270c64d285540992f988d5aa4e8d
     download_url:
       - https://dataverse.nl/api/access/datafile/46543
     media_type: image/nii
   - id: exthisdsver:./sub-011/func/sub-011_task-rest_run-2_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: ec4eedadf6dcf0c1941077b992168140
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ec4eedadf6dcf0c1941077b992168140
     download_url:
       - https://dataverse.nl/api/access/datafile/46329
     media_type: application/json
   - id: exthisdsver:./sub-011/func/sub-011_task-rest_run-2_physio.tsv.gz
     byte_size: 487630
     checksum:
-      - algorithm: md5
-        digest: 31c1315cca51318e840f45596998a980
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 31c1315cca51318e840f45596998a980
     download_url:
       - https://dataverse.nl/api/access/datafile/45977
     media_type: application/gzip
   - id: exthisdsver:./sub-012/anat/sub-012_T1w.nii
     byte_size: 20736352
     checksum:
-      - algorithm: md5
-        digest: 795af637ef08412092a8026dc0ee140d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 795af637ef08412092a8026dc0ee140d
     download_url:
       - https://dataverse.nl/api/access/datafile/46047
     media_type: image/nii
@@ -5268,8 +5268,8 @@ has_part:
   - id: exthisdsver:./sub-012/func/sub-012_task-emotionProcessing_echo-1_bold.json
     byte_size: 1041
     checksum:
-      - algorithm: md5
-        digest: 382a4823b9b110d0c58322e9c40570e1
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 382a4823b9b110d0c58322e9c40570e1
     download_url:
       - https://dataverse.nl/api/access/datafile/46354
     media_type: application/json
@@ -5388,48 +5388,48 @@ has_part:
   - id: exthisdsver:./sub-012/func/sub-012_task-emotionProcessing_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: b6a195317631932eab859ad0c3d6ea33
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b6a195317631932eab859ad0c3d6ea33
     download_url:
       - https://dataverse.nl/api/access/datafile/46535
     media_type: image/nii
   - id: exthisdsver:./sub-012/func/sub-012_task-emotionProcessing_echo-2_bold.json
     byte_size: 1041
     checksum:
-      - algorithm: md5
-        digest: 799090ea10892c2dd15b914a46564194
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 799090ea10892c2dd15b914a46564194
     download_url:
       - https://dataverse.nl/api/access/datafile/45343
     media_type: application/json
   - id: exthisdsver:./sub-012/func/sub-012_task-emotionProcessing_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: ece612ba0853e7be290ec84604dfbd93
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ece612ba0853e7be290ec84604dfbd93
     download_url:
       - https://dataverse.nl/api/access/datafile/45658
     media_type: image/nii
   - id: exthisdsver:./sub-012/func/sub-012_task-emotionProcessing_echo-3_bold.json
     byte_size: 1041
     checksum:
-      - algorithm: md5
-        digest: 7ef80e89f474467f5b3e969293f3467f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 7ef80e89f474467f5b3e969293f3467f
     download_url:
       - https://dataverse.nl/api/access/datafile/46061
     media_type: application/json
   - id: exthisdsver:./sub-012/func/sub-012_task-emotionProcessing_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 9ee8fff9e7c3ec8e70644854c7495c4c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 9ee8fff9e7c3ec8e70644854c7495c4c
     download_url:
       - https://dataverse.nl/api/access/datafile/45109
     media_type: image/nii
   - id: exthisdsver:./sub-012/func/sub-012_task-emotionProcessing_events.tsv.gz
     byte_size: 1895
     checksum:
-      - algorithm: md5
-        digest: 097058ecbe042066f14ed6220b0dfbd9
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 097058ecbe042066f14ed6220b0dfbd9
     download_url:
       - https://dataverse.nl/api/access/datafile/46562
     media_type: application/gzip
@@ -5437,8 +5437,8 @@ has_part:
       exthisdsver:./sub-012/func/sub-012_task-emotionProcessingImagined_echo-1_bold.json
     byte_size: 1048
     checksum:
-      - algorithm: md5
-        digest: 050fb9dbf93e7c09df79e9efbb02fcb9
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 050fb9dbf93e7c09df79e9efbb02fcb9
     download_url:
       - https://dataverse.nl/api/access/datafile/46483
     media_type: application/json
@@ -5446,8 +5446,8 @@ has_part:
       exthisdsver:./sub-012/func/sub-012_task-emotionProcessingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 8ae116e6ecd732f7600e04763fa2a705
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8ae116e6ecd732f7600e04763fa2a705
     download_url:
       - https://dataverse.nl/api/access/datafile/46296
     media_type: image/nii
@@ -5455,8 +5455,8 @@ has_part:
       exthisdsver:./sub-012/func/sub-012_task-emotionProcessingImagined_echo-2_bold.json
     byte_size: 1048
     checksum:
-      - algorithm: md5
-        digest: 196a26faa275c16e97365e3a8d92ff7d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 196a26faa275c16e97365e3a8d92ff7d
     download_url:
       - https://dataverse.nl/api/access/datafile/46294
     media_type: application/json
@@ -5464,8 +5464,8 @@ has_part:
       exthisdsver:./sub-012/func/sub-012_task-emotionProcessingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: c7bb51c9716c1e122ec8c2c4ae213c35
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c7bb51c9716c1e122ec8c2c4ae213c35
     download_url:
       - https://dataverse.nl/api/access/datafile/45192
     media_type: image/nii
@@ -5473,8 +5473,8 @@ has_part:
       exthisdsver:./sub-012/func/sub-012_task-emotionProcessingImagined_echo-3_bold.json
     byte_size: 1048
     checksum:
-      - algorithm: md5
-        digest: b4442c318da703f7f578646358ad1d81
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b4442c318da703f7f578646358ad1d81
     download_url:
       - https://dataverse.nl/api/access/datafile/46325
     media_type: application/json
@@ -5482,328 +5482,328 @@ has_part:
       exthisdsver:./sub-012/func/sub-012_task-emotionProcessingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 7916e42076207b5848d0e1966997d8c2
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 7916e42076207b5848d0e1966997d8c2
     download_url:
       - https://dataverse.nl/api/access/datafile/46120
     media_type: image/nii
   - id: exthisdsver:./sub-012/func/sub-012_task-emotionProcessingImagined_events.tsv.gz
     byte_size: 174
     checksum:
-      - algorithm: md5
-        digest: 3f246551ab4cffc672ab28c6c00df119
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 3f246551ab4cffc672ab28c6c00df119
     download_url:
       - https://dataverse.nl/api/access/datafile/46599
     media_type: application/gzip
   - id: exthisdsver:./sub-012/func/sub-012_task-emotionProcessingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: f0530603563aa5bff37d429077bf63b1
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f0530603563aa5bff37d429077bf63b1
     download_url:
       - https://dataverse.nl/api/access/datafile/45190
     media_type: application/json
   - id: exthisdsver:./sub-012/func/sub-012_task-emotionProcessingImagined_physio.tsv.gz
     byte_size: 463512
     checksum:
-      - algorithm: md5
-        digest: d3163cee8283f7d3a4e3eea656126800
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d3163cee8283f7d3a4e3eea656126800
     download_url:
       - https://dataverse.nl/api/access/datafile/45255
     media_type: application/gzip
   - id: exthisdsver:./sub-012/func/sub-012_task-emotionProcessing_physio.json
     byte_size: 141
     checksum:
-      - algorithm: md5
-        digest: dd61d969dba5f822d1341db9b2ea4131
+      - creator: spdx:checksumAlgorithm_md5
+        notation: dd61d969dba5f822d1341db9b2ea4131
     download_url:
       - https://dataverse.nl/api/access/datafile/46530
     media_type: application/json
   - id: exthisdsver:./sub-012/func/sub-012_task-emotionProcessing_physio.tsv.gz
     byte_size: 525307
     checksum:
-      - algorithm: md5
-        digest: 51bf4260d4068cd629c8fb1700b22fec
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 51bf4260d4068cd629c8fb1700b22fec
     download_url:
       - https://dataverse.nl/api/access/datafile/45278
     media_type: application/gzip
   - id: exthisdsver:./sub-012/func/sub-012_task-fingerTapping_echo-1_bold.json
     byte_size: 1037
     checksum:
-      - algorithm: md5
-        digest: de294fa441235170f805902ad31457e1
+      - creator: spdx:checksumAlgorithm_md5
+        notation: de294fa441235170f805902ad31457e1
     download_url:
       - https://dataverse.nl/api/access/datafile/45808
     media_type: application/json
   - id: exthisdsver:./sub-012/func/sub-012_task-fingerTapping_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: cd2c4d3cf939bf00b695ee6ecff33064
+      - creator: spdx:checksumAlgorithm_md5
+        notation: cd2c4d3cf939bf00b695ee6ecff33064
     download_url:
       - https://dataverse.nl/api/access/datafile/45618
     media_type: image/nii
   - id: exthisdsver:./sub-012/func/sub-012_task-fingerTapping_echo-2_bold.json
     byte_size: 1037
     checksum:
-      - algorithm: md5
-        digest: ea835407d646a4bc33685ebc5c5b027d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ea835407d646a4bc33685ebc5c5b027d
     download_url:
       - https://dataverse.nl/api/access/datafile/46127
     media_type: application/json
   - id: exthisdsver:./sub-012/func/sub-012_task-fingerTapping_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 3c8f0fae13660639d328ecd1ec29c0a2
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 3c8f0fae13660639d328ecd1ec29c0a2
     download_url:
       - https://dataverse.nl/api/access/datafile/45517
     media_type: image/nii
   - id: exthisdsver:./sub-012/func/sub-012_task-fingerTapping_echo-3_bold.json
     byte_size: 1037
     checksum:
-      - algorithm: md5
-        digest: 9a6686d65339d9d41577a6cdd9ffe09a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 9a6686d65339d9d41577a6cdd9ffe09a
     download_url:
       - https://dataverse.nl/api/access/datafile/45607
     media_type: application/json
   - id: exthisdsver:./sub-012/func/sub-012_task-fingerTapping_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 8ed55bd04f00b343fbaa411c09f1cdea
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8ed55bd04f00b343fbaa411c09f1cdea
     download_url:
       - https://dataverse.nl/api/access/datafile/45575
     media_type: image/nii
   - id: exthisdsver:./sub-012/func/sub-012_task-fingerTapping_events.tsv.gz
     byte_size: 164
     checksum:
-      - algorithm: md5
-        digest: d1d06fd9f3ec1c7df5d2838923cb98bd
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d1d06fd9f3ec1c7df5d2838923cb98bd
     download_url:
       - https://dataverse.nl/api/access/datafile/46601
     media_type: application/gzip
   - id: exthisdsver:./sub-012/func/sub-012_task-fingerTappingImagined_echo-1_bold.json
     byte_size: 1045
     checksum:
-      - algorithm: md5
-        digest: 10a34c63d3a97b2adc98d1386df793d8
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 10a34c63d3a97b2adc98d1386df793d8
     download_url:
       - https://dataverse.nl/api/access/datafile/46524
     media_type: application/json
   - id: exthisdsver:./sub-012/func/sub-012_task-fingerTappingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 6f95650a96ab74622d4fa8f16d0c820f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6f95650a96ab74622d4fa8f16d0c820f
     download_url:
       - https://dataverse.nl/api/access/datafile/45099
     media_type: image/nii
   - id: exthisdsver:./sub-012/func/sub-012_task-fingerTappingImagined_echo-2_bold.json
     byte_size: 1045
     checksum:
-      - algorithm: md5
-        digest: 8ac3c9410fa371e8d49a02d68bb704ff
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8ac3c9410fa371e8d49a02d68bb704ff
     download_url:
       - https://dataverse.nl/api/access/datafile/46225
     media_type: application/json
   - id: exthisdsver:./sub-012/func/sub-012_task-fingerTappingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: d10693fd693c1db4f1ebaca74e52cbbd
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d10693fd693c1db4f1ebaca74e52cbbd
     download_url:
       - https://dataverse.nl/api/access/datafile/46151
     media_type: image/nii
   - id: exthisdsver:./sub-012/func/sub-012_task-fingerTappingImagined_echo-3_bold.json
     byte_size: 1045
     checksum:
-      - algorithm: md5
-        digest: 7a03104a2d2b3e4ccde0d1236fc995dc
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 7a03104a2d2b3e4ccde0d1236fc995dc
     download_url:
       - https://dataverse.nl/api/access/datafile/46517
     media_type: application/json
   - id: exthisdsver:./sub-012/func/sub-012_task-fingerTappingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 0e1a64cd98ff26b34c4d14d0487e0636
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 0e1a64cd98ff26b34c4d14d0487e0636
     download_url:
       - https://dataverse.nl/api/access/datafile/45763
     media_type: image/nii
   - id: exthisdsver:./sub-012/func/sub-012_task-fingerTappingImagined_events.tsv.gz
     byte_size: 177
     checksum:
-      - algorithm: md5
-        digest: 0ff7dc89c68f67fbc39672b7d3cc7023
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 0ff7dc89c68f67fbc39672b7d3cc7023
     download_url:
       - https://dataverse.nl/api/access/datafile/46569
     media_type: application/gzip
   - id: exthisdsver:./sub-012/func/sub-012_task-fingerTappingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: c57f34d5f230fe2c01f06b4865f0325f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c57f34d5f230fe2c01f06b4865f0325f
     download_url:
       - https://dataverse.nl/api/access/datafile/45374
     media_type: application/json
   - id: exthisdsver:./sub-012/func/sub-012_task-fingerTappingImagined_physio.tsv.gz
     byte_size: 490085
     checksum:
-      - algorithm: md5
-        digest: b26fc2f54c1b240cd8981fcb0224b4b1
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b26fc2f54c1b240cd8981fcb0224b4b1
     download_url:
       - https://dataverse.nl/api/access/datafile/46532
     media_type: application/gzip
   - id: exthisdsver:./sub-012/func/sub-012_task-fingerTapping_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 1e300396dc5b59771f40ca8bc8b57e19
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1e300396dc5b59771f40ca8bc8b57e19
     download_url:
       - https://dataverse.nl/api/access/datafile/45142
     media_type: application/json
   - id: exthisdsver:./sub-012/func/sub-012_task-fingerTapping_physio.tsv.gz
     byte_size: 515014
     checksum:
-      - algorithm: md5
-        digest: 45f2c03f0fe510b4a3185ae6cbf496d8
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 45f2c03f0fe510b4a3185ae6cbf496d8
     download_url:
       - https://dataverse.nl/api/access/datafile/45111
     media_type: application/gzip
   - id: exthisdsver:./sub-012/func/sub-012_task-rest_run-1_echo-1_bold.json
     byte_size: 1028
     checksum:
-      - algorithm: md5
-        digest: e3a883756d27e5b8e09e93412825c7fe
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e3a883756d27e5b8e09e93412825c7fe
     download_url:
       - https://dataverse.nl/api/access/datafile/46540
     media_type: application/json
   - id: exthisdsver:./sub-012/func/sub-012_task-rest_run-1_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 7b0ef606ddc57bac0c4a06c60f51a8f3
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 7b0ef606ddc57bac0c4a06c60f51a8f3
     download_url:
       - https://dataverse.nl/api/access/datafile/45501
     media_type: image/nii
   - id: exthisdsver:./sub-012/func/sub-012_task-rest_run-1_echo-2_bold.json
     byte_size: 1028
     checksum:
-      - algorithm: md5
-        digest: f4ada1d0e02800ceb65f083847f950ba
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f4ada1d0e02800ceb65f083847f950ba
     download_url:
       - https://dataverse.nl/api/access/datafile/46034
     media_type: application/json
   - id: exthisdsver:./sub-012/func/sub-012_task-rest_run-1_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: c2ae5a5e4ea51ac54ae4d2cc4ef30f11
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c2ae5a5e4ea51ac54ae4d2cc4ef30f11
     download_url:
       - https://dataverse.nl/api/access/datafile/45636
     media_type: image/nii
   - id: exthisdsver:./sub-012/func/sub-012_task-rest_run-1_echo-3_bold.json
     byte_size: 1028
     checksum:
-      - algorithm: md5
-        digest: dda69229fb84f9b9623f8f35de79b5e2
+      - creator: spdx:checksumAlgorithm_md5
+        notation: dda69229fb84f9b9623f8f35de79b5e2
     download_url:
       - https://dataverse.nl/api/access/datafile/46443
     media_type: application/json
   - id: exthisdsver:./sub-012/func/sub-012_task-rest_run-1_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: d12af16342d85ce006b676b14a8a79e2
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d12af16342d85ce006b676b14a8a79e2
     download_url:
       - https://dataverse.nl/api/access/datafile/45709
     media_type: image/nii
   - id: exthisdsver:./sub-012/func/sub-012_task-rest_run-1_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: fadc5fbec6ea5f8adb2f31c8a837379f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: fadc5fbec6ea5f8adb2f31c8a837379f
     download_url:
       - https://dataverse.nl/api/access/datafile/45940
     media_type: application/json
   - id: exthisdsver:./sub-012/func/sub-012_task-rest_run-1_physio.tsv.gz
     byte_size: 463276
     checksum:
-      - algorithm: md5
-        digest: 4892d49ae507ce3fe61976ebb021cfec
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4892d49ae507ce3fe61976ebb021cfec
     download_url:
       - https://dataverse.nl/api/access/datafile/46402
     media_type: application/gzip
   - id: exthisdsver:./sub-012/func/sub-012_task-rest_run-2_echo-1_bold.json
     byte_size: 1028
     checksum:
-      - algorithm: md5
-        digest: 2c1dc9ae410b111eee9fcbd67674dd41
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2c1dc9ae410b111eee9fcbd67674dd41
     download_url:
       - https://dataverse.nl/api/access/datafile/46351
     media_type: application/json
   - id: exthisdsver:./sub-012/func/sub-012_task-rest_run-2_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: d2404c5a5d23dbf81d32995d653125ec
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d2404c5a5d23dbf81d32995d653125ec
     download_url:
       - https://dataverse.nl/api/access/datafile/46036
     media_type: image/nii
   - id: exthisdsver:./sub-012/func/sub-012_task-rest_run-2_echo-2_bold.json
     byte_size: 1028
     checksum:
-      - algorithm: md5
-        digest: 6dacd51f3fdb60a29f137fb5dcadc8d9
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6dacd51f3fdb60a29f137fb5dcadc8d9
     download_url:
       - https://dataverse.nl/api/access/datafile/45492
     media_type: application/json
   - id: exthisdsver:./sub-012/func/sub-012_task-rest_run-2_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: a4072099ef5cf2ec54ada3e56e44fe6d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a4072099ef5cf2ec54ada3e56e44fe6d
     download_url:
       - https://dataverse.nl/api/access/datafile/46105
     media_type: image/nii
   - id: exthisdsver:./sub-012/func/sub-012_task-rest_run-2_echo-3_bold.json
     byte_size: 1028
     checksum:
-      - algorithm: md5
-        digest: 1582d2d1a3c9da3568043e61046efc03
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1582d2d1a3c9da3568043e61046efc03
     download_url:
       - https://dataverse.nl/api/access/datafile/46235
     media_type: application/json
   - id: exthisdsver:./sub-012/func/sub-012_task-rest_run-2_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 991e8938d59ff3e37a2e5b2983b0805e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 991e8938d59ff3e37a2e5b2983b0805e
     download_url:
       - https://dataverse.nl/api/access/datafile/45625
     media_type: image/nii
   - id: exthisdsver:./sub-012/func/sub-012_task-rest_run-2_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: a71c4b97ebdfa87fd1314ee245a018d6
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a71c4b97ebdfa87fd1314ee245a018d6
     download_url:
       - https://dataverse.nl/api/access/datafile/45460
     media_type: application/json
   - id: exthisdsver:./sub-012/func/sub-012_task-rest_run-2_physio.tsv.gz
     byte_size: 451048
     checksum:
-      - algorithm: md5
-        digest: 702951e89ef28eecc2fb0431a7138703
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 702951e89ef28eecc2fb0431a7138703
     download_url:
       - https://dataverse.nl/api/access/datafile/45281
     media_type: application/gzip
   - id: exthisdsver:./sub-013/anat/sub-013_T1w.nii
     byte_size: 20736352
     checksum:
-      - algorithm: md5
-        digest: 35f0db586ee930c7cca38874da209ee8
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 35f0db586ee930c7cca38874da209ee8
     download_url:
       - https://dataverse.nl/api/access/datafile/45230
     media_type: image/nii
@@ -5820,8 +5820,8 @@ has_part:
   - id: exthisdsver:./sub-013/func/sub-013_task-emotionProcessing_echo-1_bold.json
     byte_size: 1039
     checksum:
-      - algorithm: md5
-        digest: 4c3cf2184e333516449b2fd9ab99e6f8
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4c3cf2184e333516449b2fd9ab99e6f8
     download_url:
       - https://dataverse.nl/api/access/datafile/46300
     media_type: application/json
@@ -5940,48 +5940,48 @@ has_part:
   - id: exthisdsver:./sub-013/func/sub-013_task-emotionProcessing_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 42da9e5f60b8474657f709ff80423b42
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 42da9e5f60b8474657f709ff80423b42
     download_url:
       - https://dataverse.nl/api/access/datafile/46508
     media_type: image/nii
   - id: exthisdsver:./sub-013/func/sub-013_task-emotionProcessing_echo-2_bold.json
     byte_size: 1039
     checksum:
-      - algorithm: md5
-        digest: 428d8b271dfb0ae1adf5c4e550bd371d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 428d8b271dfb0ae1adf5c4e550bd371d
     download_url:
       - https://dataverse.nl/api/access/datafile/45647
     media_type: application/json
   - id: exthisdsver:./sub-013/func/sub-013_task-emotionProcessing_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: b29b1ffd8a68f4cde389e2150cb16e13
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b29b1ffd8a68f4cde389e2150cb16e13
     download_url:
       - https://dataverse.nl/api/access/datafile/45416
     media_type: image/nii
   - id: exthisdsver:./sub-013/func/sub-013_task-emotionProcessing_echo-3_bold.json
     byte_size: 1039
     checksum:
-      - algorithm: md5
-        digest: e9b416ede6a2a916a3a835654aed276c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e9b416ede6a2a916a3a835654aed276c
     download_url:
       - https://dataverse.nl/api/access/datafile/45669
     media_type: application/json
   - id: exthisdsver:./sub-013/func/sub-013_task-emotionProcessing_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 154468e9d87e1b3daba28c51528aa2eb
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 154468e9d87e1b3daba28c51528aa2eb
     download_url:
       - https://dataverse.nl/api/access/datafile/45722
     media_type: image/nii
   - id: exthisdsver:./sub-013/func/sub-013_task-emotionProcessing_events.tsv.gz
     byte_size: 1889
     checksum:
-      - algorithm: md5
-        digest: 5b6fb06c3743fae4095da2eea36a5464
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5b6fb06c3743fae4095da2eea36a5464
     download_url:
       - https://dataverse.nl/api/access/datafile/46604
     media_type: application/gzip
@@ -5989,8 +5989,8 @@ has_part:
       exthisdsver:./sub-013/func/sub-013_task-emotionProcessingImagined_echo-1_bold.json
     byte_size: 1046
     checksum:
-      - algorithm: md5
-        digest: 39a8655efa4164001f70630f578860b5
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 39a8655efa4164001f70630f578860b5
     download_url:
       - https://dataverse.nl/api/access/datafile/45673
     media_type: application/json
@@ -5998,8 +5998,8 @@ has_part:
       exthisdsver:./sub-013/func/sub-013_task-emotionProcessingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: a5eb50a3b6d8bd2d9b9afa4af09a1672
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a5eb50a3b6d8bd2d9b9afa4af09a1672
     download_url:
       - https://dataverse.nl/api/access/datafile/45132
     media_type: image/nii
@@ -6007,8 +6007,8 @@ has_part:
       exthisdsver:./sub-013/func/sub-013_task-emotionProcessingImagined_echo-2_bold.json
     byte_size: 1046
     checksum:
-      - algorithm: md5
-        digest: 2d58a070af22c624dc461557f839120a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2d58a070af22c624dc461557f839120a
     download_url:
       - https://dataverse.nl/api/access/datafile/46169
     media_type: application/json
@@ -6016,8 +6016,8 @@ has_part:
       exthisdsver:./sub-013/func/sub-013_task-emotionProcessingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: db16713e31fcb088bf8c209cf2ccadd8
+      - creator: spdx:checksumAlgorithm_md5
+        notation: db16713e31fcb088bf8c209cf2ccadd8
     download_url:
       - https://dataverse.nl/api/access/datafile/45234
     media_type: image/nii
@@ -6025,8 +6025,8 @@ has_part:
       exthisdsver:./sub-013/func/sub-013_task-emotionProcessingImagined_echo-3_bold.json
     byte_size: 1046
     checksum:
-      - algorithm: md5
-        digest: d71aa1888f2c0b09ac19b1ba85089fb3
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d71aa1888f2c0b09ac19b1ba85089fb3
     download_url:
       - https://dataverse.nl/api/access/datafile/45830
     media_type: application/json
@@ -6034,328 +6034,328 @@ has_part:
       exthisdsver:./sub-013/func/sub-013_task-emotionProcessingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 612187d0f7bc9a6ca680efe80b47802d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 612187d0f7bc9a6ca680efe80b47802d
     download_url:
       - https://dataverse.nl/api/access/datafile/45369
     media_type: image/nii
   - id: exthisdsver:./sub-013/func/sub-013_task-emotionProcessingImagined_events.tsv.gz
     byte_size: 178
     checksum:
-      - algorithm: md5
-        digest: adb70a52e07794ff600c3039e4773864
+      - creator: spdx:checksumAlgorithm_md5
+        notation: adb70a52e07794ff600c3039e4773864
     download_url:
       - https://dataverse.nl/api/access/datafile/46591
     media_type: application/gzip
   - id: exthisdsver:./sub-013/func/sub-013_task-emotionProcessingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: b0f5c8f13d597a094a1aeb3c162588dd
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b0f5c8f13d597a094a1aeb3c162588dd
     download_url:
       - https://dataverse.nl/api/access/datafile/46227
     media_type: application/json
   - id: exthisdsver:./sub-013/func/sub-013_task-emotionProcessingImagined_physio.tsv.gz
     byte_size: 453405
     checksum:
-      - algorithm: md5
-        digest: cbda14078ebecf0cb7dbce7c2f491725
+      - creator: spdx:checksumAlgorithm_md5
+        notation: cbda14078ebecf0cb7dbce7c2f491725
     download_url:
       - https://dataverse.nl/api/access/datafile/46231
     media_type: application/gzip
   - id: exthisdsver:./sub-013/func/sub-013_task-emotionProcessing_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: d0f1d46c90bc3ff7fddcfec9826bbc14
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d0f1d46c90bc3ff7fddcfec9826bbc14
     download_url:
       - https://dataverse.nl/api/access/datafile/46264
     media_type: application/json
   - id: exthisdsver:./sub-013/func/sub-013_task-emotionProcessing_physio.tsv.gz
     byte_size: 484357
     checksum:
-      - algorithm: md5
-        digest: 6035e0d678f0067761fcca4c5b7c0bea
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6035e0d678f0067761fcca4c5b7c0bea
     download_url:
       - https://dataverse.nl/api/access/datafile/46134
     media_type: application/gzip
   - id: exthisdsver:./sub-013/func/sub-013_task-fingerTapping_echo-1_bold.json
     byte_size: 1035
     checksum:
-      - algorithm: md5
-        digest: ab12231bb38f998b0c74148deecc6053
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ab12231bb38f998b0c74148deecc6053
     download_url:
       - https://dataverse.nl/api/access/datafile/45955
     media_type: application/json
   - id: exthisdsver:./sub-013/func/sub-013_task-fingerTapping_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 2c0e630b0a1184a651e7c22bb47dfdf0
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2c0e630b0a1184a651e7c22bb47dfdf0
     download_url:
       - https://dataverse.nl/api/access/datafile/45946
     media_type: image/nii
   - id: exthisdsver:./sub-013/func/sub-013_task-fingerTapping_echo-2_bold.json
     byte_size: 1035
     checksum:
-      - algorithm: md5
-        digest: 9ca509e0c01261e7c3ed94338394f0ca
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 9ca509e0c01261e7c3ed94338394f0ca
     download_url:
       - https://dataverse.nl/api/access/datafile/45535
     media_type: application/json
   - id: exthisdsver:./sub-013/func/sub-013_task-fingerTapping_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 3ad4a140f2c76f0f5617eca438b2a82e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 3ad4a140f2c76f0f5617eca438b2a82e
     download_url:
       - https://dataverse.nl/api/access/datafile/45493
     media_type: image/nii
   - id: exthisdsver:./sub-013/func/sub-013_task-fingerTapping_echo-3_bold.json
     byte_size: 1035
     checksum:
-      - algorithm: md5
-        digest: 4a16fccd84cf4de9f19e99c54e681ddd
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4a16fccd84cf4de9f19e99c54e681ddd
     download_url:
       - https://dataverse.nl/api/access/datafile/46214
     media_type: application/json
   - id: exthisdsver:./sub-013/func/sub-013_task-fingerTapping_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 8fadb476f9c9a61003e24e404e7c9237
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8fadb476f9c9a61003e24e404e7c9237
     download_url:
       - https://dataverse.nl/api/access/datafile/45521
     media_type: image/nii
   - id: exthisdsver:./sub-013/func/sub-013_task-fingerTapping_events.tsv.gz
     byte_size: 164
     checksum:
-      - algorithm: md5
-        digest: f2f1ec4918c4fed24c7cab1b3cd4a67f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f2f1ec4918c4fed24c7cab1b3cd4a67f
     download_url:
       - https://dataverse.nl/api/access/datafile/46579
     media_type: application/gzip
   - id: exthisdsver:./sub-013/func/sub-013_task-fingerTappingImagined_echo-1_bold.json
     byte_size: 1043
     checksum:
-      - algorithm: md5
-        digest: a02e3e3953d7f52cab57250d2114050e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a02e3e3953d7f52cab57250d2114050e
     download_url:
       - https://dataverse.nl/api/access/datafile/45106
     media_type: application/json
   - id: exthisdsver:./sub-013/func/sub-013_task-fingerTappingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 256e93aa12107151a7656df8208f8f82
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 256e93aa12107151a7656df8208f8f82
     download_url:
       - https://dataverse.nl/api/access/datafile/45347
     media_type: image/nii
   - id: exthisdsver:./sub-013/func/sub-013_task-fingerTappingImagined_echo-2_bold.json
     byte_size: 1043
     checksum:
-      - algorithm: md5
-        digest: 488c3478ab3a82b0040606e7792083dc
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 488c3478ab3a82b0040606e7792083dc
     download_url:
       - https://dataverse.nl/api/access/datafile/46094
     media_type: application/json
   - id: exthisdsver:./sub-013/func/sub-013_task-fingerTappingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 057370dbee8f6dd21a7b8c5a51782ec4
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 057370dbee8f6dd21a7b8c5a51782ec4
     download_url:
       - https://dataverse.nl/api/access/datafile/46292
     media_type: image/nii
   - id: exthisdsver:./sub-013/func/sub-013_task-fingerTappingImagined_echo-3_bold.json
     byte_size: 1043
     checksum:
-      - algorithm: md5
-        digest: 6b02ab76f155bb7170609f6ff2449f2e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6b02ab76f155bb7170609f6ff2449f2e
     download_url:
       - https://dataverse.nl/api/access/datafile/45731
     media_type: application/json
   - id: exthisdsver:./sub-013/func/sub-013_task-fingerTappingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 147b61f47296003c21ab27a66ef64aad
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 147b61f47296003c21ab27a66ef64aad
     download_url:
       - https://dataverse.nl/api/access/datafile/45954
     media_type: image/nii
   - id: exthisdsver:./sub-013/func/sub-013_task-fingerTappingImagined_events.tsv.gz
     byte_size: 179
     checksum:
-      - algorithm: md5
-        digest: 284434bd2be53609b41ff2d7bcaf33b2
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 284434bd2be53609b41ff2d7bcaf33b2
     download_url:
       - https://dataverse.nl/api/access/datafile/46568
     media_type: application/gzip
   - id: exthisdsver:./sub-013/func/sub-013_task-fingerTappingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 0e63bbb9fdc6ec15fb2ed4287485919b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 0e63bbb9fdc6ec15fb2ed4287485919b
     download_url:
       - https://dataverse.nl/api/access/datafile/45422
     media_type: application/json
   - id: exthisdsver:./sub-013/func/sub-013_task-fingerTappingImagined_physio.tsv.gz
     byte_size: 454645
     checksum:
-      - algorithm: md5
-        digest: 5eabf83c020779e7cf2d45e8a89cc7fa
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5eabf83c020779e7cf2d45e8a89cc7fa
     download_url:
       - https://dataverse.nl/api/access/datafile/45571
     media_type: application/gzip
   - id: exthisdsver:./sub-013/func/sub-013_task-fingerTapping_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 735f2308bddbdd5c49117730a5de9d94
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 735f2308bddbdd5c49117730a5de9d94
     download_url:
       - https://dataverse.nl/api/access/datafile/45280
     media_type: application/json
   - id: exthisdsver:./sub-013/func/sub-013_task-fingerTapping_physio.tsv.gz
     byte_size: 522038
     checksum:
-      - algorithm: md5
-        digest: 56f78b4bf78e6f5bbea9f758b867bb75
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 56f78b4bf78e6f5bbea9f758b867bb75
     download_url:
       - https://dataverse.nl/api/access/datafile/45644
     media_type: application/gzip
   - id: exthisdsver:./sub-013/func/sub-013_task-rest_run-1_echo-1_bold.json
     byte_size: 1026
     checksum:
-      - algorithm: md5
-        digest: d04baff7ec38efc1cf1c7dd5f3d88863
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d04baff7ec38efc1cf1c7dd5f3d88863
     download_url:
       - https://dataverse.nl/api/access/datafile/46374
     media_type: application/json
   - id: exthisdsver:./sub-013/func/sub-013_task-rest_run-1_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 5351444b82f30e3188c4afce97b5636a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5351444b82f30e3188c4afce97b5636a
     download_url:
       - https://dataverse.nl/api/access/datafile/46172
     media_type: image/nii
   - id: exthisdsver:./sub-013/func/sub-013_task-rest_run-1_echo-2_bold.json
     byte_size: 1026
     checksum:
-      - algorithm: md5
-        digest: c76360cc45e8f6240d909fdce03aab99
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c76360cc45e8f6240d909fdce03aab99
     download_url:
       - https://dataverse.nl/api/access/datafile/46435
     media_type: application/json
   - id: exthisdsver:./sub-013/func/sub-013_task-rest_run-1_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: dd0e2c99669e92efeecb0ef43e0f94b3
+      - creator: spdx:checksumAlgorithm_md5
+        notation: dd0e2c99669e92efeecb0ef43e0f94b3
     download_url:
       - https://dataverse.nl/api/access/datafile/46108
     media_type: image/nii
   - id: exthisdsver:./sub-013/func/sub-013_task-rest_run-1_echo-3_bold.json
     byte_size: 1026
     checksum:
-      - algorithm: md5
-        digest: 64c1f677782135ea0fa494767c387168
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 64c1f677782135ea0fa494767c387168
     download_url:
       - https://dataverse.nl/api/access/datafile/46437
     media_type: application/json
   - id: exthisdsver:./sub-013/func/sub-013_task-rest_run-1_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: afbcd0293b5deec30840611b2cc6cf31
+      - creator: spdx:checksumAlgorithm_md5
+        notation: afbcd0293b5deec30840611b2cc6cf31
     download_url:
       - https://dataverse.nl/api/access/datafile/46321
     media_type: image/nii
   - id: exthisdsver:./sub-013/func/sub-013_task-rest_run-1_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 979fda86b6c63e7652a8985cae52adf9
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 979fda86b6c63e7652a8985cae52adf9
     download_url:
       - https://dataverse.nl/api/access/datafile/45645
     media_type: application/json
   - id: exthisdsver:./sub-013/func/sub-013_task-rest_run-1_physio.tsv.gz
     byte_size: 453506
     checksum:
-      - algorithm: md5
-        digest: def5bd7e52762f2163b0d5ec6217b362
+      - creator: spdx:checksumAlgorithm_md5
+        notation: def5bd7e52762f2163b0d5ec6217b362
     download_url:
       - https://dataverse.nl/api/access/datafile/45151
     media_type: application/gzip
   - id: exthisdsver:./sub-013/func/sub-013_task-rest_run-2_echo-1_bold.json
     byte_size: 1025
     checksum:
-      - algorithm: md5
-        digest: 42c0cb9985346cd68316fcbe48a8f368
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 42c0cb9985346cd68316fcbe48a8f368
     download_url:
       - https://dataverse.nl/api/access/datafile/46023
     media_type: application/json
   - id: exthisdsver:./sub-013/func/sub-013_task-rest_run-2_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 43cfafd2ae5359fb8e447fa19f19c36c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 43cfafd2ae5359fb8e447fa19f19c36c
     download_url:
       - https://dataverse.nl/api/access/datafile/45624
     media_type: image/nii
   - id: exthisdsver:./sub-013/func/sub-013_task-rest_run-2_echo-2_bold.json
     byte_size: 1025
     checksum:
-      - algorithm: md5
-        digest: d8d7338d9fe7676ffc6afef85edb81c9
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d8d7338d9fe7676ffc6afef85edb81c9
     download_url:
       - https://dataverse.nl/api/access/datafile/45885
     media_type: application/json
   - id: exthisdsver:./sub-013/func/sub-013_task-rest_run-2_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: af2f57986f7d007905fcbe99a28f7674
+      - creator: spdx:checksumAlgorithm_md5
+        notation: af2f57986f7d007905fcbe99a28f7674
     download_url:
       - https://dataverse.nl/api/access/datafile/45262
     media_type: image/nii
   - id: exthisdsver:./sub-013/func/sub-013_task-rest_run-2_echo-3_bold.json
     byte_size: 1025
     checksum:
-      - algorithm: md5
-        digest: 43a8d6de09dbc08e15946c5a02ff7da0
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 43a8d6de09dbc08e15946c5a02ff7da0
     download_url:
       - https://dataverse.nl/api/access/datafile/45884
     media_type: application/json
   - id: exthisdsver:./sub-013/func/sub-013_task-rest_run-2_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: d10ad38ae6a94e6bd64e73aaa648a10e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d10ad38ae6a94e6bd64e73aaa648a10e
     download_url:
       - https://dataverse.nl/api/access/datafile/46048
     media_type: image/nii
   - id: exthisdsver:./sub-013/func/sub-013_task-rest_run-2_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 325a060b570ee400010c4eccbb4a1359
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 325a060b570ee400010c4eccbb4a1359
     download_url:
       - https://dataverse.nl/api/access/datafile/45948
     media_type: application/json
   - id: exthisdsver:./sub-013/func/sub-013_task-rest_run-2_physio.tsv.gz
     byte_size: 451134
     checksum:
-      - algorithm: md5
-        digest: a64f2d494aaf61668dce532ba4a248a6
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a64f2d494aaf61668dce532ba4a248a6
     download_url:
       - https://dataverse.nl/api/access/datafile/45809
     media_type: application/gzip
   - id: exthisdsver:./sub-015/anat/sub-015_T1w.nii
     byte_size: 20736352
     checksum:
-      - algorithm: md5
-        digest: 88afdfebbc04230478e37729e2b3f721
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 88afdfebbc04230478e37729e2b3f721
     download_url:
       - https://dataverse.nl/api/access/datafile/46499
     media_type: image/nii
@@ -6372,8 +6372,8 @@ has_part:
   - id: exthisdsver:./sub-015/func/sub-015_task-emotionProcessing_echo-1_bold.json
     byte_size: 1042
     checksum:
-      - algorithm: md5
-        digest: e34120816cd5c0bdbcd0ad658edbba83
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e34120816cd5c0bdbcd0ad658edbba83
     download_url:
       - https://dataverse.nl/api/access/datafile/45114
     media_type: application/json
@@ -6492,48 +6492,48 @@ has_part:
   - id: exthisdsver:./sub-015/func/sub-015_task-emotionProcessing_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: c4f4862cfe0ec835801044fdef643eb8
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c4f4862cfe0ec835801044fdef643eb8
     download_url:
       - https://dataverse.nl/api/access/datafile/46163
     media_type: image/nii
   - id: exthisdsver:./sub-015/func/sub-015_task-emotionProcessing_echo-2_bold.json
     byte_size: 1042
     checksum:
-      - algorithm: md5
-        digest: da28d9f7598921b29c7c8b1cfde51760
+      - creator: spdx:checksumAlgorithm_md5
+        notation: da28d9f7598921b29c7c8b1cfde51760
     download_url:
       - https://dataverse.nl/api/access/datafile/45686
     media_type: application/json
   - id: exthisdsver:./sub-015/func/sub-015_task-emotionProcessing_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 6350675b0a5449fc341702a1e797a496
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6350675b0a5449fc341702a1e797a496
     download_url:
       - https://dataverse.nl/api/access/datafile/46185
     media_type: image/nii
   - id: exthisdsver:./sub-015/func/sub-015_task-emotionProcessing_echo-3_bold.json
     byte_size: 1042
     checksum:
-      - algorithm: md5
-        digest: 85be727178c6906ab4191aa061d7e062
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 85be727178c6906ab4191aa061d7e062
     download_url:
       - https://dataverse.nl/api/access/datafile/46041
     media_type: application/json
   - id: exthisdsver:./sub-015/func/sub-015_task-emotionProcessing_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: ea75db2b708aa51f91cfe0385e2e40d7
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ea75db2b708aa51f91cfe0385e2e40d7
     download_url:
       - https://dataverse.nl/api/access/datafile/46251
     media_type: image/nii
   - id: exthisdsver:./sub-015/func/sub-015_task-emotionProcessing_events.tsv.gz
     byte_size: 1880
     checksum:
-      - algorithm: md5
-        digest: 326ca4adf81e609245fe034068456435
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 326ca4adf81e609245fe034068456435
     download_url:
       - https://dataverse.nl/api/access/datafile/46586
     media_type: application/gzip
@@ -6541,8 +6541,8 @@ has_part:
       exthisdsver:./sub-015/func/sub-015_task-emotionProcessingImagined_echo-1_bold.json
     byte_size: 1050
     checksum:
-      - algorithm: md5
-        digest: 872a7f47690c97733de490f79c640f98
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 872a7f47690c97733de490f79c640f98
     download_url:
       - https://dataverse.nl/api/access/datafile/46146
     media_type: application/json
@@ -6550,8 +6550,8 @@ has_part:
       exthisdsver:./sub-015/func/sub-015_task-emotionProcessingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 1955df590f59261e51b1223ac656275c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1955df590f59261e51b1223ac656275c
     download_url:
       - https://dataverse.nl/api/access/datafile/46447
     media_type: image/nii
@@ -6559,8 +6559,8 @@ has_part:
       exthisdsver:./sub-015/func/sub-015_task-emotionProcessingImagined_echo-2_bold.json
     byte_size: 1050
     checksum:
-      - algorithm: md5
-        digest: a224651fde289975bbb82313bd6c150f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a224651fde289975bbb82313bd6c150f
     download_url:
       - https://dataverse.nl/api/access/datafile/45288
     media_type: application/json
@@ -6568,8 +6568,8 @@ has_part:
       exthisdsver:./sub-015/func/sub-015_task-emotionProcessingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: ffcc052a264c93f46d1d92789ab31ae8
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ffcc052a264c93f46d1d92789ab31ae8
     download_url:
       - https://dataverse.nl/api/access/datafile/46357
     media_type: image/nii
@@ -6577,8 +6577,8 @@ has_part:
       exthisdsver:./sub-015/func/sub-015_task-emotionProcessingImagined_echo-3_bold.json
     byte_size: 1050
     checksum:
-      - algorithm: md5
-        digest: cfc596e4689c6c034a6f856db2cb5b97
+      - creator: spdx:checksumAlgorithm_md5
+        notation: cfc596e4689c6c034a6f856db2cb5b97
     download_url:
       - https://dataverse.nl/api/access/datafile/45853
     media_type: application/json
@@ -6586,328 +6586,328 @@ has_part:
       exthisdsver:./sub-015/func/sub-015_task-emotionProcessingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 96a0121b2b151d673be11a230c686734
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 96a0121b2b151d673be11a230c686734
     download_url:
       - https://dataverse.nl/api/access/datafile/45478
     media_type: image/nii
   - id: exthisdsver:./sub-015/func/sub-015_task-emotionProcessingImagined_events.tsv.gz
     byte_size: 177
     checksum:
-      - algorithm: md5
-        digest: 1c79205bc8559203086dc94a4b0bb65e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1c79205bc8559203086dc94a4b0bb65e
     download_url:
       - https://dataverse.nl/api/access/datafile/46653
     media_type: application/gzip
   - id: exthisdsver:./sub-015/func/sub-015_task-emotionProcessingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 3d4d62a9a2163fb86392bbf84b5f859d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 3d4d62a9a2163fb86392bbf84b5f859d
     download_url:
       - https://dataverse.nl/api/access/datafile/46362
     media_type: application/json
   - id: exthisdsver:./sub-015/func/sub-015_task-emotionProcessingImagined_physio.tsv.gz
     byte_size: 472958
     checksum:
-      - algorithm: md5
-        digest: 6133d70b03c4f51c70e396973ea82385
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6133d70b03c4f51c70e396973ea82385
     download_url:
       - https://dataverse.nl/api/access/datafile/46067
     media_type: application/gzip
   - id: exthisdsver:./sub-015/func/sub-015_task-emotionProcessing_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 8feb93770421265f6f1661f8c6ec04ff
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8feb93770421265f6f1661f8c6ec04ff
     download_url:
       - https://dataverse.nl/api/access/datafile/45258
     media_type: application/json
   - id: exthisdsver:./sub-015/func/sub-015_task-emotionProcessing_physio.tsv.gz
     byte_size: 539456
     checksum:
-      - algorithm: md5
-        digest: 137568dffa4ffbc20f1f6fa6f39cfe55
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 137568dffa4ffbc20f1f6fa6f39cfe55
     download_url:
       - https://dataverse.nl/api/access/datafile/45573
     media_type: application/gzip
   - id: exthisdsver:./sub-015/func/sub-015_task-fingerTapping_echo-1_bold.json
     byte_size: 1038
     checksum:
-      - algorithm: md5
-        digest: b89ec3da1b58f481388a5f3fcc8f4829
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b89ec3da1b58f481388a5f3fcc8f4829
     download_url:
       - https://dataverse.nl/api/access/datafile/45970
     media_type: application/json
   - id: exthisdsver:./sub-015/func/sub-015_task-fingerTapping_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 8762710b3a1640653f95ac0be249be19
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8762710b3a1640653f95ac0be249be19
     download_url:
       - https://dataverse.nl/api/access/datafile/45184
     media_type: image/nii
   - id: exthisdsver:./sub-015/func/sub-015_task-fingerTapping_echo-2_bold.json
     byte_size: 1038
     checksum:
-      - algorithm: md5
-        digest: 5fb29bdd93aef561498e3589cb02f3cf
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5fb29bdd93aef561498e3589cb02f3cf
     download_url:
       - https://dataverse.nl/api/access/datafile/46429
     media_type: application/json
   - id: exthisdsver:./sub-015/func/sub-015_task-fingerTapping_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 74c02f0a65f121ab49d411d45328e0b1
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 74c02f0a65f121ab49d411d45328e0b1
     download_url:
       - https://dataverse.nl/api/access/datafile/45815
     media_type: image/nii
   - id: exthisdsver:./sub-015/func/sub-015_task-fingerTapping_echo-3_bold.json
     byte_size: 1038
     checksum:
-      - algorithm: md5
-        digest: 3f4552ae365c2cb7475c6c86cbf6c38e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 3f4552ae365c2cb7475c6c86cbf6c38e
     download_url:
       - https://dataverse.nl/api/access/datafile/45580
     media_type: application/json
   - id: exthisdsver:./sub-015/func/sub-015_task-fingerTapping_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 5207fe7a02f624ba589113d071dfeca6
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5207fe7a02f624ba589113d071dfeca6
     download_url:
       - https://dataverse.nl/api/access/datafile/45582
     media_type: image/nii
   - id: exthisdsver:./sub-015/func/sub-015_task-fingerTapping_events.tsv.gz
     byte_size: 164
     checksum:
-      - algorithm: md5
-        digest: 5e35a4bc332d46f5a7a5a9c43e484528
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5e35a4bc332d46f5a7a5a9c43e484528
     download_url:
       - https://dataverse.nl/api/access/datafile/46603
     media_type: application/gzip
   - id: exthisdsver:./sub-015/func/sub-015_task-fingerTappingImagined_echo-1_bold.json
     byte_size: 1046
     checksum:
-      - algorithm: md5
-        digest: 1d1f6527f07c9a5e0d31945da0845d7d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1d1f6527f07c9a5e0d31945da0845d7d
     download_url:
       - https://dataverse.nl/api/access/datafile/45900
     media_type: application/json
   - id: exthisdsver:./sub-015/func/sub-015_task-fingerTappingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 5f68b6fb473779bdbff68a8bad9fa6b7
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5f68b6fb473779bdbff68a8bad9fa6b7
     download_url:
       - https://dataverse.nl/api/access/datafile/45391
     media_type: image/nii
   - id: exthisdsver:./sub-015/func/sub-015_task-fingerTappingImagined_echo-2_bold.json
     byte_size: 1046
     checksum:
-      - algorithm: md5
-        digest: bd90e2394796a552e249cd243d132138
+      - creator: spdx:checksumAlgorithm_md5
+        notation: bd90e2394796a552e249cd243d132138
     download_url:
       - https://dataverse.nl/api/access/datafile/45819
     media_type: application/json
   - id: exthisdsver:./sub-015/func/sub-015_task-fingerTappingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: fe551edd889621ed399f7326c4226966
+      - creator: spdx:checksumAlgorithm_md5
+        notation: fe551edd889621ed399f7326c4226966
     download_url:
       - https://dataverse.nl/api/access/datafile/45473
     media_type: image/nii
   - id: exthisdsver:./sub-015/func/sub-015_task-fingerTappingImagined_echo-3_bold.json
     byte_size: 1046
     checksum:
-      - algorithm: md5
-        digest: 18d87d036fbfdeda251d459b3b06edfa
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 18d87d036fbfdeda251d459b3b06edfa
     download_url:
       - https://dataverse.nl/api/access/datafile/46118
     media_type: application/json
   - id: exthisdsver:./sub-015/func/sub-015_task-fingerTappingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 989e2e3ef6fa5bc0c0a66a160ba865b3
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 989e2e3ef6fa5bc0c0a66a160ba865b3
     download_url:
       - https://dataverse.nl/api/access/datafile/46388
     media_type: image/nii
   - id: exthisdsver:./sub-015/func/sub-015_task-fingerTappingImagined_events.tsv.gz
     byte_size: 177
     checksum:
-      - algorithm: md5
-        digest: c443bfaaf23700ea97fe30cec70c288d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c443bfaaf23700ea97fe30cec70c288d
     download_url:
       - https://dataverse.nl/api/access/datafile/46556
     media_type: application/gzip
   - id: exthisdsver:./sub-015/func/sub-015_task-fingerTappingImagined_physio.json
     byte_size: 142
     checksum:
-      - algorithm: md5
-        digest: c2ddbb68d9d67c56140f6bb9010eedfc
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c2ddbb68d9d67c56140f6bb9010eedfc
     download_url:
       - https://dataverse.nl/api/access/datafile/45147
     media_type: application/json
   - id: exthisdsver:./sub-015/func/sub-015_task-fingerTappingImagined_physio.tsv.gz
     byte_size: 463339
     checksum:
-      - algorithm: md5
-        digest: da35b5b1491a0f48718389a2705f281a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: da35b5b1491a0f48718389a2705f281a
     download_url:
       - https://dataverse.nl/api/access/datafile/45589
     media_type: application/gzip
   - id: exthisdsver:./sub-015/func/sub-015_task-fingerTapping_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: ddbfe6f792ffd8a9f2188637ea838e76
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ddbfe6f792ffd8a9f2188637ea838e76
     download_url:
       - https://dataverse.nl/api/access/datafile/45332
     media_type: application/json
   - id: exthisdsver:./sub-015/func/sub-015_task-fingerTapping_physio.tsv.gz
     byte_size: 525902
     checksum:
-      - algorithm: md5
-        digest: 8193c1d45a3b81190ed3f359256b9dae
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8193c1d45a3b81190ed3f359256b9dae
     download_url:
       - https://dataverse.nl/api/access/datafile/45903
     media_type: application/gzip
   - id: exthisdsver:./sub-015/func/sub-015_task-rest_run-1_echo-1_bold.json
     byte_size: 1029
     checksum:
-      - algorithm: md5
-        digest: b2008f846b94285f46b7ff0aa4b8116b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b2008f846b94285f46b7ff0aa4b8116b
     download_url:
       - https://dataverse.nl/api/access/datafile/45963
     media_type: application/json
   - id: exthisdsver:./sub-015/func/sub-015_task-rest_run-1_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: a5264529e7bc3b589a9fd9564a809639
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a5264529e7bc3b589a9fd9564a809639
     download_url:
       - https://dataverse.nl/api/access/datafile/45993
     media_type: image/nii
   - id: exthisdsver:./sub-015/func/sub-015_task-rest_run-1_echo-2_bold.json
     byte_size: 1029
     checksum:
-      - algorithm: md5
-        digest: 0fab7eb93c9cb4e9412fdf078ced4d5f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 0fab7eb93c9cb4e9412fdf078ced4d5f
     download_url:
       - https://dataverse.nl/api/access/datafile/46074
     media_type: application/json
   - id: exthisdsver:./sub-015/func/sub-015_task-rest_run-1_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: f8fd22cfecbc61a942031c81077dafc3
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f8fd22cfecbc61a942031c81077dafc3
     download_url:
       - https://dataverse.nl/api/access/datafile/45583
     media_type: image/nii
   - id: exthisdsver:./sub-015/func/sub-015_task-rest_run-1_echo-3_bold.json
     byte_size: 1029
     checksum:
-      - algorithm: md5
-        digest: 771d2ee1db43888675efa14349f68ca0
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 771d2ee1db43888675efa14349f68ca0
     download_url:
       - https://dataverse.nl/api/access/datafile/45320
     media_type: application/json
   - id: exthisdsver:./sub-015/func/sub-015_task-rest_run-1_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: cef947dcd2cbf4567fb5189670544df5
+      - creator: spdx:checksumAlgorithm_md5
+        notation: cef947dcd2cbf4567fb5189670544df5
     download_url:
       - https://dataverse.nl/api/access/datafile/45790
     media_type: image/nii
   - id: exthisdsver:./sub-015/func/sub-015_task-rest_run-1_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: d44f0f7ec71d61a858c1daaee5cfb10c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d44f0f7ec71d61a858c1daaee5cfb10c
     download_url:
       - https://dataverse.nl/api/access/datafile/45519
     media_type: application/json
   - id: exthisdsver:./sub-015/func/sub-015_task-rest_run-1_physio.tsv.gz
     byte_size: 446679
     checksum:
-      - algorithm: md5
-        digest: 62335324d50f4057f2958b816a39ac22
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 62335324d50f4057f2958b816a39ac22
     download_url:
       - https://dataverse.nl/api/access/datafile/45791
     media_type: application/gzip
   - id: exthisdsver:./sub-015/func/sub-015_task-rest_run-2_echo-1_bold.json
     byte_size: 1029
     checksum:
-      - algorithm: md5
-        digest: 57e0d4362eca162d5911e2d54923d9c3
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 57e0d4362eca162d5911e2d54923d9c3
     download_url:
       - https://dataverse.nl/api/access/datafile/45657
     media_type: application/json
   - id: exthisdsver:./sub-015/func/sub-015_task-rest_run-2_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: d57f18c07866ce290bd12113c8eea00a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d57f18c07866ce290bd12113c8eea00a
     download_url:
       - https://dataverse.nl/api/access/datafile/45782
     media_type: image/nii
   - id: exthisdsver:./sub-015/func/sub-015_task-rest_run-2_echo-2_bold.json
     byte_size: 1029
     checksum:
-      - algorithm: md5
-        digest: e3bacec427ab14cf578613c06c37d0e6
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e3bacec427ab14cf578613c06c37d0e6
     download_url:
       - https://dataverse.nl/api/access/datafile/46145
     media_type: application/json
   - id: exthisdsver:./sub-015/func/sub-015_task-rest_run-2_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 5d3d93fc7d0c2ea6252499f8960b1723
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5d3d93fc7d0c2ea6252499f8960b1723
     download_url:
       - https://dataverse.nl/api/access/datafile/45157
     media_type: image/nii
   - id: exthisdsver:./sub-015/func/sub-015_task-rest_run-2_echo-3_bold.json
     byte_size: 1029
     checksum:
-      - algorithm: md5
-        digest: bebbfe796e2da76a7f6690b6ab54f03a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: bebbfe796e2da76a7f6690b6ab54f03a
     download_url:
       - https://dataverse.nl/api/access/datafile/46052
     media_type: application/json
   - id: exthisdsver:./sub-015/func/sub-015_task-rest_run-2_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 9c0d403a28c6bd3600ca21f8dc4095dc
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 9c0d403a28c6bd3600ca21f8dc4095dc
     download_url:
       - https://dataverse.nl/api/access/datafile/46343
     media_type: image/nii
   - id: exthisdsver:./sub-015/func/sub-015_task-rest_run-2_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 986bbaac9424c364df4be2bda84111c2
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 986bbaac9424c364df4be2bda84111c2
     download_url:
       - https://dataverse.nl/api/access/datafile/45439
     media_type: application/json
   - id: exthisdsver:./sub-015/func/sub-015_task-rest_run-2_physio.tsv.gz
     byte_size: 459996
     checksum:
-      - algorithm: md5
-        digest: ba40101046df40b0be95469ba89170f6
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ba40101046df40b0be95469ba89170f6
     download_url:
       - https://dataverse.nl/api/access/datafile/45368
     media_type: application/gzip
   - id: exthisdsver:./sub-016/anat/sub-016_T1w.nii
     byte_size: 20736352
     checksum:
-      - algorithm: md5
-        digest: 31d8026e20e90e8eb58f5c8369da33b9
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 31d8026e20e90e8eb58f5c8369da33b9
     download_url:
       - https://dataverse.nl/api/access/datafile/45246
     media_type: image/nii
@@ -6924,8 +6924,8 @@ has_part:
   - id: exthisdsver:./sub-016/func/sub-016_task-emotionProcessing_echo-1_bold.json
     byte_size: 1042
     checksum:
-      - algorithm: md5
-        digest: 08e8474c185376d0779ff3d59b2bff3c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 08e8474c185376d0779ff3d59b2bff3c
     download_url:
       - https://dataverse.nl/api/access/datafile/45461
     media_type: application/json
@@ -7044,48 +7044,48 @@ has_part:
   - id: exthisdsver:./sub-016/func/sub-016_task-emotionProcessing_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: b0ae1b4660b02ce44f6fe8fb2e376a8b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b0ae1b4660b02ce44f6fe8fb2e376a8b
     download_url:
       - https://dataverse.nl/api/access/datafile/45447
     media_type: image/nii
   - id: exthisdsver:./sub-016/func/sub-016_task-emotionProcessing_echo-2_bold.json
     byte_size: 1042
     checksum:
-      - algorithm: md5
-        digest: ed1dee63197dd55d6e072e2f6f5405b2
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ed1dee63197dd55d6e072e2f6f5405b2
     download_url:
       - https://dataverse.nl/api/access/datafile/45953
     media_type: application/json
   - id: exthisdsver:./sub-016/func/sub-016_task-emotionProcessing_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 80aa8e8b5b109e4a0ffff5a34a2fd34e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 80aa8e8b5b109e4a0ffff5a34a2fd34e
     download_url:
       - https://dataverse.nl/api/access/datafile/45371
     media_type: image/nii
   - id: exthisdsver:./sub-016/func/sub-016_task-emotionProcessing_echo-3_bold.json
     byte_size: 1042
     checksum:
-      - algorithm: md5
-        digest: 38f5eaea9660539ecdd735ca35ab616e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 38f5eaea9660539ecdd735ca35ab616e
     download_url:
       - https://dataverse.nl/api/access/datafile/46161
     media_type: application/json
   - id: exthisdsver:./sub-016/func/sub-016_task-emotionProcessing_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 40cb433e5c6fb302f54f6fb0e6facf33
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 40cb433e5c6fb302f54f6fb0e6facf33
     download_url:
       - https://dataverse.nl/api/access/datafile/45701
     media_type: image/nii
   - id: exthisdsver:./sub-016/func/sub-016_task-emotionProcessing_events.tsv.gz
     byte_size: 1898
     checksum:
-      - algorithm: md5
-        digest: dac29a68dc5c3f4f2ca10ec46f11c7eb
+      - creator: spdx:checksumAlgorithm_md5
+        notation: dac29a68dc5c3f4f2ca10ec46f11c7eb
     download_url:
       - https://dataverse.nl/api/access/datafile/46651
     media_type: application/gzip
@@ -7093,8 +7093,8 @@ has_part:
       exthisdsver:./sub-016/func/sub-016_task-emotionProcessingImagined_echo-1_bold.json
     byte_size: 1050
     checksum:
-      - algorithm: md5
-        digest: 3bb868574acd187ae6e7bbef7107f316
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 3bb868574acd187ae6e7bbef7107f316
     download_url:
       - https://dataverse.nl/api/access/datafile/45814
     media_type: application/json
@@ -7102,8 +7102,8 @@ has_part:
       exthisdsver:./sub-016/func/sub-016_task-emotionProcessingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: d245b1944f7c9b7a30330096fa9ea2a6
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d245b1944f7c9b7a30330096fa9ea2a6
     download_url:
       - https://dataverse.nl/api/access/datafile/46162
     media_type: image/nii
@@ -7111,8 +7111,8 @@ has_part:
       exthisdsver:./sub-016/func/sub-016_task-emotionProcessingImagined_echo-2_bold.json
     byte_size: 1050
     checksum:
-      - algorithm: md5
-        digest: 5f83ec535cdd690e0e325334e30f40fc
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5f83ec535cdd690e0e325334e30f40fc
     download_url:
       - https://dataverse.nl/api/access/datafile/46542
     media_type: application/json
@@ -7120,8 +7120,8 @@ has_part:
       exthisdsver:./sub-016/func/sub-016_task-emotionProcessingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 8b448020772aa64321a9523fe0afe0a8
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8b448020772aa64321a9523fe0afe0a8
     download_url:
       - https://dataverse.nl/api/access/datafile/45494
     media_type: image/nii
@@ -7129,8 +7129,8 @@ has_part:
       exthisdsver:./sub-016/func/sub-016_task-emotionProcessingImagined_echo-3_bold.json
     byte_size: 1050
     checksum:
-      - algorithm: md5
-        digest: 6751befbdf215f731ce2023a98546f1a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6751befbdf215f731ce2023a98546f1a
     download_url:
       - https://dataverse.nl/api/access/datafile/45325
     media_type: application/json
@@ -7138,328 +7138,328 @@ has_part:
       exthisdsver:./sub-016/func/sub-016_task-emotionProcessingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: f2aa0fad61d8596559792ed080af9155
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f2aa0fad61d8596559792ed080af9155
     download_url:
       - https://dataverse.nl/api/access/datafile/46187
     media_type: image/nii
   - id: exthisdsver:./sub-016/func/sub-016_task-emotionProcessingImagined_events.tsv.gz
     byte_size: 174
     checksum:
-      - algorithm: md5
-        digest: c759824e08e5265a576a3ed30c41c9a8
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c759824e08e5265a576a3ed30c41c9a8
     download_url:
       - https://dataverse.nl/api/access/datafile/46585
     media_type: application/gzip
   - id: exthisdsver:./sub-016/func/sub-016_task-emotionProcessingImagined_physio.json
     byte_size: 141
     checksum:
-      - algorithm: md5
-        digest: 7ffdf8881f8ca0fb33e3e295a0dfcbed
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 7ffdf8881f8ca0fb33e3e295a0dfcbed
     download_url:
       - https://dataverse.nl/api/access/datafile/45285
     media_type: application/json
   - id: exthisdsver:./sub-016/func/sub-016_task-emotionProcessingImagined_physio.tsv.gz
     byte_size: 459585
     checksum:
-      - algorithm: md5
-        digest: 23ad5834ff7d3176559ce62569dbfdb1
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 23ad5834ff7d3176559ce62569dbfdb1
     download_url:
       - https://dataverse.nl/api/access/datafile/46307
     media_type: application/gzip
   - id: exthisdsver:./sub-016/func/sub-016_task-emotionProcessing_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 845c1ac8b70929f102b23512388aaae0
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 845c1ac8b70929f102b23512388aaae0
     download_url:
       - https://dataverse.nl/api/access/datafile/46018
     media_type: application/json
   - id: exthisdsver:./sub-016/func/sub-016_task-emotionProcessing_physio.tsv.gz
     byte_size: 446734
     checksum:
-      - algorithm: md5
-        digest: af36d726b8fc5b7ba253e32869ca16bc
+      - creator: spdx:checksumAlgorithm_md5
+        notation: af36d726b8fc5b7ba253e32869ca16bc
     download_url:
       - https://dataverse.nl/api/access/datafile/45169
     media_type: application/gzip
   - id: exthisdsver:./sub-016/func/sub-016_task-fingerTapping_echo-1_bold.json
     byte_size: 1038
     checksum:
-      - algorithm: md5
-        digest: 9b8c71edb5f51fd9c5fa7f4be9b6972d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 9b8c71edb5f51fd9c5fa7f4be9b6972d
     download_url:
       - https://dataverse.nl/api/access/datafile/46247
     media_type: application/json
   - id: exthisdsver:./sub-016/func/sub-016_task-fingerTapping_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 444724a76166a7d01752c3139a54efce
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 444724a76166a7d01752c3139a54efce
     download_url:
       - https://dataverse.nl/api/access/datafile/45507
     media_type: image/nii
   - id: exthisdsver:./sub-016/func/sub-016_task-fingerTapping_echo-2_bold.json
     byte_size: 1038
     checksum:
-      - algorithm: md5
-        digest: 46afa05e3f9bcc5a620f9a5e877c4002
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 46afa05e3f9bcc5a620f9a5e877c4002
     download_url:
       - https://dataverse.nl/api/access/datafile/45792
     media_type: application/json
   - id: exthisdsver:./sub-016/func/sub-016_task-fingerTapping_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 424531972f2df2146e7b9f180efadd95
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 424531972f2df2146e7b9f180efadd95
     download_url:
       - https://dataverse.nl/api/access/datafile/46378
     media_type: image/nii
   - id: exthisdsver:./sub-016/func/sub-016_task-fingerTapping_echo-3_bold.json
     byte_size: 1038
     checksum:
-      - algorithm: md5
-        digest: fac4ea384b9a185e10043873f781f607
+      - creator: spdx:checksumAlgorithm_md5
+        notation: fac4ea384b9a185e10043873f781f607
     download_url:
       - https://dataverse.nl/api/access/datafile/45844
     media_type: application/json
   - id: exthisdsver:./sub-016/func/sub-016_task-fingerTapping_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: abe4380cbfbb8d05eb71d189bbc7e370
+      - creator: spdx:checksumAlgorithm_md5
+        notation: abe4380cbfbb8d05eb71d189bbc7e370
     download_url:
       - https://dataverse.nl/api/access/datafile/45744
     media_type: image/nii
   - id: exthisdsver:./sub-016/func/sub-016_task-fingerTapping_events.tsv.gz
     byte_size: 165
     checksum:
-      - algorithm: md5
-        digest: d314343e2900e7ba82ff56fdfa53e54d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d314343e2900e7ba82ff56fdfa53e54d
     download_url:
       - https://dataverse.nl/api/access/datafile/46549
     media_type: application/gzip
   - id: exthisdsver:./sub-016/func/sub-016_task-fingerTappingImagined_echo-1_bold.json
     byte_size: 1046
     checksum:
-      - algorithm: md5
-        digest: 4445e300960c70aeac5820f704add828
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4445e300960c70aeac5820f704add828
     download_url:
       - https://dataverse.nl/api/access/datafile/45581
     media_type: application/json
   - id: exthisdsver:./sub-016/func/sub-016_task-fingerTappingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 712ffd316600020031eeb25ce0ad1048
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 712ffd316600020031eeb25ce0ad1048
     download_url:
       - https://dataverse.nl/api/access/datafile/45586
     media_type: image/nii
   - id: exthisdsver:./sub-016/func/sub-016_task-fingerTappingImagined_echo-2_bold.json
     byte_size: 1046
     checksum:
-      - algorithm: md5
-        digest: fa36384d47253e6f49fd1c3a84ce8ae1
+      - creator: spdx:checksumAlgorithm_md5
+        notation: fa36384d47253e6f49fd1c3a84ce8ae1
     download_url:
       - https://dataverse.nl/api/access/datafile/46058
     media_type: application/json
   - id: exthisdsver:./sub-016/func/sub-016_task-fingerTappingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: c3d90e1a44f369ee830fbc925846242a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c3d90e1a44f369ee830fbc925846242a
     download_url:
       - https://dataverse.nl/api/access/datafile/45379
     media_type: image/nii
   - id: exthisdsver:./sub-016/func/sub-016_task-fingerTappingImagined_echo-3_bold.json
     byte_size: 1046
     checksum:
-      - algorithm: md5
-        digest: 9445320d6da082a454ed1766fa19d3f5
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 9445320d6da082a454ed1766fa19d3f5
     download_url:
       - https://dataverse.nl/api/access/datafile/45424
     media_type: application/json
   - id: exthisdsver:./sub-016/func/sub-016_task-fingerTappingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: c586fd28791472c2ebdc9c657ffad17b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c586fd28791472c2ebdc9c657ffad17b
     download_url:
       - https://dataverse.nl/api/access/datafile/45595
     media_type: image/nii
   - id: exthisdsver:./sub-016/func/sub-016_task-fingerTappingImagined_events.tsv.gz
     byte_size: 178
     checksum:
-      - algorithm: md5
-        digest: cfbd687636039bc92fa556dad233fc4f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: cfbd687636039bc92fa556dad233fc4f
     download_url:
       - https://dataverse.nl/api/access/datafile/46564
     media_type: application/gzip
   - id: exthisdsver:./sub-016/func/sub-016_task-fingerTappingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 034768366c7e99c5ae5c7bd5d8062feb
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 034768366c7e99c5ae5c7bd5d8062feb
     download_url:
       - https://dataverse.nl/api/access/datafile/45309
     media_type: application/json
   - id: exthisdsver:./sub-016/func/sub-016_task-fingerTappingImagined_physio.tsv.gz
     byte_size: 458214
     checksum:
-      - algorithm: md5
-        digest: 6438acf1576ca083bf8d44530648aa9a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6438acf1576ca083bf8d44530648aa9a
     download_url:
       - https://dataverse.nl/api/access/datafile/46129
     media_type: application/gzip
   - id: exthisdsver:./sub-016/func/sub-016_task-fingerTapping_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 41386e28ee5edf34ed2e10d5cf61bf41
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 41386e28ee5edf34ed2e10d5cf61bf41
     download_url:
       - https://dataverse.nl/api/access/datafile/45924
     media_type: application/json
   - id: exthisdsver:./sub-016/func/sub-016_task-fingerTapping_physio.tsv.gz
     byte_size: 372090
     checksum:
-      - algorithm: md5
-        digest: 6e0d586e839d86a2badb6b80926b641f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6e0d586e839d86a2badb6b80926b641f
     download_url:
       - https://dataverse.nl/api/access/datafile/45695
     media_type: application/gzip
   - id: exthisdsver:./sub-016/func/sub-016_task-rest_run-1_echo-1_bold.json
     byte_size: 1029
     checksum:
-      - algorithm: md5
-        digest: 48a0f7170aa013d14aeb303e3f856824
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 48a0f7170aa013d14aeb303e3f856824
     download_url:
       - https://dataverse.nl/api/access/datafile/45793
     media_type: application/json
   - id: exthisdsver:./sub-016/func/sub-016_task-rest_run-1_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: f532551700f959a6b9a9b78298d8ed33
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f532551700f959a6b9a9b78298d8ed33
     download_url:
       - https://dataverse.nl/api/access/datafile/46004
     media_type: image/nii
   - id: exthisdsver:./sub-016/func/sub-016_task-rest_run-1_echo-2_bold.json
     byte_size: 1029
     checksum:
-      - algorithm: md5
-        digest: 4ae0b674baa370cd8825e53f413bab2e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4ae0b674baa370cd8825e53f413bab2e
     download_url:
       - https://dataverse.nl/api/access/datafile/46355
     media_type: application/json
   - id: exthisdsver:./sub-016/func/sub-016_task-rest_run-1_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 0241c09d9cba424e36bed06f41863ccd
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 0241c09d9cba424e36bed06f41863ccd
     download_url:
       - https://dataverse.nl/api/access/datafile/45901
     media_type: image/nii
   - id: exthisdsver:./sub-016/func/sub-016_task-rest_run-1_echo-3_bold.json
     byte_size: 1029
     checksum:
-      - algorithm: md5
-        digest: 963cce7febb74776ab3ec1c60588a5e2
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 963cce7febb74776ab3ec1c60588a5e2
     download_url:
       - https://dataverse.nl/api/access/datafile/46522
     media_type: application/json
   - id: exthisdsver:./sub-016/func/sub-016_task-rest_run-1_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 655370b635f41840115b4c560492d47e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 655370b635f41840115b4c560492d47e
     download_url:
       - https://dataverse.nl/api/access/datafile/46224
     media_type: image/nii
   - id: exthisdsver:./sub-016/func/sub-016_task-rest_run-1_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 6f93d507dfb2f0e8d5f1c701e4905883
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6f93d507dfb2f0e8d5f1c701e4905883
     download_url:
       - https://dataverse.nl/api/access/datafile/46241
     media_type: application/json
   - id: exthisdsver:./sub-016/func/sub-016_task-rest_run-1_physio.tsv.gz
     byte_size: 430389
     checksum:
-      - algorithm: md5
-        digest: fcee2d47ec8682d2b225e8ab3fb9f04a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: fcee2d47ec8682d2b225e8ab3fb9f04a
     download_url:
       - https://dataverse.nl/api/access/datafile/46289
     media_type: application/gzip
   - id: exthisdsver:./sub-016/func/sub-016_task-rest_run-2_echo-1_bold.json
     byte_size: 1029
     checksum:
-      - algorithm: md5
-        digest: 84cc70775c04a49d194655df552503cc
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 84cc70775c04a49d194655df552503cc
     download_url:
       - https://dataverse.nl/api/access/datafile/45370
     media_type: application/json
   - id: exthisdsver:./sub-016/func/sub-016_task-rest_run-2_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 402f8627e49e317bfbe1a2cc698325e5
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 402f8627e49e317bfbe1a2cc698325e5
     download_url:
       - https://dataverse.nl/api/access/datafile/45523
     media_type: image/nii
   - id: exthisdsver:./sub-016/func/sub-016_task-rest_run-2_echo-2_bold.json
     byte_size: 1029
     checksum:
-      - algorithm: md5
-        digest: 57434db2ad04582f7f96d8f037069076
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 57434db2ad04582f7f96d8f037069076
     download_url:
       - https://dataverse.nl/api/access/datafile/45172
     media_type: application/json
   - id: exthisdsver:./sub-016/func/sub-016_task-rest_run-2_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 74ec0685e27a57412cb74d00d60813da
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 74ec0685e27a57412cb74d00d60813da
     download_url:
       - https://dataverse.nl/api/access/datafile/45560
     media_type: image/nii
   - id: exthisdsver:./sub-016/func/sub-016_task-rest_run-2_echo-3_bold.json
     byte_size: 1029
     checksum:
-      - algorithm: md5
-        digest: 94f7316ef91ade5b966f52c68f6343a5
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 94f7316ef91ade5b966f52c68f6343a5
     download_url:
       - https://dataverse.nl/api/access/datafile/45895
     media_type: application/json
   - id: exthisdsver:./sub-016/func/sub-016_task-rest_run-2_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 1ac94022b69e64c4ff225f728ec49bc3
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1ac94022b69e64c4ff225f728ec49bc3
     download_url:
       - https://dataverse.nl/api/access/datafile/45162
     media_type: image/nii
   - id: exthisdsver:./sub-016/func/sub-016_task-rest_run-2_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 6ff54c42753602c542673831aae3e39c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6ff54c42753602c542673831aae3e39c
     download_url:
       - https://dataverse.nl/api/access/datafile/46368
     media_type: application/json
   - id: exthisdsver:./sub-016/func/sub-016_task-rest_run-2_physio.tsv.gz
     byte_size: 462641
     checksum:
-      - algorithm: md5
-        digest: 1d6be496d3bb38563acfb4de457cca63
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1d6be496d3bb38563acfb4de457cca63
     download_url:
       - https://dataverse.nl/api/access/datafile/46320
     media_type: application/gzip
   - id: exthisdsver:./sub-017/anat/sub-017_T1w.nii
     byte_size: 20736352
     checksum:
-      - algorithm: md5
-        digest: 8a31ce74ffb3bb8218e54828ce1bb7bc
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8a31ce74ffb3bb8218e54828ce1bb7bc
     download_url:
       - https://dataverse.nl/api/access/datafile/46093
     media_type: image/nii
@@ -7476,8 +7476,8 @@ has_part:
   - id: exthisdsver:./sub-017/func/sub-017_task-emotionProcessing_echo-1_bold.json
     byte_size: 1039
     checksum:
-      - algorithm: md5
-        digest: f0eff72e0e7149911dac1674911c0a53
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f0eff72e0e7149911dac1674911c0a53
     download_url:
       - https://dataverse.nl/api/access/datafile/46090
     media_type: application/json
@@ -7596,48 +7596,48 @@ has_part:
   - id: exthisdsver:./sub-017/func/sub-017_task-emotionProcessing_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 49bd6392aabdd13fb1f061d584fdfc5d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 49bd6392aabdd13fb1f061d584fdfc5d
     download_url:
       - https://dataverse.nl/api/access/datafile/46395
     media_type: image/nii
   - id: exthisdsver:./sub-017/func/sub-017_task-emotionProcessing_echo-2_bold.json
     byte_size: 1039
     checksum:
-      - algorithm: md5
-        digest: c6792ff5c1c23b3515f3f1f9302baf75
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c6792ff5c1c23b3515f3f1f9302baf75
     download_url:
       - https://dataverse.nl/api/access/datafile/46324
     media_type: application/json
   - id: exthisdsver:./sub-017/func/sub-017_task-emotionProcessing_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: cfb6e06f72ecb8eabf9cd409edaeaf93
+      - creator: spdx:checksumAlgorithm_md5
+        notation: cfb6e06f72ecb8eabf9cd409edaeaf93
     download_url:
       - https://dataverse.nl/api/access/datafile/45754
     media_type: image/nii
   - id: exthisdsver:./sub-017/func/sub-017_task-emotionProcessing_echo-3_bold.json
     byte_size: 1039
     checksum:
-      - algorithm: md5
-        digest: a528b89b95b3f3128e8e98a9237edc64
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a528b89b95b3f3128e8e98a9237edc64
     download_url:
       - https://dataverse.nl/api/access/datafile/45454
     media_type: application/json
   - id: exthisdsver:./sub-017/func/sub-017_task-emotionProcessing_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 6f919d3a07df2b44ee4ebf59a04eefad
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6f919d3a07df2b44ee4ebf59a04eefad
     download_url:
       - https://dataverse.nl/api/access/datafile/45336
     media_type: image/nii
   - id: exthisdsver:./sub-017/func/sub-017_task-emotionProcessing_events.tsv.gz
     byte_size: 1896
     checksum:
-      - algorithm: md5
-        digest: 512913b1b38ca0f4202f6ca3c3605ab7
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 512913b1b38ca0f4202f6ca3c3605ab7
     download_url:
       - https://dataverse.nl/api/access/datafile/46557
     media_type: application/gzip
@@ -7645,8 +7645,8 @@ has_part:
       exthisdsver:./sub-017/func/sub-017_task-emotionProcessingImagined_echo-1_bold.json
     byte_size: 1047
     checksum:
-      - algorithm: md5
-        digest: 35681199bfc3e571aae5477ce1191bf3
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 35681199bfc3e571aae5477ce1191bf3
     download_url:
       - https://dataverse.nl/api/access/datafile/46269
     media_type: application/json
@@ -7654,8 +7654,8 @@ has_part:
       exthisdsver:./sub-017/func/sub-017_task-emotionProcessingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 246521bd5001db167861cf5da9c9468e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 246521bd5001db167861cf5da9c9468e
     download_url:
       - https://dataverse.nl/api/access/datafile/45687
     media_type: image/nii
@@ -7663,8 +7663,8 @@ has_part:
       exthisdsver:./sub-017/func/sub-017_task-emotionProcessingImagined_echo-2_bold.json
     byte_size: 1047
     checksum:
-      - algorithm: md5
-        digest: cd5b275b00155c6655e6163dc9563bac
+      - creator: spdx:checksumAlgorithm_md5
+        notation: cd5b275b00155c6655e6163dc9563bac
     download_url:
       - https://dataverse.nl/api/access/datafile/45243
     media_type: application/json
@@ -7672,8 +7672,8 @@ has_part:
       exthisdsver:./sub-017/func/sub-017_task-emotionProcessingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 193cb8ecc6cd158d8ecd4764aeba0b02
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 193cb8ecc6cd158d8ecd4764aeba0b02
     download_url:
       - https://dataverse.nl/api/access/datafile/46113
     media_type: image/nii
@@ -7681,8 +7681,8 @@ has_part:
       exthisdsver:./sub-017/func/sub-017_task-emotionProcessingImagined_echo-3_bold.json
     byte_size: 1047
     checksum:
-      - algorithm: md5
-        digest: f4c03ab759da66ffb6774913e4bf6c70
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f4c03ab759da66ffb6774913e4bf6c70
     download_url:
       - https://dataverse.nl/api/access/datafile/45935
     media_type: application/json
@@ -7690,328 +7690,328 @@ has_part:
       exthisdsver:./sub-017/func/sub-017_task-emotionProcessingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: e1f5d15b62dde1cde99e429788d7be0e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e1f5d15b62dde1cde99e429788d7be0e
     download_url:
       - https://dataverse.nl/api/access/datafile/45362
     media_type: image/nii
   - id: exthisdsver:./sub-017/func/sub-017_task-emotionProcessingImagined_events.tsv.gz
     byte_size: 175
     checksum:
-      - algorithm: md5
-        digest: 782ccc689087c2d7ebbac8acd4770997
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 782ccc689087c2d7ebbac8acd4770997
     download_url:
       - https://dataverse.nl/api/access/datafile/46561
     media_type: application/gzip
   - id: exthisdsver:./sub-017/func/sub-017_task-emotionProcessingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: d09ab3c66bdfca4f24ca0495469c9b78
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d09ab3c66bdfca4f24ca0495469c9b78
     download_url:
       - https://dataverse.nl/api/access/datafile/46165
     media_type: application/json
   - id: exthisdsver:./sub-017/func/sub-017_task-emotionProcessingImagined_physio.tsv.gz
     byte_size: 473929
     checksum:
-      - algorithm: md5
-        digest: 6a2527bd9a7c8b613cef15d92020f475
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6a2527bd9a7c8b613cef15d92020f475
     download_url:
       - https://dataverse.nl/api/access/datafile/46168
     media_type: application/gzip
   - id: exthisdsver:./sub-017/func/sub-017_task-emotionProcessing_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 5ab56953069930dde62e936cca3bb403
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5ab56953069930dde62e936cca3bb403
     download_url:
       - https://dataverse.nl/api/access/datafile/45735
     media_type: application/json
   - id: exthisdsver:./sub-017/func/sub-017_task-emotionProcessing_physio.tsv.gz
     byte_size: 499951
     checksum:
-      - algorithm: md5
-        digest: d2d2f6899051f0b2703084793376566a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d2d2f6899051f0b2703084793376566a
     download_url:
       - https://dataverse.nl/api/access/datafile/45445
     media_type: application/gzip
   - id: exthisdsver:./sub-017/func/sub-017_task-fingerTapping_echo-1_bold.json
     byte_size: 1035
     checksum:
-      - algorithm: md5
-        digest: a81c54ce06347f213b53121dae0893cb
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a81c54ce06347f213b53121dae0893cb
     download_url:
       - https://dataverse.nl/api/access/datafile/45678
     media_type: application/json
   - id: exthisdsver:./sub-017/func/sub-017_task-fingerTapping_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: a3ae572c8c08c4f4439aedc929b2f764
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a3ae572c8c08c4f4439aedc929b2f764
     download_url:
       - https://dataverse.nl/api/access/datafile/45804
     media_type: image/nii
   - id: exthisdsver:./sub-017/func/sub-017_task-fingerTapping_echo-2_bold.json
     byte_size: 1035
     checksum:
-      - algorithm: md5
-        digest: 1fae2f3de9799c2f5453c2fd7f1eb6b7
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1fae2f3de9799c2f5453c2fd7f1eb6b7
     download_url:
       - https://dataverse.nl/api/access/datafile/45440
     media_type: application/json
   - id: exthisdsver:./sub-017/func/sub-017_task-fingerTapping_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 91a3a7af3f8746d109626c0abe9047ac
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 91a3a7af3f8746d109626c0abe9047ac
     download_url:
       - https://dataverse.nl/api/access/datafile/45350
     media_type: image/nii
   - id: exthisdsver:./sub-017/func/sub-017_task-fingerTapping_echo-3_bold.json
     byte_size: 1035
     checksum:
-      - algorithm: md5
-        digest: 21a1213eceb3fa03b239b84a2ee553b9
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 21a1213eceb3fa03b239b84a2ee553b9
     download_url:
       - https://dataverse.nl/api/access/datafile/45344
     media_type: application/json
   - id: exthisdsver:./sub-017/func/sub-017_task-fingerTapping_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 05142b0bacff1ab7da64ebfcb73bae03
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 05142b0bacff1ab7da64ebfcb73bae03
     download_url:
       - https://dataverse.nl/api/access/datafile/46186
     media_type: image/nii
   - id: exthisdsver:./sub-017/func/sub-017_task-fingerTapping_events.tsv.gz
     byte_size: 161
     checksum:
-      - algorithm: md5
-        digest: f0f48d05413226bdc642faef1aa666ff
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f0f48d05413226bdc642faef1aa666ff
     download_url:
       - https://dataverse.nl/api/access/datafile/46571
     media_type: application/gzip
   - id: exthisdsver:./sub-017/func/sub-017_task-fingerTappingImagined_echo-1_bold.json
     byte_size: 1043
     checksum:
-      - algorithm: md5
-        digest: 476d04c8a39a356361311baa48b3d47f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 476d04c8a39a356361311baa48b3d47f
     download_url:
       - https://dataverse.nl/api/access/datafile/46078
     media_type: application/json
   - id: exthisdsver:./sub-017/func/sub-017_task-fingerTappingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 39110bab63dc3d41f3d09c1b5a5e6dd8
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 39110bab63dc3d41f3d09c1b5a5e6dd8
     download_url:
       - https://dataverse.nl/api/access/datafile/45591
     media_type: image/nii
   - id: exthisdsver:./sub-017/func/sub-017_task-fingerTappingImagined_echo-2_bold.json
     byte_size: 1043
     checksum:
-      - algorithm: md5
-        digest: 27e9d3e5020feb7b3c45f290447b72da
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 27e9d3e5020feb7b3c45f290447b72da
     download_url:
       - https://dataverse.nl/api/access/datafile/46274
     media_type: application/json
   - id: exthisdsver:./sub-017/func/sub-017_task-fingerTappingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: f0b062a4383267f9392126b8ded03250
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f0b062a4383267f9392126b8ded03250
     download_url:
       - https://dataverse.nl/api/access/datafile/46407
     media_type: image/nii
   - id: exthisdsver:./sub-017/func/sub-017_task-fingerTappingImagined_echo-3_bold.json
     byte_size: 1043
     checksum:
-      - algorithm: md5
-        digest: 640d68482d7ca776db7d8ffd20c710f5
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 640d68482d7ca776db7d8ffd20c710f5
     download_url:
       - https://dataverse.nl/api/access/datafile/45626
     media_type: application/json
   - id: exthisdsver:./sub-017/func/sub-017_task-fingerTappingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 66f1619b1ba2e9eda4749c3aef4b552b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 66f1619b1ba2e9eda4749c3aef4b552b
     download_url:
       - https://dataverse.nl/api/access/datafile/45550
     media_type: image/nii
   - id: exthisdsver:./sub-017/func/sub-017_task-fingerTappingImagined_events.tsv.gz
     byte_size: 176
     checksum:
-      - algorithm: md5
-        digest: a98da27e0755ccefd4d98a77debc5e5f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a98da27e0755ccefd4d98a77debc5e5f
     download_url:
       - https://dataverse.nl/api/access/datafile/46621
     media_type: application/gzip
   - id: exthisdsver:./sub-017/func/sub-017_task-fingerTappingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 294a3c8ca8bfd7441b17a63378592daa
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 294a3c8ca8bfd7441b17a63378592daa
     download_url:
       - https://dataverse.nl/api/access/datafile/45799
     media_type: application/json
   - id: exthisdsver:./sub-017/func/sub-017_task-fingerTappingImagined_physio.tsv.gz
     byte_size: 460894
     checksum:
-      - algorithm: md5
-        digest: 46290d9393671049db251e3435e4aeef
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 46290d9393671049db251e3435e4aeef
     download_url:
       - https://dataverse.nl/api/access/datafile/46012
     media_type: application/gzip
   - id: exthisdsver:./sub-017/func/sub-017_task-fingerTapping_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: a3342ebda0beb4502ce9c9dd5ab527d6
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a3342ebda0beb4502ce9c9dd5ab527d6
     download_url:
       - https://dataverse.nl/api/access/datafile/46160
     media_type: application/json
   - id: exthisdsver:./sub-017/func/sub-017_task-fingerTapping_physio.tsv.gz
     byte_size: 495881
     checksum:
-      - algorithm: md5
-        digest: 6d23e1674aa125506ca24aa173282614
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6d23e1674aa125506ca24aa173282614
     download_url:
       - https://dataverse.nl/api/access/datafile/46344
     media_type: application/gzip
   - id: exthisdsver:./sub-017/func/sub-017_task-rest_run-1_echo-1_bold.json
     byte_size: 1024
     checksum:
-      - algorithm: md5
-        digest: ea2c4f2379ca18e87ea3f6d52b0568e9
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ea2c4f2379ca18e87ea3f6d52b0568e9
     download_url:
       - https://dataverse.nl/api/access/datafile/45137
     media_type: application/json
   - id: exthisdsver:./sub-017/func/sub-017_task-rest_run-1_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: dd1fd2df29e32a6ea212fe640e375a39
+      - creator: spdx:checksumAlgorithm_md5
+        notation: dd1fd2df29e32a6ea212fe640e375a39
     download_url:
       - https://dataverse.nl/api/access/datafile/45140
     media_type: image/nii
   - id: exthisdsver:./sub-017/func/sub-017_task-rest_run-1_echo-2_bold.json
     byte_size: 1024
     checksum:
-      - algorithm: md5
-        digest: c1da6b603a1c3d11ff9cff5e78690a6e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c1da6b603a1c3d11ff9cff5e78690a6e
     download_url:
       - https://dataverse.nl/api/access/datafile/45611
     media_type: application/json
   - id: exthisdsver:./sub-017/func/sub-017_task-rest_run-1_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: baf772ab2471f417131cb7e9dda728f8
+      - creator: spdx:checksumAlgorithm_md5
+        notation: baf772ab2471f417131cb7e9dda728f8
     download_url:
       - https://dataverse.nl/api/access/datafile/46306
     media_type: image/nii
   - id: exthisdsver:./sub-017/func/sub-017_task-rest_run-1_echo-3_bold.json
     byte_size: 1024
     checksum:
-      - algorithm: md5
-        digest: 3a7f850a5b7f3465ae0c623be38910ec
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 3a7f850a5b7f3465ae0c623be38910ec
     download_url:
       - https://dataverse.nl/api/access/datafile/45097
     media_type: application/json
   - id: exthisdsver:./sub-017/func/sub-017_task-rest_run-1_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: a2a7e7eb3bcdf8a867ce1b99b653c4b9
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a2a7e7eb3bcdf8a867ce1b99b653c4b9
     download_url:
       - https://dataverse.nl/api/access/datafile/46466
     media_type: image/nii
   - id: exthisdsver:./sub-017/func/sub-017_task-rest_run-1_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: e8f482f7e7732c656de46ba094f00b71
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e8f482f7e7732c656de46ba094f00b71
     download_url:
       - https://dataverse.nl/api/access/datafile/46250
     media_type: application/json
   - id: exthisdsver:./sub-017/func/sub-017_task-rest_run-1_physio.tsv.gz
     byte_size: 456750
     checksum:
-      - algorithm: md5
-        digest: 78267cb7d6e83c76d9c0f993e3925f14
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 78267cb7d6e83c76d9c0f993e3925f14
     download_url:
       - https://dataverse.nl/api/access/datafile/45691
     media_type: application/gzip
   - id: exthisdsver:./sub-017/func/sub-017_task-rest_run-2_echo-1_bold.json
     byte_size: 1026
     checksum:
-      - algorithm: md5
-        digest: 20f75958d0053920cb12a8e5d594fc8c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 20f75958d0053920cb12a8e5d594fc8c
     download_url:
       - https://dataverse.nl/api/access/datafile/46253
     media_type: application/json
   - id: exthisdsver:./sub-017/func/sub-017_task-rest_run-2_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 448b7a0ec38d72fce9923dfa86c90c74
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 448b7a0ec38d72fce9923dfa86c90c74
     download_url:
       - https://dataverse.nl/api/access/datafile/46485
     media_type: image/nii
   - id: exthisdsver:./sub-017/func/sub-017_task-rest_run-2_echo-2_bold.json
     byte_size: 1026
     checksum:
-      - algorithm: md5
-        digest: ac5b05347c7c89c81616416a4d599159
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ac5b05347c7c89c81616416a4d599159
     download_url:
       - https://dataverse.nl/api/access/datafile/46315
     media_type: application/json
   - id: exthisdsver:./sub-017/func/sub-017_task-rest_run-2_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 1a9aebad3a6c4790cbd335d657be9fb8
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1a9aebad3a6c4790cbd335d657be9fb8
     download_url:
       - https://dataverse.nl/api/access/datafile/45905
     media_type: image/nii
   - id: exthisdsver:./sub-017/func/sub-017_task-rest_run-2_echo-3_bold.json
     byte_size: 1026
     checksum:
-      - algorithm: md5
-        digest: ab14d28bb0b0111dcbd82e34a685f0c9
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ab14d28bb0b0111dcbd82e34a685f0c9
     download_url:
       - https://dataverse.nl/api/access/datafile/45665
     media_type: application/json
   - id: exthisdsver:./sub-017/func/sub-017_task-rest_run-2_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 4699b14b4d1fc69be7e5753b10b4eb8a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4699b14b4d1fc69be7e5753b10b4eb8a
     download_url:
       - https://dataverse.nl/api/access/datafile/45364
     media_type: image/nii
   - id: exthisdsver:./sub-017/func/sub-017_task-rest_run-2_physio.json
     byte_size: 142
     checksum:
-      - algorithm: md5
-        digest: 36c47f48e263ca8084edd851e612d302
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 36c47f48e263ca8084edd851e612d302
     download_url:
       - https://dataverse.nl/api/access/datafile/46523
     media_type: application/json
   - id: exthisdsver:./sub-017/func/sub-017_task-rest_run-2_physio.tsv.gz
     byte_size: 464147
     checksum:
-      - algorithm: md5
-        digest: b5790975f1314dc05b060076a288be5d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b5790975f1314dc05b060076a288be5d
     download_url:
       - https://dataverse.nl/api/access/datafile/45820
     media_type: application/gzip
   - id: exthisdsver:./sub-018/anat/sub-018_T1w.nii
     byte_size: 20736352
     checksum:
-      - algorithm: md5
-        digest: 0562eacf5cf688fece5bb99d1bf11d7a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 0562eacf5cf688fece5bb99d1bf11d7a
     download_url:
       - https://dataverse.nl/api/access/datafile/46477
     media_type: image/nii
@@ -8028,8 +8028,8 @@ has_part:
   - id: exthisdsver:./sub-018/func/sub-018_task-emotionProcessing_echo-1_bold.json
     byte_size: 1042
     checksum:
-      - algorithm: md5
-        digest: c3469a90251c21df2cd808f4ab158b5e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c3469a90251c21df2cd808f4ab158b5e
     download_url:
       - https://dataverse.nl/api/access/datafile/46027
     media_type: application/json
@@ -8148,48 +8148,48 @@ has_part:
   - id: exthisdsver:./sub-018/func/sub-018_task-emotionProcessing_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 10c530a30235ce16ca1f242f1741bf84
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 10c530a30235ce16ca1f242f1741bf84
     download_url:
       - https://dataverse.nl/api/access/datafile/46143
     media_type: image/nii
   - id: exthisdsver:./sub-018/func/sub-018_task-emotionProcessing_echo-2_bold.json
     byte_size: 1042
     checksum:
-      - algorithm: md5
-        digest: 9083871e42e383818f0153139602bcbe
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 9083871e42e383818f0153139602bcbe
     download_url:
       - https://dataverse.nl/api/access/datafile/46243
     media_type: application/json
   - id: exthisdsver:./sub-018/func/sub-018_task-emotionProcessing_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: e9fceab854c3d0cdbfc49f0ca87636a0
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e9fceab854c3d0cdbfc49f0ca87636a0
     download_url:
       - https://dataverse.nl/api/access/datafile/46498
     media_type: image/nii
   - id: exthisdsver:./sub-018/func/sub-018_task-emotionProcessing_echo-3_bold.json
     byte_size: 1042
     checksum:
-      - algorithm: md5
-        digest: 81812dbee74b11f9eb9ec34ed2267291
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 81812dbee74b11f9eb9ec34ed2267291
     download_url:
       - https://dataverse.nl/api/access/datafile/45295
     media_type: application/json
   - id: exthisdsver:./sub-018/func/sub-018_task-emotionProcessing_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: b1182ef00fe01573f3673946877fbdd4
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b1182ef00fe01573f3673946877fbdd4
     download_url:
       - https://dataverse.nl/api/access/datafile/45547
     media_type: image/nii
   - id: exthisdsver:./sub-018/func/sub-018_task-emotionProcessing_events.tsv.gz
     byte_size: 1936
     checksum:
-      - algorithm: md5
-        digest: 94ab76b693f38ad49ee5371a27ab6276
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 94ab76b693f38ad49ee5371a27ab6276
     download_url:
       - https://dataverse.nl/api/access/datafile/46558
     media_type: application/gzip
@@ -8197,8 +8197,8 @@ has_part:
       exthisdsver:./sub-018/func/sub-018_task-emotionProcessingImagined_echo-1_bold.json
     byte_size: 1051
     checksum:
-      - algorithm: md5
-        digest: 2160787763f6b9fbc2ae28d843f31279
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2160787763f6b9fbc2ae28d843f31279
     download_url:
       - https://dataverse.nl/api/access/datafile/46416
     media_type: application/json
@@ -8206,8 +8206,8 @@ has_part:
       exthisdsver:./sub-018/func/sub-018_task-emotionProcessingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 4df238d58b3bb698ce1be59503355897
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4df238d58b3bb698ce1be59503355897
     download_url:
       - https://dataverse.nl/api/access/datafile/45962
     media_type: image/nii
@@ -8215,8 +8215,8 @@ has_part:
       exthisdsver:./sub-018/func/sub-018_task-emotionProcessingImagined_echo-2_bold.json
     byte_size: 1051
     checksum:
-      - algorithm: md5
-        digest: 62d008dae0c8adfbe27eb46a087c4b8c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 62d008dae0c8adfbe27eb46a087c4b8c
     download_url:
       - https://dataverse.nl/api/access/datafile/45122
     media_type: application/json
@@ -8224,8 +8224,8 @@ has_part:
       exthisdsver:./sub-018/func/sub-018_task-emotionProcessingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 5a9413d4da22e50224287e8e96d41810
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5a9413d4da22e50224287e8e96d41810
     download_url:
       - https://dataverse.nl/api/access/datafile/46527
     media_type: image/nii
@@ -8233,8 +8233,8 @@ has_part:
       exthisdsver:./sub-018/func/sub-018_task-emotionProcessingImagined_echo-3_bold.json
     byte_size: 1051
     checksum:
-      - algorithm: md5
-        digest: c409998196cb9a5131a63402444232ac
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c409998196cb9a5131a63402444232ac
     download_url:
       - https://dataverse.nl/api/access/datafile/45774
     media_type: application/json
@@ -8242,328 +8242,328 @@ has_part:
       exthisdsver:./sub-018/func/sub-018_task-emotionProcessingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 6a73e734759a10f82ff828482fe2d084
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6a73e734759a10f82ff828482fe2d084
     download_url:
       - https://dataverse.nl/api/access/datafile/45101
     media_type: image/nii
   - id: exthisdsver:./sub-018/func/sub-018_task-emotionProcessingImagined_events.tsv.gz
     byte_size: 178
     checksum:
-      - algorithm: md5
-        digest: 743a87b2467a7337dfb6390668a1eee7
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 743a87b2467a7337dfb6390668a1eee7
     download_url:
       - https://dataverse.nl/api/access/datafile/46550
     media_type: application/gzip
   - id: exthisdsver:./sub-018/func/sub-018_task-emotionProcessingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: ec52dc6c7e742e9080a469c814e936e3
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ec52dc6c7e742e9080a469c814e936e3
     download_url:
       - https://dataverse.nl/api/access/datafile/45479
     media_type: application/json
   - id: exthisdsver:./sub-018/func/sub-018_task-emotionProcessingImagined_physio.tsv.gz
     byte_size: 477438
     checksum:
-      - algorithm: md5
-        digest: 9f32c8d0c82ebe7a4c7c2f3ed1964bb3
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 9f32c8d0c82ebe7a4c7c2f3ed1964bb3
     download_url:
       - https://dataverse.nl/api/access/datafile/45552
     media_type: application/gzip
   - id: exthisdsver:./sub-018/func/sub-018_task-emotionProcessing_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 2aafbcf919a4ecd3813d471678b194e8
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2aafbcf919a4ecd3813d471678b194e8
     download_url:
       - https://dataverse.nl/api/access/datafile/45173
     media_type: application/json
   - id: exthisdsver:./sub-018/func/sub-018_task-emotionProcessing_physio.tsv.gz
     byte_size: 643344
     checksum:
-      - algorithm: md5
-        digest: 4a6ecece2df4de53f22b90facf70accf
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4a6ecece2df4de53f22b90facf70accf
     download_url:
       - https://dataverse.nl/api/access/datafile/45703
     media_type: application/gzip
   - id: exthisdsver:./sub-018/func/sub-018_task-fingerTapping_echo-1_bold.json
     byte_size: 1039
     checksum:
-      - algorithm: md5
-        digest: e423c29e0444e827b1811bd8fd595528
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e423c29e0444e827b1811bd8fd595528
     download_url:
       - https://dataverse.nl/api/access/datafile/46195
     media_type: application/json
   - id: exthisdsver:./sub-018/func/sub-018_task-fingerTapping_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: f929fad9fa89daa7375f57c988e29302
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f929fad9fa89daa7375f57c988e29302
     download_url:
       - https://dataverse.nl/api/access/datafile/45261
     media_type: image/nii
   - id: exthisdsver:./sub-018/func/sub-018_task-fingerTapping_echo-2_bold.json
     byte_size: 1039
     checksum:
-      - algorithm: md5
-        digest: 861a3cd2e3a4fa2c191e262cabbbdef6
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 861a3cd2e3a4fa2c191e262cabbbdef6
     download_url:
       - https://dataverse.nl/api/access/datafile/45233
     media_type: application/json
   - id: exthisdsver:./sub-018/func/sub-018_task-fingerTapping_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 27c2135927b49179019bcf61804f45bf
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 27c2135927b49179019bcf61804f45bf
     download_url:
       - https://dataverse.nl/api/access/datafile/45747
     media_type: image/nii
   - id: exthisdsver:./sub-018/func/sub-018_task-fingerTapping_echo-3_bold.json
     byte_size: 1039
     checksum:
-      - algorithm: md5
-        digest: d1e95a770e7b00f4cf23bfeed927ae4f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d1e95a770e7b00f4cf23bfeed927ae4f
     download_url:
       - https://dataverse.nl/api/access/datafile/45409
     media_type: application/json
   - id: exthisdsver:./sub-018/func/sub-018_task-fingerTapping_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: b94d5b9fb36479ec1f67582d78d07229
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b94d5b9fb36479ec1f67582d78d07229
     download_url:
       - https://dataverse.nl/api/access/datafile/45302
     media_type: image/nii
   - id: exthisdsver:./sub-018/func/sub-018_task-fingerTapping_events.tsv.gz
     byte_size: 167
     checksum:
-      - algorithm: md5
-        digest: e0f507974252817e79c9fbe4879847f0
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e0f507974252817e79c9fbe4879847f0
     download_url:
       - https://dataverse.nl/api/access/datafile/46655
     media_type: application/gzip
   - id: exthisdsver:./sub-018/func/sub-018_task-fingerTappingImagined_echo-1_bold.json
     byte_size: 1047
     checksum:
-      - algorithm: md5
-        digest: ced4090a09793017f415eebed9b3bc01
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ced4090a09793017f415eebed9b3bc01
     download_url:
       - https://dataverse.nl/api/access/datafile/45428
     media_type: application/json
   - id: exthisdsver:./sub-018/func/sub-018_task-fingerTappingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: abf2229dc1c0186c3c24b9f198142407
+      - creator: spdx:checksumAlgorithm_md5
+        notation: abf2229dc1c0186c3c24b9f198142407
     download_url:
       - https://dataverse.nl/api/access/datafile/45188
     media_type: image/nii
   - id: exthisdsver:./sub-018/func/sub-018_task-fingerTappingImagined_echo-2_bold.json
     byte_size: 1047
     checksum:
-      - algorithm: md5
-        digest: 09962b2c547b21ae031f3e440bd2f60c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 09962b2c547b21ae031f3e440bd2f60c
     download_url:
       - https://dataverse.nl/api/access/datafile/45745
     media_type: application/json
   - id: exthisdsver:./sub-018/func/sub-018_task-fingerTappingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 4f3444ad5223f1996fbd107349c95486
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4f3444ad5223f1996fbd107349c95486
     download_url:
       - https://dataverse.nl/api/access/datafile/46038
     media_type: image/nii
   - id: exthisdsver:./sub-018/func/sub-018_task-fingerTappingImagined_echo-3_bold.json
     byte_size: 1047
     checksum:
-      - algorithm: md5
-        digest: 7bac8f37bec0dc4e0aab226b5edbf4c6
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 7bac8f37bec0dc4e0aab226b5edbf4c6
     download_url:
       - https://dataverse.nl/api/access/datafile/45426
     media_type: application/json
   - id: exthisdsver:./sub-018/func/sub-018_task-fingerTappingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 071183c6163bdbf82510bcee1592c3ff
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 071183c6163bdbf82510bcee1592c3ff
     download_url:
       - https://dataverse.nl/api/access/datafile/46069
     media_type: image/nii
   - id: exthisdsver:./sub-018/func/sub-018_task-fingerTappingImagined_events.tsv.gz
     byte_size: 179
     checksum:
-      - algorithm: md5
-        digest: a92cd802a259c806053f2408c3a9ced7
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a92cd802a259c806053f2408c3a9ced7
     download_url:
       - https://dataverse.nl/api/access/datafile/46602
     media_type: application/gzip
   - id: exthisdsver:./sub-018/func/sub-018_task-fingerTappingImagined_physio.json
     byte_size: 142
     checksum:
-      - algorithm: md5
-        digest: f8fba2227070030bfad34288122cfe9d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f8fba2227070030bfad34288122cfe9d
     download_url:
       - https://dataverse.nl/api/access/datafile/46138
     media_type: application/json
   - id: exthisdsver:./sub-018/func/sub-018_task-fingerTappingImagined_physio.tsv.gz
     byte_size: 474630
     checksum:
-      - algorithm: md5
-        digest: 743e580636625b4cd29911bdb803dda6
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 743e580636625b4cd29911bdb803dda6
     download_url:
       - https://dataverse.nl/api/access/datafile/46442
     media_type: application/gzip
   - id: exthisdsver:./sub-018/func/sub-018_task-fingerTapping_physio.json
     byte_size: 142
     checksum:
-      - algorithm: md5
-        digest: aec3e1ac31432db849b7b97677b140e4
+      - creator: spdx:checksumAlgorithm_md5
+        notation: aec3e1ac31432db849b7b97677b140e4
     download_url:
       - https://dataverse.nl/api/access/datafile/46322
     media_type: application/json
   - id: exthisdsver:./sub-018/func/sub-018_task-fingerTapping_physio.tsv.gz
     byte_size: 513523
     checksum:
-      - algorithm: md5
-        digest: bf9f8ed0e10c83d504f6b6ec5e565021
+      - creator: spdx:checksumAlgorithm_md5
+        notation: bf9f8ed0e10c83d504f6b6ec5e565021
     download_url:
       - https://dataverse.nl/api/access/datafile/45579
     media_type: application/gzip
   - id: exthisdsver:./sub-018/func/sub-018_task-rest_run-1_echo-1_bold.json
     byte_size: 1030
     checksum:
-      - algorithm: md5
-        digest: 582d335a6f1ff0292b253b6b7f7ac70f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 582d335a6f1ff0292b253b6b7f7ac70f
     download_url:
       - https://dataverse.nl/api/access/datafile/46263
     media_type: application/json
   - id: exthisdsver:./sub-018/func/sub-018_task-rest_run-1_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 65f53aa192dcf0cfdb39272e50b4cd41
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 65f53aa192dcf0cfdb39272e50b4cd41
     download_url:
       - https://dataverse.nl/api/access/datafile/45916
     media_type: image/nii
   - id: exthisdsver:./sub-018/func/sub-018_task-rest_run-1_echo-2_bold.json
     byte_size: 1030
     checksum:
-      - algorithm: md5
-        digest: 639e135352fd3dc65180f8741ddca7a5
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 639e135352fd3dc65180f8741ddca7a5
     download_url:
       - https://dataverse.nl/api/access/datafile/45923
     media_type: application/json
   - id: exthisdsver:./sub-018/func/sub-018_task-rest_run-1_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 34704cd69f8ffe219490b9b8ac489bee
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 34704cd69f8ffe219490b9b8ac489bee
     download_url:
       - https://dataverse.nl/api/access/datafile/45123
     media_type: image/nii
   - id: exthisdsver:./sub-018/func/sub-018_task-rest_run-1_echo-3_bold.json
     byte_size: 1030
     checksum:
-      - algorithm: md5
-        digest: fd5f69e655165421934afcb46d6d9ab7
+      - creator: spdx:checksumAlgorithm_md5
+        notation: fd5f69e655165421934afcb46d6d9ab7
     download_url:
       - https://dataverse.nl/api/access/datafile/46188
     media_type: application/json
   - id: exthisdsver:./sub-018/func/sub-018_task-rest_run-1_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 205ddb41c3fb0f6a75248fde2596ef9f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 205ddb41c3fb0f6a75248fde2596ef9f
     download_url:
       - https://dataverse.nl/api/access/datafile/46228
     media_type: image/nii
   - id: exthisdsver:./sub-018/func/sub-018_task-rest_run-1_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: fa48a2a92f511b5b2bf86f89eff447ea
+      - creator: spdx:checksumAlgorithm_md5
+        notation: fa48a2a92f511b5b2bf86f89eff447ea
     download_url:
       - https://dataverse.nl/api/access/datafile/46339
     media_type: application/json
   - id: exthisdsver:./sub-018/func/sub-018_task-rest_run-1_physio.tsv.gz
     byte_size: 456499
     checksum:
-      - algorithm: md5
-        digest: e6cd780a202753329df22e92906086ea
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e6cd780a202753329df22e92906086ea
     download_url:
       - https://dataverse.nl/api/access/datafile/45175
     media_type: application/gzip
   - id: exthisdsver:./sub-018/func/sub-018_task-rest_run-2_echo-1_bold.json
     byte_size: 1030
     checksum:
-      - algorithm: md5
-        digest: 9dd4558b268c0f1e51654984a9817602
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 9dd4558b268c0f1e51654984a9817602
     download_url:
       - https://dataverse.nl/api/access/datafile/45961
     media_type: application/json
   - id: exthisdsver:./sub-018/func/sub-018_task-rest_run-2_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: dbda73c0db2c05ab9afc6d3bd7145618
+      - creator: spdx:checksumAlgorithm_md5
+        notation: dbda73c0db2c05ab9afc6d3bd7145618
     download_url:
       - https://dataverse.nl/api/access/datafile/46513
     media_type: image/nii
   - id: exthisdsver:./sub-018/func/sub-018_task-rest_run-2_echo-2_bold.json
     byte_size: 1030
     checksum:
-      - algorithm: md5
-        digest: f1dca01b8dd106ea30e379432867b265
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f1dca01b8dd106ea30e379432867b265
     download_url:
       - https://dataverse.nl/api/access/datafile/45557
     media_type: application/json
   - id: exthisdsver:./sub-018/func/sub-018_task-rest_run-2_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 8dcf40fa74d8d71fb5d04eddae09f246
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8dcf40fa74d8d71fb5d04eddae09f246
     download_url:
       - https://dataverse.nl/api/access/datafile/45376
     media_type: image/nii
   - id: exthisdsver:./sub-018/func/sub-018_task-rest_run-2_echo-3_bold.json
     byte_size: 1030
     checksum:
-      - algorithm: md5
-        digest: 7f32563d7e6d8f41efba1a2f2ffe2484
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 7f32563d7e6d8f41efba1a2f2ffe2484
     download_url:
       - https://dataverse.nl/api/access/datafile/46365
     media_type: application/json
   - id: exthisdsver:./sub-018/func/sub-018_task-rest_run-2_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 28467ebfdcf77caaa83d407fe31c7464
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 28467ebfdcf77caaa83d407fe31c7464
     download_url:
       - https://dataverse.nl/api/access/datafile/46249
     media_type: image/nii
   - id: exthisdsver:./sub-018/func/sub-018_task-rest_run-2_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: fd2778d2800a21e39b4561327eecb5ce
+      - creator: spdx:checksumAlgorithm_md5
+        notation: fd2778d2800a21e39b4561327eecb5ce
     download_url:
       - https://dataverse.nl/api/access/datafile/45676
     media_type: application/json
   - id: exthisdsver:./sub-018/func/sub-018_task-rest_run-2_physio.tsv.gz
     byte_size: 462069
     checksum:
-      - algorithm: md5
-        digest: 2b4b5e1520eea448d3df546544a719e7
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2b4b5e1520eea448d3df546544a719e7
     download_url:
       - https://dataverse.nl/api/access/datafile/45199
     media_type: application/gzip
   - id: exthisdsver:./sub-019/anat/sub-019_T1w.nii
     byte_size: 20736352
     checksum:
-      - algorithm: md5
-        digest: 2f4fa393be40ddc00c27a138b5f7fd48
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2f4fa393be40ddc00c27a138b5f7fd48
     download_url:
       - https://dataverse.nl/api/access/datafile/46125
     media_type: image/nii
@@ -8580,8 +8580,8 @@ has_part:
   - id: exthisdsver:./sub-019/func/sub-019_task-emotionProcessing_echo-1_bold.json
     byte_size: 1038
     checksum:
-      - algorithm: md5
-        digest: 26489abd8ee555b1de70af69095875e5
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 26489abd8ee555b1de70af69095875e5
     download_url:
       - https://dataverse.nl/api/access/datafile/45859
     media_type: application/json
@@ -8700,48 +8700,48 @@ has_part:
   - id: exthisdsver:./sub-019/func/sub-019_task-emotionProcessing_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 6aa733780d6bf9addd4ea3d05ed51924
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6aa733780d6bf9addd4ea3d05ed51924
     download_url:
       - https://dataverse.nl/api/access/datafile/45112
     media_type: image/nii
   - id: exthisdsver:./sub-019/func/sub-019_task-emotionProcessing_echo-2_bold.json
     byte_size: 1038
     checksum:
-      - algorithm: md5
-        digest: 11c9a5133067418baba05651e4e6d53b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 11c9a5133067418baba05651e4e6d53b
     download_url:
       - https://dataverse.nl/api/access/datafile/46261
     media_type: application/json
   - id: exthisdsver:./sub-019/func/sub-019_task-emotionProcessing_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 1855f130ac422e998e659ac0386e8ede
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1855f130ac422e998e659ac0386e8ede
     download_url:
       - https://dataverse.nl/api/access/datafile/45769
     media_type: image/nii
   - id: exthisdsver:./sub-019/func/sub-019_task-emotionProcessing_echo-3_bold.json
     byte_size: 1038
     checksum:
-      - algorithm: md5
-        digest: d19eb8cedec51262e5eb75d2785fca6a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d19eb8cedec51262e5eb75d2785fca6a
     download_url:
       - https://dataverse.nl/api/access/datafile/45249
     media_type: application/json
   - id: exthisdsver:./sub-019/func/sub-019_task-emotionProcessing_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 08ca55e4d2fd91fc5b15a22b732938a3
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 08ca55e4d2fd91fc5b15a22b732938a3
     download_url:
       - https://dataverse.nl/api/access/datafile/45554
     media_type: image/nii
   - id: exthisdsver:./sub-019/func/sub-019_task-emotionProcessing_events.tsv.gz
     byte_size: 1857
     checksum:
-      - algorithm: md5
-        digest: bb5add688ff56a82bbca17a6eb55e7ca
+      - creator: spdx:checksumAlgorithm_md5
+        notation: bb5add688ff56a82bbca17a6eb55e7ca
     download_url:
       - https://dataverse.nl/api/access/datafile/46612
     media_type: application/gzip
@@ -8749,8 +8749,8 @@ has_part:
       exthisdsver:./sub-019/func/sub-019_task-emotionProcessingImagined_echo-1_bold.json
     byte_size: 1045
     checksum:
-      - algorithm: md5
-        digest: b1a3e5cb27a2636734ba18ce531d9248
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b1a3e5cb27a2636734ba18ce531d9248
     download_url:
       - https://dataverse.nl/api/access/datafile/45359
     media_type: application/json
@@ -8758,8 +8758,8 @@ has_part:
       exthisdsver:./sub-019/func/sub-019_task-emotionProcessingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: ee1d6e2cb43a658f018f3cee66691205
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ee1d6e2cb43a658f018f3cee66691205
     download_url:
       - https://dataverse.nl/api/access/datafile/45508
     media_type: image/nii
@@ -8767,8 +8767,8 @@ has_part:
       exthisdsver:./sub-019/func/sub-019_task-emotionProcessingImagined_echo-2_bold.json
     byte_size: 1045
     checksum:
-      - algorithm: md5
-        digest: cc8b80c64786026ecdb401d835b6c2ea
+      - creator: spdx:checksumAlgorithm_md5
+        notation: cc8b80c64786026ecdb401d835b6c2ea
     download_url:
       - https://dataverse.nl/api/access/datafile/46279
     media_type: application/json
@@ -8776,8 +8776,8 @@ has_part:
       exthisdsver:./sub-019/func/sub-019_task-emotionProcessingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 07e6633e94e0e6e104ed0b768a685d97
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 07e6633e94e0e6e104ed0b768a685d97
     download_url:
       - https://dataverse.nl/api/access/datafile/46117
     media_type: image/nii
@@ -8785,8 +8785,8 @@ has_part:
       exthisdsver:./sub-019/func/sub-019_task-emotionProcessingImagined_echo-3_bold.json
     byte_size: 1045
     checksum:
-      - algorithm: md5
-        digest: da2025294b29d05a04a3ce88334bb78e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: da2025294b29d05a04a3ce88334bb78e
     download_url:
       - https://dataverse.nl/api/access/datafile/45807
     media_type: application/json
@@ -8794,328 +8794,328 @@ has_part:
       exthisdsver:./sub-019/func/sub-019_task-emotionProcessingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 593b93faf187ed1529d0d67c70a52064
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 593b93faf187ed1529d0d67c70a52064
     download_url:
       - https://dataverse.nl/api/access/datafile/46076
     media_type: image/nii
   - id: exthisdsver:./sub-019/func/sub-019_task-emotionProcessingImagined_events.tsv.gz
     byte_size: 176
     checksum:
-      - algorithm: md5
-        digest: 189b63cfd0ed5265678518483743162c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 189b63cfd0ed5265678518483743162c
     download_url:
       - https://dataverse.nl/api/access/datafile/46583
     media_type: application/gzip
   - id: exthisdsver:./sub-019/func/sub-019_task-emotionProcessingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: af8c49a408751e4d2e1c7550ac3196ce
+      - creator: spdx:checksumAlgorithm_md5
+        notation: af8c49a408751e4d2e1c7550ac3196ce
     download_url:
       - https://dataverse.nl/api/access/datafile/45805
     media_type: application/json
   - id: exthisdsver:./sub-019/func/sub-019_task-emotionProcessingImagined_physio.tsv.gz
     byte_size: 474948
     checksum:
-      - algorithm: md5
-        digest: 247a7ecbb38fef53debe799b72e7064e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 247a7ecbb38fef53debe799b72e7064e
     download_url:
       - https://dataverse.nl/api/access/datafile/45276
     media_type: application/gzip
   - id: exthisdsver:./sub-019/func/sub-019_task-emotionProcessing_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 0b5cb7229e2fcbae77ef3ad2b2db8040
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 0b5cb7229e2fcbae77ef3ad2b2db8040
     download_url:
       - https://dataverse.nl/api/access/datafile/45225
     media_type: application/json
   - id: exthisdsver:./sub-019/func/sub-019_task-emotionProcessing_physio.tsv.gz
     byte_size: 494275
     checksum:
-      - algorithm: md5
-        digest: 3aa4c7b9e8339ac90a0e764c89ea6647
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 3aa4c7b9e8339ac90a0e764c89ea6647
     download_url:
       - https://dataverse.nl/api/access/datafile/45105
     media_type: application/gzip
   - id: exthisdsver:./sub-019/func/sub-019_task-fingerTapping_echo-1_bold.json
     byte_size: 1034
     checksum:
-      - algorithm: md5
-        digest: 3d01dda30aaba71344aaaa17e47b8e11
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 3d01dda30aaba71344aaaa17e47b8e11
     download_url:
       - https://dataverse.nl/api/access/datafile/45937
     media_type: application/json
   - id: exthisdsver:./sub-019/func/sub-019_task-fingerTapping_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: a770d3f9ca52e238a5c322eda9a483c3
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a770d3f9ca52e238a5c322eda9a483c3
     download_url:
       - https://dataverse.nl/api/access/datafile/46149
     media_type: image/nii
   - id: exthisdsver:./sub-019/func/sub-019_task-fingerTapping_echo-2_bold.json
     byte_size: 1034
     checksum:
-      - algorithm: md5
-        digest: 9270a115239c71322b2136225d1de014
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 9270a115239c71322b2136225d1de014
     download_url:
       - https://dataverse.nl/api/access/datafile/46475
     media_type: application/json
   - id: exthisdsver:./sub-019/func/sub-019_task-fingerTapping_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: ec9c3f2cded0b6462edf4727b4179bed
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ec9c3f2cded0b6462edf4727b4179bed
     download_url:
       - https://dataverse.nl/api/access/datafile/46411
     media_type: image/nii
   - id: exthisdsver:./sub-019/func/sub-019_task-fingerTapping_echo-3_bold.json
     byte_size: 1034
     checksum:
-      - algorithm: md5
-        digest: 04d5039942c6ecb2b4cd0b84f256b2a7
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 04d5039942c6ecb2b4cd0b84f256b2a7
     download_url:
       - https://dataverse.nl/api/access/datafile/45683
     media_type: application/json
   - id: exthisdsver:./sub-019/func/sub-019_task-fingerTapping_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 22d7379427b1021462add9190e53ebfc
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 22d7379427b1021462add9190e53ebfc
     download_url:
       - https://dataverse.nl/api/access/datafile/46358
     media_type: image/nii
   - id: exthisdsver:./sub-019/func/sub-019_task-fingerTapping_events.tsv.gz
     byte_size: 167
     checksum:
-      - algorithm: md5
-        digest: f1c6da5fca90a4d4da36d5cf97c31e2b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f1c6da5fca90a4d4da36d5cf97c31e2b
     download_url:
       - https://dataverse.nl/api/access/datafile/46560
     media_type: application/gzip
   - id: exthisdsver:./sub-019/func/sub-019_task-fingerTappingImagined_echo-1_bold.json
     byte_size: 1042
     checksum:
-      - algorithm: md5
-        digest: 2d252ae6f47238c8407e63b425e1a323
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2d252ae6f47238c8407e63b425e1a323
     download_url:
       - https://dataverse.nl/api/access/datafile/45742
     media_type: application/json
   - id: exthisdsver:./sub-019/func/sub-019_task-fingerTappingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: ffffccac3809ac8d3f344a8cdc59a967
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ffffccac3809ac8d3f344a8cdc59a967
     download_url:
       - https://dataverse.nl/api/access/datafile/45982
     media_type: image/nii
   - id: exthisdsver:./sub-019/func/sub-019_task-fingerTappingImagined_echo-2_bold.json
     byte_size: 1042
     checksum:
-      - algorithm: md5
-        digest: 72a4cd3573a708d5ececf2b51097c5a8
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 72a4cd3573a708d5ececf2b51097c5a8
     download_url:
       - https://dataverse.nl/api/access/datafile/46217
     media_type: application/json
   - id: exthisdsver:./sub-019/func/sub-019_task-fingerTappingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: f77f9150229dd232cc026c61a8f936b9
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f77f9150229dd232cc026c61a8f936b9
     download_url:
       - https://dataverse.nl/api/access/datafile/46457
     media_type: image/nii
   - id: exthisdsver:./sub-019/func/sub-019_task-fingerTappingImagined_echo-3_bold.json
     byte_size: 1042
     checksum:
-      - algorithm: md5
-        digest: 989b6c9e32ee328c74763545e14aa7ac
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 989b6c9e32ee328c74763545e14aa7ac
     download_url:
       - https://dataverse.nl/api/access/datafile/46472
     media_type: application/json
   - id: exthisdsver:./sub-019/func/sub-019_task-fingerTappingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: f4d329cb4f46502b98ca797d6efb821a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f4d329cb4f46502b98ca797d6efb821a
     download_url:
       - https://dataverse.nl/api/access/datafile/46383
     media_type: image/nii
   - id: exthisdsver:./sub-019/func/sub-019_task-fingerTappingImagined_events.tsv.gz
     byte_size: 179
     checksum:
-      - algorithm: md5
-        digest: e22a6384385779bfd07902623d084563
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e22a6384385779bfd07902623d084563
     download_url:
       - https://dataverse.nl/api/access/datafile/46609
     media_type: application/gzip
   - id: exthisdsver:./sub-019/func/sub-019_task-fingerTappingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: e5c279f326ee9a8d48e4fe532807129b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e5c279f326ee9a8d48e4fe532807129b
     download_url:
       - https://dataverse.nl/api/access/datafile/45197
     media_type: application/json
   - id: exthisdsver:./sub-019/func/sub-019_task-fingerTappingImagined_physio.tsv.gz
     byte_size: 470533
     checksum:
-      - algorithm: md5
-        digest: 63e7ec079d0b86765b16405bca76eaa7
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 63e7ec079d0b86765b16405bca76eaa7
     download_url:
       - https://dataverse.nl/api/access/datafile/45525
     media_type: application/gzip
   - id: exthisdsver:./sub-019/func/sub-019_task-fingerTapping_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 3eee13807fa200e7c94d7241dd26cd7a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 3eee13807fa200e7c94d7241dd26cd7a
     download_url:
       - https://dataverse.nl/api/access/datafile/45960
     media_type: application/json
   - id: exthisdsver:./sub-019/func/sub-019_task-fingerTapping_physio.tsv.gz
     byte_size: 519192
     checksum:
-      - algorithm: md5
-        digest: ca4c0bbbb035517432413a9cbb5187cd
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ca4c0bbbb035517432413a9cbb5187cd
     download_url:
       - https://dataverse.nl/api/access/datafile/45252
     media_type: application/gzip
   - id: exthisdsver:./sub-019/func/sub-019_task-rest_run-1_echo-1_bold.json
     byte_size: 1023
     checksum:
-      - algorithm: md5
-        digest: a0365d0d70eef29defbe1518c75efaf8
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a0365d0d70eef29defbe1518c75efaf8
     download_url:
       - https://dataverse.nl/api/access/datafile/46510
     media_type: application/json
   - id: exthisdsver:./sub-019/func/sub-019_task-rest_run-1_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: b3db2bf6ef1925eb2d0602e3318f5a3a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b3db2bf6ef1925eb2d0602e3318f5a3a
     download_url:
       - https://dataverse.nl/api/access/datafile/45764
     media_type: image/nii
   - id: exthisdsver:./sub-019/func/sub-019_task-rest_run-1_echo-2_bold.json
     byte_size: 1023
     checksum:
-      - algorithm: md5
-        digest: ea41f1b42f6ccca0ba65174f3b2e3b6b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ea41f1b42f6ccca0ba65174f3b2e3b6b
     download_url:
       - https://dataverse.nl/api/access/datafile/45777
     media_type: application/json
   - id: exthisdsver:./sub-019/func/sub-019_task-rest_run-1_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: ed3231b108f5e7ad6749f2c8eef91cea
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ed3231b108f5e7ad6749f2c8eef91cea
     download_url:
       - https://dataverse.nl/api/access/datafile/45346
     media_type: image/nii
   - id: exthisdsver:./sub-019/func/sub-019_task-rest_run-1_echo-3_bold.json
     byte_size: 1023
     checksum:
-      - algorithm: md5
-        digest: 70a500bab6e0571167acf5378e335e0a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 70a500bab6e0571167acf5378e335e0a
     download_url:
       - https://dataverse.nl/api/access/datafile/45907
     media_type: application/json
   - id: exthisdsver:./sub-019/func/sub-019_task-rest_run-1_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 754b73d4ff587d8bcd246fbb26e1fe83
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 754b73d4ff587d8bcd246fbb26e1fe83
     download_url:
       - https://dataverse.nl/api/access/datafile/45616
     media_type: image/nii
   - id: exthisdsver:./sub-019/func/sub-019_task-rest_run-1_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 276ce10bff283ab4d57782e8992d4593
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 276ce10bff283ab4d57782e8992d4593
     download_url:
       - https://dataverse.nl/api/access/datafile/46400
     media_type: application/json
   - id: exthisdsver:./sub-019/func/sub-019_task-rest_run-1_physio.tsv.gz
     byte_size: 468658
     checksum:
-      - algorithm: md5
-        digest: 515d8d65fbe994cfb276173666c5d084
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 515d8d65fbe994cfb276173666c5d084
     download_url:
       - https://dataverse.nl/api/access/datafile/46079
     media_type: application/gzip
   - id: exthisdsver:./sub-019/func/sub-019_task-rest_run-2_echo-1_bold.json
     byte_size: 1025
     checksum:
-      - algorithm: md5
-        digest: ccea34f1f7872ae7188e375f7909c8d0
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ccea34f1f7872ae7188e375f7909c8d0
     download_url:
       - https://dataverse.nl/api/access/datafile/46386
     media_type: application/json
   - id: exthisdsver:./sub-019/func/sub-019_task-rest_run-2_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 89d7c2abf06fc026ad7dd36eb852748b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 89d7c2abf06fc026ad7dd36eb852748b
     download_url:
       - https://dataverse.nl/api/access/datafile/45866
     media_type: image/nii
   - id: exthisdsver:./sub-019/func/sub-019_task-rest_run-2_echo-2_bold.json
     byte_size: 1025
     checksum:
-      - algorithm: md5
-        digest: cbfd7780f899b213b810417dab5bfed5
+      - creator: spdx:checksumAlgorithm_md5
+        notation: cbfd7780f899b213b810417dab5bfed5
     download_url:
       - https://dataverse.nl/api/access/datafile/45680
     media_type: application/json
   - id: exthisdsver:./sub-019/func/sub-019_task-rest_run-2_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 4c5cee193ed25e8927d349759c4390bd
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4c5cee193ed25e8927d349759c4390bd
     download_url:
       - https://dataverse.nl/api/access/datafile/45378
     media_type: image/nii
   - id: exthisdsver:./sub-019/func/sub-019_task-rest_run-2_echo-3_bold.json
     byte_size: 1025
     checksum:
-      - algorithm: md5
-        digest: fbc01f613cb706a07b5bd20a965962c5
+      - creator: spdx:checksumAlgorithm_md5
+        notation: fbc01f613cb706a07b5bd20a965962c5
     download_url:
       - https://dataverse.nl/api/access/datafile/45828
     media_type: application/json
   - id: exthisdsver:./sub-019/func/sub-019_task-rest_run-2_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 311ff32bb975770b4f8f5c822c4330cc
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 311ff32bb975770b4f8f5c822c4330cc
     download_url:
       - https://dataverse.nl/api/access/datafile/46153
     media_type: image/nii
   - id: exthisdsver:./sub-019/func/sub-019_task-rest_run-2_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 37c77f3c79b7551b8e19f42a7db9ea8d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 37c77f3c79b7551b8e19f42a7db9ea8d
     download_url:
       - https://dataverse.nl/api/access/datafile/45966
     media_type: application/json
   - id: exthisdsver:./sub-019/func/sub-019_task-rest_run-2_physio.tsv.gz
     byte_size: 467073
     checksum:
-      - algorithm: md5
-        digest: 5633574342d8f03a72e934625fa9201c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5633574342d8f03a72e934625fa9201c
     download_url:
       - https://dataverse.nl/api/access/datafile/45497
     media_type: application/gzip
   - id: exthisdsver:./sub-020/anat/sub-020_T1w.nii
     byte_size: 20736352
     checksum:
-      - algorithm: md5
-        digest: 2031bfb21864f6e06400b510b8203044
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2031bfb21864f6e06400b510b8203044
     download_url:
       - https://dataverse.nl/api/access/datafile/45619
     media_type: image/nii
@@ -9132,8 +9132,8 @@ has_part:
   - id: exthisdsver:./sub-020/func/sub-020_task-emotionProcessing_echo-1_bold.json
     byte_size: 1041
     checksum:
-      - algorithm: md5
-        digest: af9d9451739f64a0f22ff1b30a3fa978
+      - creator: spdx:checksumAlgorithm_md5
+        notation: af9d9451739f64a0f22ff1b30a3fa978
     download_url:
       - https://dataverse.nl/api/access/datafile/45324
     media_type: application/json
@@ -9252,48 +9252,48 @@ has_part:
   - id: exthisdsver:./sub-020/func/sub-020_task-emotionProcessing_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: a9236393e1e47f0b93eec303465128cb
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a9236393e1e47f0b93eec303465128cb
     download_url:
       - https://dataverse.nl/api/access/datafile/46100
     media_type: image/nii
   - id: exthisdsver:./sub-020/func/sub-020_task-emotionProcessing_echo-2_bold.json
     byte_size: 1041
     checksum:
-      - algorithm: md5
-        digest: 68a0cc41e95d67371eaaea84c0dbc4a6
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 68a0cc41e95d67371eaaea84c0dbc4a6
     download_url:
       - https://dataverse.nl/api/access/datafile/46423
     media_type: application/json
   - id: exthisdsver:./sub-020/func/sub-020_task-emotionProcessing_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: a773cd7727a540c59e6f360646037c27
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a773cd7727a540c59e6f360646037c27
     download_url:
       - https://dataverse.nl/api/access/datafile/45677
     media_type: image/nii
   - id: exthisdsver:./sub-020/func/sub-020_task-emotionProcessing_echo-3_bold.json
     byte_size: 1041
     checksum:
-      - algorithm: md5
-        digest: 6bc691ba3a1cdd343b8f316e59f79f0f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6bc691ba3a1cdd343b8f316e59f79f0f
     download_url:
       - https://dataverse.nl/api/access/datafile/46257
     media_type: application/json
   - id: exthisdsver:./sub-020/func/sub-020_task-emotionProcessing_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 4f896fe9c393d710e40dcea762abfb29
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4f896fe9c393d710e40dcea762abfb29
     download_url:
       - https://dataverse.nl/api/access/datafile/45780
     media_type: image/nii
   - id: exthisdsver:./sub-020/func/sub-020_task-emotionProcessing_events.tsv.gz
     byte_size: 1895
     checksum:
-      - algorithm: md5
-        digest: 18d24a490dfd820a1fb7b01308a7ac6f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 18d24a490dfd820a1fb7b01308a7ac6f
     download_url:
       - https://dataverse.nl/api/access/datafile/46636
     media_type: application/gzip
@@ -9301,8 +9301,8 @@ has_part:
       exthisdsver:./sub-020/func/sub-020_task-emotionProcessingImagined_echo-1_bold.json
     byte_size: 1049
     checksum:
-      - algorithm: md5
-        digest: 7043bbbcd78adf0cc7baf6dad05d43d6
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 7043bbbcd78adf0cc7baf6dad05d43d6
     download_url:
       - https://dataverse.nl/api/access/datafile/46316
     media_type: application/json
@@ -9310,8 +9310,8 @@ has_part:
       exthisdsver:./sub-020/func/sub-020_task-emotionProcessingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 7fab3783b35f2a4965cf7b92cabcf99c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 7fab3783b35f2a4965cf7b92cabcf99c
     download_url:
       - https://dataverse.nl/api/access/datafile/45654
     media_type: image/nii
@@ -9319,8 +9319,8 @@ has_part:
       exthisdsver:./sub-020/func/sub-020_task-emotionProcessingImagined_echo-2_bold.json
     byte_size: 1049
     checksum:
-      - algorithm: md5
-        digest: 9696bd7cb2254077b09d1a659e634eef
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 9696bd7cb2254077b09d1a659e634eef
     download_url:
       - https://dataverse.nl/api/access/datafile/46252
     media_type: application/json
@@ -9328,8 +9328,8 @@ has_part:
       exthisdsver:./sub-020/func/sub-020_task-emotionProcessingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 2f9286f8332bf92a2491e5ff12ef4680
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2f9286f8332bf92a2491e5ff12ef4680
     download_url:
       - https://dataverse.nl/api/access/datafile/45835
     media_type: image/nii
@@ -9337,8 +9337,8 @@ has_part:
       exthisdsver:./sub-020/func/sub-020_task-emotionProcessingImagined_echo-3_bold.json
     byte_size: 1049
     checksum:
-      - algorithm: md5
-        digest: 71d6b2d68cace2c79dda7774f55df7ec
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 71d6b2d68cace2c79dda7774f55df7ec
     download_url:
       - https://dataverse.nl/api/access/datafile/46205
     media_type: application/json
@@ -9346,328 +9346,328 @@ has_part:
       exthisdsver:./sub-020/func/sub-020_task-emotionProcessingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: cf5c63c15cab2821cecf8856c4e2ef25
+      - creator: spdx:checksumAlgorithm_md5
+        notation: cf5c63c15cab2821cecf8856c4e2ef25
     download_url:
       - https://dataverse.nl/api/access/datafile/46070
     media_type: image/nii
   - id: exthisdsver:./sub-020/func/sub-020_task-emotionProcessingImagined_events.tsv.gz
     byte_size: 178
     checksum:
-      - algorithm: md5
-        digest: b3077b1bd8ce0512419d6284e37f40c6
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b3077b1bd8ce0512419d6284e37f40c6
     download_url:
       - https://dataverse.nl/api/access/datafile/46567
     media_type: application/gzip
   - id: exthisdsver:./sub-020/func/sub-020_task-emotionProcessingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 0bf96f9d17dae1e39fe5c65b0e55ed9d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 0bf96f9d17dae1e39fe5c65b0e55ed9d
     download_url:
       - https://dataverse.nl/api/access/datafile/46191
     media_type: application/json
   - id: exthisdsver:./sub-020/func/sub-020_task-emotionProcessingImagined_physio.tsv.gz
     byte_size: 456047
     checksum:
-      - algorithm: md5
-        digest: 5d0319f59b05a52823b0c79e79eb8a52
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5d0319f59b05a52823b0c79e79eb8a52
     download_url:
       - https://dataverse.nl/api/access/datafile/45968
     media_type: application/gzip
   - id: exthisdsver:./sub-020/func/sub-020_task-emotionProcessing_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 4788b62f42bca229f416979a1a70f3af
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4788b62f42bca229f416979a1a70f3af
     download_url:
       - https://dataverse.nl/api/access/datafile/45696
     media_type: application/json
   - id: exthisdsver:./sub-020/func/sub-020_task-emotionProcessing_physio.tsv.gz
     byte_size: 480332
     checksum:
-      - algorithm: md5
-        digest: 37f51d06e4000f7cead83073bdb49c90
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 37f51d06e4000f7cead83073bdb49c90
     download_url:
       - https://dataverse.nl/api/access/datafile/45632
     media_type: application/gzip
   - id: exthisdsver:./sub-020/func/sub-020_task-fingerTapping_echo-1_bold.json
     byte_size: 1036
     checksum:
-      - algorithm: md5
-        digest: 91e9a2070f99e72c49bdd5f067cad2c0
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 91e9a2070f99e72c49bdd5f067cad2c0
     download_url:
       - https://dataverse.nl/api/access/datafile/45417
     media_type: application/json
   - id: exthisdsver:./sub-020/func/sub-020_task-fingerTapping_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 2b3c91a743b6a6e4c5a0e74389ec45a1
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2b3c91a743b6a6e4c5a0e74389ec45a1
     download_url:
       - https://dataverse.nl/api/access/datafile/45394
     media_type: image/nii
   - id: exthisdsver:./sub-020/func/sub-020_task-fingerTapping_echo-2_bold.json
     byte_size: 1036
     checksum:
-      - algorithm: md5
-        digest: 299e79b9c488c38b8708d86e1ad3ea54
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 299e79b9c488c38b8708d86e1ad3ea54
     download_url:
       - https://dataverse.nl/api/access/datafile/45776
     media_type: application/json
   - id: exthisdsver:./sub-020/func/sub-020_task-fingerTapping_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 47a984ac1c5b613e9a2d280ed1dfd925
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 47a984ac1c5b613e9a2d280ed1dfd925
     download_url:
       - https://dataverse.nl/api/access/datafile/46305
     media_type: image/nii
   - id: exthisdsver:./sub-020/func/sub-020_task-fingerTapping_echo-3_bold.json
     byte_size: 1036
     checksum:
-      - algorithm: md5
-        digest: b68ebef9beb3d443a8cda33c81eed151
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b68ebef9beb3d443a8cda33c81eed151
     download_url:
       - https://dataverse.nl/api/access/datafile/45734
     media_type: application/json
   - id: exthisdsver:./sub-020/func/sub-020_task-fingerTapping_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 66ea37e8bb1555d1624e3a4e6a01ae64
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 66ea37e8bb1555d1624e3a4e6a01ae64
     download_url:
       - https://dataverse.nl/api/access/datafile/45725
     media_type: image/nii
   - id: exthisdsver:./sub-020/func/sub-020_task-fingerTapping_events.tsv.gz
     byte_size: 167
     checksum:
-      - algorithm: md5
-        digest: 470665491f9f9cc008c64311d0907b0f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 470665491f9f9cc008c64311d0907b0f
     download_url:
       - https://dataverse.nl/api/access/datafile/46563
     media_type: application/gzip
   - id: exthisdsver:./sub-020/func/sub-020_task-fingerTappingImagined_echo-1_bold.json
     byte_size: 1045
     checksum:
-      - algorithm: md5
-        digest: fc7a4059aa5d62bc93ef8a2d4af7bfbd
+      - creator: spdx:checksumAlgorithm_md5
+        notation: fc7a4059aa5d62bc93ef8a2d4af7bfbd
     download_url:
       - https://dataverse.nl/api/access/datafile/45148
     media_type: application/json
   - id: exthisdsver:./sub-020/func/sub-020_task-fingerTappingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: b62010362a3182366cf429f65aca268b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b62010362a3182366cf429f65aca268b
     download_url:
       - https://dataverse.nl/api/access/datafile/46360
     media_type: image/nii
   - id: exthisdsver:./sub-020/func/sub-020_task-fingerTappingImagined_echo-2_bold.json
     byte_size: 1045
     checksum:
-      - algorithm: md5
-        digest: b00ce22e507a1ef0de51435b0fc675b5
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b00ce22e507a1ef0de51435b0fc675b5
     download_url:
       - https://dataverse.nl/api/access/datafile/45536
     media_type: application/json
   - id: exthisdsver:./sub-020/func/sub-020_task-fingerTappingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 624d93602e8bdaa6b373a2851910dc7e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 624d93602e8bdaa6b373a2851910dc7e
     download_url:
       - https://dataverse.nl/api/access/datafile/45623
     media_type: image/nii
   - id: exthisdsver:./sub-020/func/sub-020_task-fingerTappingImagined_echo-3_bold.json
     byte_size: 1045
     checksum:
-      - algorithm: md5
-        digest: d497cf246c43221189d05e659d07387e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d497cf246c43221189d05e659d07387e
     download_url:
       - https://dataverse.nl/api/access/datafile/45936
     media_type: application/json
   - id: exthisdsver:./sub-020/func/sub-020_task-fingerTappingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 7f78ecccca242d27e608a4f7e5e6f716
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 7f78ecccca242d27e608a4f7e5e6f716
     download_url:
       - https://dataverse.nl/api/access/datafile/45643
     media_type: image/nii
   - id: exthisdsver:./sub-020/func/sub-020_task-fingerTappingImagined_events.tsv.gz
     byte_size: 179
     checksum:
-      - algorithm: md5
-        digest: 31ca847b21f8e14a7dd11e8bb92d56d4
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 31ca847b21f8e14a7dd11e8bb92d56d4
     download_url:
       - https://dataverse.nl/api/access/datafile/46650
     media_type: application/gzip
   - id: exthisdsver:./sub-020/func/sub-020_task-fingerTappingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 49b4f774348322000298d4f1fa57434b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 49b4f774348322000298d4f1fa57434b
     download_url:
       - https://dataverse.nl/api/access/datafile/45559
     media_type: application/json
   - id: exthisdsver:./sub-020/func/sub-020_task-fingerTappingImagined_physio.tsv.gz
     byte_size: 460768
     checksum:
-      - algorithm: md5
-        digest: 1268aae9d99d26faa2e0d0eb7cd9848e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1268aae9d99d26faa2e0d0eb7cd9848e
     download_url:
       - https://dataverse.nl/api/access/datafile/45600
     media_type: application/gzip
   - id: exthisdsver:./sub-020/func/sub-020_task-fingerTapping_physio.json
     byte_size: 142
     checksum:
-      - algorithm: md5
-        digest: 6993ca98abbb4f4d0d8e666b7eb31d6f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6993ca98abbb4f4d0d8e666b7eb31d6f
     download_url:
       - https://dataverse.nl/api/access/datafile/45455
     media_type: application/json
   - id: exthisdsver:./sub-020/func/sub-020_task-fingerTapping_physio.tsv.gz
     byte_size: 464906
     checksum:
-      - algorithm: md5
-        digest: ac252b88b9d7469952d7d62b7a53bc76
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ac252b88b9d7469952d7d62b7a53bc76
     download_url:
       - https://dataverse.nl/api/access/datafile/45450
     media_type: application/gzip
   - id: exthisdsver:./sub-020/func/sub-020_task-rest_run-1_echo-1_bold.json
     byte_size: 1028
     checksum:
-      - algorithm: md5
-        digest: ae71582204caffee278155a68df35674
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ae71582204caffee278155a68df35674
     download_url:
       - https://dataverse.nl/api/access/datafile/46544
     media_type: application/json
   - id: exthisdsver:./sub-020/func/sub-020_task-rest_run-1_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: ba087d91bd1df4b312360e0a4923fea2
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ba087d91bd1df4b312360e0a4923fea2
     download_url:
       - https://dataverse.nl/api/access/datafile/45170
     media_type: image/nii
   - id: exthisdsver:./sub-020/func/sub-020_task-rest_run-1_echo-2_bold.json
     byte_size: 1028
     checksum:
-      - algorithm: md5
-        digest: 98d7f873c7cebfb8da8498c9e97b2810
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 98d7f873c7cebfb8da8498c9e97b2810
     download_url:
       - https://dataverse.nl/api/access/datafile/45400
     media_type: application/json
   - id: exthisdsver:./sub-020/func/sub-020_task-rest_run-1_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 92b3f5ebc3d4f75af4fe5bf9b179f77f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 92b3f5ebc3d4f75af4fe5bf9b179f77f
     download_url:
       - https://dataverse.nl/api/access/datafile/45385
     media_type: image/nii
   - id: exthisdsver:./sub-020/func/sub-020_task-rest_run-1_echo-3_bold.json
     byte_size: 1028
     checksum:
-      - algorithm: md5
-        digest: 5c3f69bccff20a48110b0e530030dfa9
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5c3f69bccff20a48110b0e530030dfa9
     download_url:
       - https://dataverse.nl/api/access/datafile/45640
     media_type: application/json
   - id: exthisdsver:./sub-020/func/sub-020_task-rest_run-1_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 8763f410a5a6a7dd1cfdf98f04b3d97b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8763f410a5a6a7dd1cfdf98f04b3d97b
     download_url:
       - https://dataverse.nl/api/access/datafile/45882
     media_type: image/nii
   - id: exthisdsver:./sub-020/func/sub-020_task-rest_run-1_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 30032943c7e6d421b524177d8a1afcfa
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 30032943c7e6d421b524177d8a1afcfa
     download_url:
       - https://dataverse.nl/api/access/datafile/45333
     media_type: application/json
   - id: exthisdsver:./sub-020/func/sub-020_task-rest_run-1_physio.tsv.gz
     byte_size: 462284
     checksum:
-      - algorithm: md5
-        digest: c9cd7dd79bc049e4aca8997874ad5c3d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c9cd7dd79bc049e4aca8997874ad5c3d
     download_url:
       - https://dataverse.nl/api/access/datafile/45693
     media_type: application/gzip
   - id: exthisdsver:./sub-020/func/sub-020_task-rest_run-2_echo-1_bold.json
     byte_size: 1026
     checksum:
-      - algorithm: md5
-        digest: e117073f0b47f4dcbd4cc1765c1aa582
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e117073f0b47f4dcbd4cc1765c1aa582
     download_url:
       - https://dataverse.nl/api/access/datafile/45504
     media_type: application/json
   - id: exthisdsver:./sub-020/func/sub-020_task-rest_run-2_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: fb48a6a4aa6665b6908666ca166fa950
+      - creator: spdx:checksumAlgorithm_md5
+        notation: fb48a6a4aa6665b6908666ca166fa950
     download_url:
       - https://dataverse.nl/api/access/datafile/45947
     media_type: image/nii
   - id: exthisdsver:./sub-020/func/sub-020_task-rest_run-2_echo-2_bold.json
     byte_size: 1026
     checksum:
-      - algorithm: md5
-        digest: 4db99ba729989081c0a195bfbf1ee245
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4db99ba729989081c0a195bfbf1ee245
     download_url:
       - https://dataverse.nl/api/access/datafile/46152
     media_type: application/json
   - id: exthisdsver:./sub-020/func/sub-020_task-rest_run-2_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 4e4e116169a7258dfc095073ce0079c3
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4e4e116169a7258dfc095073ce0079c3
     download_url:
       - https://dataverse.nl/api/access/datafile/46278
     media_type: image/nii
   - id: exthisdsver:./sub-020/func/sub-020_task-rest_run-2_echo-3_bold.json
     byte_size: 1026
     checksum:
-      - algorithm: md5
-        digest: bc6d8b1879a42ca35c758b7a0299916a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: bc6d8b1879a42ca35c758b7a0299916a
     download_url:
       - https://dataverse.nl/api/access/datafile/45892
     media_type: application/json
   - id: exthisdsver:./sub-020/func/sub-020_task-rest_run-2_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 997be2b101d7cd226bac1edc5af3cd09
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 997be2b101d7cd226bac1edc5af3cd09
     download_url:
       - https://dataverse.nl/api/access/datafile/46404
     media_type: image/nii
   - id: exthisdsver:./sub-020/func/sub-020_task-rest_run-2_physio.json
     byte_size: 142
     checksum:
-      - algorithm: md5
-        digest: 3dc97a367484e8ab554c66df31b45fe8
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 3dc97a367484e8ab554c66df31b45fe8
     download_url:
       - https://dataverse.nl/api/access/datafile/46174
     media_type: application/json
   - id: exthisdsver:./sub-020/func/sub-020_task-rest_run-2_physio.tsv.gz
     byte_size: 457579
     checksum:
-      - algorithm: md5
-        digest: e1aed881353ca29400e6a2190ced6f91
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e1aed881353ca29400e6a2190ced6f91
     download_url:
       - https://dataverse.nl/api/access/datafile/45516
     media_type: application/gzip
   - id: exthisdsver:./sub-021/anat/sub-021_T1w.nii
     byte_size: 20736352
     checksum:
-      - algorithm: md5
-        digest: 9591a73ee0d16e4b489af21b1bb91e05
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 9591a73ee0d16e4b489af21b1bb91e05
     download_url:
       - https://dataverse.nl/api/access/datafile/45858
     media_type: image/nii
@@ -9684,8 +9684,8 @@ has_part:
   - id: exthisdsver:./sub-021/func/sub-021_task-emotionProcessing_echo-1_bold.json
     byte_size: 1040
     checksum:
-      - algorithm: md5
-        digest: d0023eb081b190e3c8fc0dd8509bb0f9
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d0023eb081b190e3c8fc0dd8509bb0f9
     download_url:
       - https://dataverse.nl/api/access/datafile/45268
     media_type: application/json
@@ -9804,48 +9804,48 @@ has_part:
   - id: exthisdsver:./sub-021/func/sub-021_task-emotionProcessing_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 57d9a3bf07cfe88fe10de40a8b4032d3
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 57d9a3bf07cfe88fe10de40a8b4032d3
     download_url:
       - https://dataverse.nl/api/access/datafile/45587
     media_type: image/nii
   - id: exthisdsver:./sub-021/func/sub-021_task-emotionProcessing_echo-2_bold.json
     byte_size: 1040
     checksum:
-      - algorithm: md5
-        digest: 645130bfc1161abba0de6ae3f3f4e6c9
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 645130bfc1161abba0de6ae3f3f4e6c9
     download_url:
       - https://dataverse.nl/api/access/datafile/45307
     media_type: application/json
   - id: exthisdsver:./sub-021/func/sub-021_task-emotionProcessing_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 8c0b8a19e338f222d0ce0ca1fda9588e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8c0b8a19e338f222d0ce0ca1fda9588e
     download_url:
       - https://dataverse.nl/api/access/datafile/45761
     media_type: image/nii
   - id: exthisdsver:./sub-021/func/sub-021_task-emotionProcessing_echo-3_bold.json
     byte_size: 1040
     checksum:
-      - algorithm: md5
-        digest: debb30a678f8fe0afecf0266d2bf6adf
+      - creator: spdx:checksumAlgorithm_md5
+        notation: debb30a678f8fe0afecf0266d2bf6adf
     download_url:
       - https://dataverse.nl/api/access/datafile/46479
     media_type: application/json
   - id: exthisdsver:./sub-021/func/sub-021_task-emotionProcessing_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 5cd16353333566365b09a317b6fa8f4d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5cd16353333566365b09a317b6fa8f4d
     download_url:
       - https://dataverse.nl/api/access/datafile/46112
     media_type: image/nii
   - id: exthisdsver:./sub-021/func/sub-021_task-emotionProcessing_events.tsv.gz
     byte_size: 1938
     checksum:
-      - algorithm: md5
-        digest: 759a80d55b3aa2f2796f5a25790bf290
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 759a80d55b3aa2f2796f5a25790bf290
     download_url:
       - https://dataverse.nl/api/access/datafile/46616
     media_type: application/gzip
@@ -9853,8 +9853,8 @@ has_part:
       exthisdsver:./sub-021/func/sub-021_task-emotionProcessingImagined_echo-1_bold.json
     byte_size: 1048
     checksum:
-      - algorithm: md5
-        digest: a152a08f2e48f0b7b5cc243f7cc26f53
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a152a08f2e48f0b7b5cc243f7cc26f53
     download_url:
       - https://dataverse.nl/api/access/datafile/45414
     media_type: application/json
@@ -9862,8 +9862,8 @@ has_part:
       exthisdsver:./sub-021/func/sub-021_task-emotionProcessingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 1b82e698e524c8dcaa6b9e6bea44b1ca
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1b82e698e524c8dcaa6b9e6bea44b1ca
     download_url:
       - https://dataverse.nl/api/access/datafile/45569
     media_type: image/nii
@@ -9871,8 +9871,8 @@ has_part:
       exthisdsver:./sub-021/func/sub-021_task-emotionProcessingImagined_echo-2_bold.json
     byte_size: 1048
     checksum:
-      - algorithm: md5
-        digest: 873d7d8d93c7c346f8f4f598cc4e15c0
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 873d7d8d93c7c346f8f4f598cc4e15c0
     download_url:
       - https://dataverse.nl/api/access/datafile/46459
     media_type: application/json
@@ -9880,8 +9880,8 @@ has_part:
       exthisdsver:./sub-021/func/sub-021_task-emotionProcessingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 351d54c39476a6491885442fc63604ef
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 351d54c39476a6491885442fc63604ef
     download_url:
       - https://dataverse.nl/api/access/datafile/46246
     media_type: image/nii
@@ -9889,8 +9889,8 @@ has_part:
       exthisdsver:./sub-021/func/sub-021_task-emotionProcessingImagined_echo-3_bold.json
     byte_size: 1048
     checksum:
-      - algorithm: md5
-        digest: 89f70975ea2771e0ed50e8ea9720d55e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 89f70975ea2771e0ed50e8ea9720d55e
     download_url:
       - https://dataverse.nl/api/access/datafile/46418
     media_type: application/json
@@ -9898,328 +9898,328 @@ has_part:
       exthisdsver:./sub-021/func/sub-021_task-emotionProcessingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 8db1f89aba4a97bd203e827e4044318b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8db1f89aba4a97bd203e827e4044318b
     download_url:
       - https://dataverse.nl/api/access/datafile/46399
     media_type: image/nii
   - id: exthisdsver:./sub-021/func/sub-021_task-emotionProcessingImagined_events.tsv.gz
     byte_size: 173
     checksum:
-      - algorithm: md5
-        digest: 67ed2f653f579202ed7340435c6ab73b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 67ed2f653f579202ed7340435c6ab73b
     download_url:
       - https://dataverse.nl/api/access/datafile/46575
     media_type: application/gzip
   - id: exthisdsver:./sub-021/func/sub-021_task-emotionProcessingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 4e10497094e60af65c678efe3925d47b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4e10497094e60af65c678efe3925d47b
     download_url:
       - https://dataverse.nl/api/access/datafile/46525
     media_type: application/json
   - id: exthisdsver:./sub-021/func/sub-021_task-emotionProcessingImagined_physio.tsv.gz
     byte_size: 481794
     checksum:
-      - algorithm: md5
-        digest: 9b3bbbb443a9a48ef0c2d822cb1cb6b5
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 9b3bbbb443a9a48ef0c2d822cb1cb6b5
     download_url:
       - https://dataverse.nl/api/access/datafile/46501
     media_type: application/gzip
   - id: exthisdsver:./sub-021/func/sub-021_task-emotionProcessing_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 32cd9758c3c70f30f9f6cf55829adc82
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 32cd9758c3c70f30f9f6cf55829adc82
     download_url:
       - https://dataverse.nl/api/access/datafile/45145
     media_type: application/json
   - id: exthisdsver:./sub-021/func/sub-021_task-emotionProcessing_physio.tsv.gz
     byte_size: 515684
     checksum:
-      - algorithm: md5
-        digest: 6108f65d2b70c30e0d1175a95b20ad6c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6108f65d2b70c30e0d1175a95b20ad6c
     download_url:
       - https://dataverse.nl/api/access/datafile/46220
     media_type: application/gzip
   - id: exthisdsver:./sub-021/func/sub-021_task-fingerTapping_echo-1_bold.json
     byte_size: 1036
     checksum:
-      - algorithm: md5
-        digest: 8cf4e469e5ba11fa1919bee6736165ab
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8cf4e469e5ba11fa1919bee6736165ab
     download_url:
       - https://dataverse.nl/api/access/datafile/45663
     media_type: application/json
   - id: exthisdsver:./sub-021/func/sub-021_task-fingerTapping_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 5b2d8410ab537f6341837a8b7d43173f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5b2d8410ab537f6341837a8b7d43173f
     download_url:
       - https://dataverse.nl/api/access/datafile/45670
     media_type: image/nii
   - id: exthisdsver:./sub-021/func/sub-021_task-fingerTapping_echo-2_bold.json
     byte_size: 1036
     checksum:
-      - algorithm: md5
-        digest: 438c6dba76ba2d63e2aaed7c147084ee
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 438c6dba76ba2d63e2aaed7c147084ee
     download_url:
       - https://dataverse.nl/api/access/datafile/45727
     media_type: application/json
   - id: exthisdsver:./sub-021/func/sub-021_task-fingerTapping_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 8cdcaf74eede11999411bf9b662a7f00
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8cdcaf74eede11999411bf9b662a7f00
     download_url:
       - https://dataverse.nl/api/access/datafile/45684
     media_type: image/nii
   - id: exthisdsver:./sub-021/func/sub-021_task-fingerTapping_echo-3_bold.json
     byte_size: 1036
     checksum:
-      - algorithm: md5
-        digest: b406dd2f244b6773f01dd9f39d0ec087
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b406dd2f244b6773f01dd9f39d0ec087
     download_url:
       - https://dataverse.nl/api/access/datafile/45902
     media_type: application/json
   - id: exthisdsver:./sub-021/func/sub-021_task-fingerTapping_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: e2c088d4f19fba0369901e56e3158501
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e2c088d4f19fba0369901e56e3158501
     download_url:
       - https://dataverse.nl/api/access/datafile/45685
     media_type: image/nii
   - id: exthisdsver:./sub-021/func/sub-021_task-fingerTapping_events.tsv.gz
     byte_size: 161
     checksum:
-      - algorithm: md5
-        digest: e92392f12915a922a166216e0c8a799f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e92392f12915a922a166216e0c8a799f
     download_url:
       - https://dataverse.nl/api/access/datafile/46639
     media_type: application/gzip
   - id: exthisdsver:./sub-021/func/sub-021_task-fingerTappingImagined_echo-1_bold.json
     byte_size: 1044
     checksum:
-      - algorithm: md5
-        digest: 00f67e6452f7bbb3118454730dc6d317
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 00f67e6452f7bbb3118454730dc6d317
     download_url:
       - https://dataverse.nl/api/access/datafile/45179
     media_type: application/json
   - id: exthisdsver:./sub-021/func/sub-021_task-fingerTappingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 2ce149c5a4af8b9957da0dc40dc715cb
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2ce149c5a4af8b9957da0dc40dc715cb
     download_url:
       - https://dataverse.nl/api/access/datafile/45209
     media_type: image/nii
   - id: exthisdsver:./sub-021/func/sub-021_task-fingerTappingImagined_echo-2_bold.json
     byte_size: 1044
     checksum:
-      - algorithm: md5
-        digest: 43937553b0f8fad6ab85114f9b1fd135
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 43937553b0f8fad6ab85114f9b1fd135
     download_url:
       - https://dataverse.nl/api/access/datafile/45134
     media_type: application/json
   - id: exthisdsver:./sub-021/func/sub-021_task-fingerTappingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 2d838ecd17860236e958442999d380a6
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2d838ecd17860236e958442999d380a6
     download_url:
       - https://dataverse.nl/api/access/datafile/45697
     media_type: image/nii
   - id: exthisdsver:./sub-021/func/sub-021_task-fingerTappingImagined_echo-3_bold.json
     byte_size: 1044
     checksum:
-      - algorithm: md5
-        digest: 70d0a2ff1effbbb17bb3148cdd5a1c65
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 70d0a2ff1effbbb17bb3148cdd5a1c65
     download_url:
       - https://dataverse.nl/api/access/datafile/45842
     media_type: application/json
   - id: exthisdsver:./sub-021/func/sub-021_task-fingerTappingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 57ca7c934b6dfc41c14ea723ba6c0424
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 57ca7c934b6dfc41c14ea723ba6c0424
     download_url:
       - https://dataverse.nl/api/access/datafile/45403
     media_type: image/nii
   - id: exthisdsver:./sub-021/func/sub-021_task-fingerTappingImagined_events.tsv.gz
     byte_size: 177
     checksum:
-      - algorithm: md5
-        digest: 5f2b58977057a2f8e8f3a63afdbf26cc
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5f2b58977057a2f8e8f3a63afdbf26cc
     download_url:
       - https://dataverse.nl/api/access/datafile/46559
     media_type: application/gzip
   - id: exthisdsver:./sub-021/func/sub-021_task-fingerTappingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 20674885589debb9c452b1e18fa23a0a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 20674885589debb9c452b1e18fa23a0a
     download_url:
       - https://dataverse.nl/api/access/datafile/45768
     media_type: application/json
   - id: exthisdsver:./sub-021/func/sub-021_task-fingerTappingImagined_physio.tsv.gz
     byte_size: 503755
     checksum:
-      - algorithm: md5
-        digest: c89e4808bbab12010f23016a0cf937ae
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c89e4808bbab12010f23016a0cf937ae
     download_url:
       - https://dataverse.nl/api/access/datafile/46371
     media_type: application/gzip
   - id: exthisdsver:./sub-021/func/sub-021_task-fingerTapping_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 0a33dbb8d6e81df3efa76ea8a52b02bc
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 0a33dbb8d6e81df3efa76ea8a52b02bc
     download_url:
       - https://dataverse.nl/api/access/datafile/46469
     media_type: application/json
   - id: exthisdsver:./sub-021/func/sub-021_task-fingerTapping_physio.tsv.gz
     byte_size: 493542
     checksum:
-      - algorithm: md5
-        digest: 81ad87529d1a8598643ab6a282f424f1
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 81ad87529d1a8598643ab6a282f424f1
     download_url:
       - https://dataverse.nl/api/access/datafile/46045
     media_type: application/gzip
   - id: exthisdsver:./sub-021/func/sub-021_task-rest_run-1_echo-1_bold.json
     byte_size: 1027
     checksum:
-      - algorithm: md5
-        digest: 439532d80054b2f2b25bc5029f644101
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 439532d80054b2f2b25bc5029f644101
     download_url:
       - https://dataverse.nl/api/access/datafile/45224
     media_type: application/json
   - id: exthisdsver:./sub-021/func/sub-021_task-rest_run-1_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: d16963c7dd0eec20ffc6b1d61262e0f8
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d16963c7dd0eec20ffc6b1d61262e0f8
     download_url:
       - https://dataverse.nl/api/access/datafile/46393
     media_type: image/nii
   - id: exthisdsver:./sub-021/func/sub-021_task-rest_run-1_echo-2_bold.json
     byte_size: 1027
     checksum:
-      - algorithm: md5
-        digest: 482b1c24457a0da28096c2a4a99c3ae1
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 482b1c24457a0da28096c2a4a99c3ae1
     download_url:
       - https://dataverse.nl/api/access/datafile/45913
     media_type: application/json
   - id: exthisdsver:./sub-021/func/sub-021_task-rest_run-1_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: ab844da48b9cd77cb915b4be5e32c053
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ab844da48b9cd77cb915b4be5e32c053
     download_url:
       - https://dataverse.nl/api/access/datafile/45702
     media_type: image/nii
   - id: exthisdsver:./sub-021/func/sub-021_task-rest_run-1_echo-3_bold.json
     byte_size: 1027
     checksum:
-      - algorithm: md5
-        digest: a99b02aa878cfb5f143bb91d3ede0087
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a99b02aa878cfb5f143bb91d3ede0087
     download_url:
       - https://dataverse.nl/api/access/datafile/45427
     media_type: application/json
   - id: exthisdsver:./sub-021/func/sub-021_task-rest_run-1_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: e80f236e33afd69ae1b0f87ba29346b6
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e80f236e33afd69ae1b0f87ba29346b6
     download_url:
       - https://dataverse.nl/api/access/datafile/45987
     media_type: image/nii
   - id: exthisdsver:./sub-021/func/sub-021_task-rest_run-1_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: d79c73483b13c27b4c5ce1e06ac44473
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d79c73483b13c27b4c5ce1e06ac44473
     download_url:
       - https://dataverse.nl/api/access/datafile/45360
     media_type: application/json
   - id: exthisdsver:./sub-021/func/sub-021_task-rest_run-1_physio.tsv.gz
     byte_size: 472964
     checksum:
-      - algorithm: md5
-        digest: 7a2374c3a0b447ef4e822a9010dfb1d5
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 7a2374c3a0b447ef4e822a9010dfb1d5
     download_url:
       - https://dataverse.nl/api/access/datafile/45548
     media_type: application/gzip
   - id: exthisdsver:./sub-021/func/sub-021_task-rest_run-2_echo-1_bold.json
     byte_size: 1027
     checksum:
-      - algorithm: md5
-        digest: 56619e6f98a70ea32e028893cbe358da
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 56619e6f98a70ea32e028893cbe358da
     download_url:
       - https://dataverse.nl/api/access/datafile/46276
     media_type: application/json
   - id: exthisdsver:./sub-021/func/sub-021_task-rest_run-2_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: f4094fd68d34823fd6b4123c02129fa2
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f4094fd68d34823fd6b4123c02129fa2
     download_url:
       - https://dataverse.nl/api/access/datafile/45474
     media_type: image/nii
   - id: exthisdsver:./sub-021/func/sub-021_task-rest_run-2_echo-2_bold.json
     byte_size: 1027
     checksum:
-      - algorithm: md5
-        digest: 475d75d2c07d00ee4f24e4f9435bf949
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 475d75d2c07d00ee4f24e4f9435bf949
     download_url:
       - https://dataverse.nl/api/access/datafile/45540
     media_type: application/json
   - id: exthisdsver:./sub-021/func/sub-021_task-rest_run-2_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 47e7d3ecfa69dc91f8316a1206bbb370
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 47e7d3ecfa69dc91f8316a1206bbb370
     download_url:
       - https://dataverse.nl/api/access/datafile/45612
     media_type: image/nii
   - id: exthisdsver:./sub-021/func/sub-021_task-rest_run-2_echo-3_bold.json
     byte_size: 1027
     checksum:
-      - algorithm: md5
-        digest: 50722e2e70ab9b8e8f76933bc17604e5
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 50722e2e70ab9b8e8f76933bc17604e5
     download_url:
       - https://dataverse.nl/api/access/datafile/46202
     media_type: application/json
   - id: exthisdsver:./sub-021/func/sub-021_task-rest_run-2_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 1c9f3613de8fb930b5f899b347062957
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1c9f3613de8fb930b5f899b347062957
     download_url:
       - https://dataverse.nl/api/access/datafile/45272
     media_type: image/nii
   - id: exthisdsver:./sub-021/func/sub-021_task-rest_run-2_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 10a80fd8b46666dd4467720de4a113fb
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 10a80fd8b46666dd4467720de4a113fb
     download_url:
       - https://dataverse.nl/api/access/datafile/46237
     media_type: application/json
   - id: exthisdsver:./sub-021/func/sub-021_task-rest_run-2_physio.tsv.gz
     byte_size: 466392
     checksum:
-      - algorithm: md5
-        digest: 7dfcc62dc4e2e6c62a344642dffa3d0d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 7dfcc62dc4e2e6c62a344642dffa3d0d
     download_url:
       - https://dataverse.nl/api/access/datafile/45168
     media_type: application/gzip
   - id: exthisdsver:./sub-022/anat/sub-022_T1w.nii
     byte_size: 20736352
     checksum:
-      - algorithm: md5
-        digest: 485d9f7ff0ca722ebdb751023d3206f1
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 485d9f7ff0ca722ebdb751023d3206f1
     download_url:
       - https://dataverse.nl/api/access/datafile/45406
     media_type: image/nii
@@ -10236,8 +10236,8 @@ has_part:
   - id: exthisdsver:./sub-022/func/sub-022_task-emotionProcessing_echo-1_bold.json
     byte_size: 1040
     checksum:
-      - algorithm: md5
-        digest: e9bb70745528c4630bac456ea0b0c3e7
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e9bb70745528c4630bac456ea0b0c3e7
     download_url:
       - https://dataverse.nl/api/access/datafile/46392
     media_type: application/json
@@ -10356,48 +10356,48 @@ has_part:
   - id: exthisdsver:./sub-022/func/sub-022_task-emotionProcessing_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 90c647375623883b3b8413095208c276
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 90c647375623883b3b8413095208c276
     download_url:
       - https://dataverse.nl/api/access/datafile/45206
     media_type: image/nii
   - id: exthisdsver:./sub-022/func/sub-022_task-emotionProcessing_echo-2_bold.json
     byte_size: 1040
     checksum:
-      - algorithm: md5
-        digest: 857a1942641a85653c9ce048d46767ea
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 857a1942641a85653c9ce048d46767ea
     download_url:
       - https://dataverse.nl/api/access/datafile/45141
     media_type: application/json
   - id: exthisdsver:./sub-022/func/sub-022_task-emotionProcessing_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: bb86f022f1ebf2b26365d437ebe105df
+      - creator: spdx:checksumAlgorithm_md5
+        notation: bb86f022f1ebf2b26365d437ebe105df
     download_url:
       - https://dataverse.nl/api/access/datafile/45822
     media_type: image/nii
   - id: exthisdsver:./sub-022/func/sub-022_task-emotionProcessing_echo-3_bold.json
     byte_size: 1040
     checksum:
-      - algorithm: md5
-        digest: 2bb9650a47d89ce97ca95a1a5fa6a3b1
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2bb9650a47d89ce97ca95a1a5fa6a3b1
     download_url:
       - https://dataverse.nl/api/access/datafile/46114
     media_type: application/json
   - id: exthisdsver:./sub-022/func/sub-022_task-emotionProcessing_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 17f5f08163012f6a580f98e82e87eb2c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 17f5f08163012f6a580f98e82e87eb2c
     download_url:
       - https://dataverse.nl/api/access/datafile/45845
     media_type: image/nii
   - id: exthisdsver:./sub-022/func/sub-022_task-emotionProcessing_events.tsv.gz
     byte_size: 1899
     checksum:
-      - algorithm: md5
-        digest: 8189057888af59647daccefdc59e4eb4
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8189057888af59647daccefdc59e4eb4
     download_url:
       - https://dataverse.nl/api/access/datafile/46658
     media_type: application/gzip
@@ -10405,8 +10405,8 @@ has_part:
       exthisdsver:./sub-022/func/sub-022_task-emotionProcessingImagined_echo-1_bold.json
     byte_size: 1049
     checksum:
-      - algorithm: md5
-        digest: dc7224e4a5ea9828b7ea312aaf7ba646
+      - creator: spdx:checksumAlgorithm_md5
+        notation: dc7224e4a5ea9828b7ea312aaf7ba646
     download_url:
       - https://dataverse.nl/api/access/datafile/46016
     media_type: application/json
@@ -10414,8 +10414,8 @@ has_part:
       exthisdsver:./sub-022/func/sub-022_task-emotionProcessingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 823032ce07d962c4a133f74e121b3761
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 823032ce07d962c4a133f74e121b3761
     download_url:
       - https://dataverse.nl/api/access/datafile/45906
     media_type: image/nii
@@ -10423,8 +10423,8 @@ has_part:
       exthisdsver:./sub-022/func/sub-022_task-emotionProcessingImagined_echo-2_bold.json
     byte_size: 1049
     checksum:
-      - algorithm: md5
-        digest: 026cb0721fd8bf78490e741ea5d91794
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 026cb0721fd8bf78490e741ea5d91794
     download_url:
       - https://dataverse.nl/api/access/datafile/45798
     media_type: application/json
@@ -10432,8 +10432,8 @@ has_part:
       exthisdsver:./sub-022/func/sub-022_task-emotionProcessingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 24a26e779af8ea625527291f9046aefb
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 24a26e779af8ea625527291f9046aefb
     download_url:
       - https://dataverse.nl/api/access/datafile/46133
     media_type: image/nii
@@ -10441,8 +10441,8 @@ has_part:
       exthisdsver:./sub-022/func/sub-022_task-emotionProcessingImagined_echo-3_bold.json
     byte_size: 1049
     checksum:
-      - algorithm: md5
-        digest: ce7c422b09e0f0b02f34d4613ccc4229
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ce7c422b09e0f0b02f34d4613ccc4229
     download_url:
       - https://dataverse.nl/api/access/datafile/45688
     media_type: application/json
@@ -10450,328 +10450,328 @@ has_part:
       exthisdsver:./sub-022/func/sub-022_task-emotionProcessingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 1845ba28a5fc280f36b605043a38541b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1845ba28a5fc280f36b605043a38541b
     download_url:
       - https://dataverse.nl/api/access/datafile/46101
     media_type: image/nii
   - id: exthisdsver:./sub-022/func/sub-022_task-emotionProcessingImagined_events.tsv.gz
     byte_size: 174
     checksum:
-      - algorithm: md5
-        digest: b241742b7e85b01450282a2e7aa4e058
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b241742b7e85b01450282a2e7aa4e058
     download_url:
       - https://dataverse.nl/api/access/datafile/46597
     media_type: application/gzip
   - id: exthisdsver:./sub-022/func/sub-022_task-emotionProcessingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 32828a99a87019d6f9078e03c648c68d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 32828a99a87019d6f9078e03c648c68d
     download_url:
       - https://dataverse.nl/api/access/datafile/46389
     media_type: application/json
   - id: exthisdsver:./sub-022/func/sub-022_task-emotionProcessingImagined_physio.tsv.gz
     byte_size: 461489
     checksum:
-      - algorithm: md5
-        digest: 82af247c3278288279a833073b9066db
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 82af247c3278288279a833073b9066db
     download_url:
       - https://dataverse.nl/api/access/datafile/45338
     media_type: application/gzip
   - id: exthisdsver:./sub-022/func/sub-022_task-emotionProcessing_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: fe69e80cf45f5e9d5310ed1a738a696e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: fe69e80cf45f5e9d5310ed1a738a696e
     download_url:
       - https://dataverse.nl/api/access/datafile/45655
     media_type: application/json
   - id: exthisdsver:./sub-022/func/sub-022_task-emotionProcessing_physio.tsv.gz
     byte_size: 568493
     checksum:
-      - algorithm: md5
-        digest: dad4fcc69a0b3469fbf3a26b71965b55
+      - creator: spdx:checksumAlgorithm_md5
+        notation: dad4fcc69a0b3469fbf3a26b71965b55
     download_url:
       - https://dataverse.nl/api/access/datafile/45300
     media_type: application/gzip
   - id: exthisdsver:./sub-022/func/sub-022_task-fingerTapping_echo-1_bold.json
     byte_size: 1037
     checksum:
-      - algorithm: md5
-        digest: 7d197f0669600972b57583e3532570dd
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 7d197f0669600972b57583e3532570dd
     download_url:
       - https://dataverse.nl/api/access/datafile/45384
     media_type: application/json
   - id: exthisdsver:./sub-022/func/sub-022_task-fingerTapping_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: fe849a80e4cd766fd6835344b8bd1f3d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: fe849a80e4cd766fd6835344b8bd1f3d
     download_url:
       - https://dataverse.nl/api/access/datafile/45472
     media_type: image/nii
   - id: exthisdsver:./sub-022/func/sub-022_task-fingerTapping_echo-2_bold.json
     byte_size: 1037
     checksum:
-      - algorithm: md5
-        digest: 52a2f13d5077977571bf6496be1c32a5
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 52a2f13d5077977571bf6496be1c32a5
     download_url:
       - https://dataverse.nl/api/access/datafile/45649
     media_type: application/json
   - id: exthisdsver:./sub-022/func/sub-022_task-fingerTapping_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: f210ac99e2c99a5bfa20be2b781f89ff
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f210ac99e2c99a5bfa20be2b781f89ff
     download_url:
       - https://dataverse.nl/api/access/datafile/45195
     media_type: image/nii
   - id: exthisdsver:./sub-022/func/sub-022_task-fingerTapping_echo-3_bold.json
     byte_size: 1037
     checksum:
-      - algorithm: md5
-        digest: 8e7a2146ec718c117d2b903b43af828a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8e7a2146ec718c117d2b903b43af828a
     download_url:
       - https://dataverse.nl/api/access/datafile/46445
     media_type: application/json
   - id: exthisdsver:./sub-022/func/sub-022_task-fingerTapping_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: c0b91f1e9a73301ba10b8eccff10a605
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c0b91f1e9a73301ba10b8eccff10a605
     download_url:
       - https://dataverse.nl/api/access/datafile/46131
     media_type: image/nii
   - id: exthisdsver:./sub-022/func/sub-022_task-fingerTapping_events.tsv.gz
     byte_size: 163
     checksum:
-      - algorithm: md5
-        digest: 0aefea2893935c3e98e5c277f766941f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 0aefea2893935c3e98e5c277f766941f
     download_url:
       - https://dataverse.nl/api/access/datafile/46635
     media_type: application/gzip
   - id: exthisdsver:./sub-022/func/sub-022_task-fingerTappingImagined_echo-1_bold.json
     byte_size: 1045
     checksum:
-      - algorithm: md5
-        digest: 5533bdd647e1a2cabd33ed8d1acdde59
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5533bdd647e1a2cabd33ed8d1acdde59
     download_url:
       - https://dataverse.nl/api/access/datafile/46308
     media_type: application/json
   - id: exthisdsver:./sub-022/func/sub-022_task-fingerTappingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: dc4d3bc21a3c8ed6d4a7e65d2ac3199b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: dc4d3bc21a3c8ed6d4a7e65d2ac3199b
     download_url:
       - https://dataverse.nl/api/access/datafile/45788
     media_type: image/nii
   - id: exthisdsver:./sub-022/func/sub-022_task-fingerTappingImagined_echo-2_bold.json
     byte_size: 1045
     checksum:
-      - algorithm: md5
-        digest: a13d744ad4c709cf59dc9e1b10a1b1f1
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a13d744ad4c709cf59dc9e1b10a1b1f1
     download_url:
       - https://dataverse.nl/api/access/datafile/45922
     media_type: application/json
   - id: exthisdsver:./sub-022/func/sub-022_task-fingerTappingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: e869e8e8559023be1856f208982d05d7
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e869e8e8559023be1856f208982d05d7
     download_url:
       - https://dataverse.nl/api/access/datafile/46233
     media_type: image/nii
   - id: exthisdsver:./sub-022/func/sub-022_task-fingerTappingImagined_echo-3_bold.json
     byte_size: 1045
     checksum:
-      - algorithm: md5
-        digest: d1908bea5803e84906ad952c234953bb
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d1908bea5803e84906ad952c234953bb
     download_url:
       - https://dataverse.nl/api/access/datafile/45939
     media_type: application/json
   - id: exthisdsver:./sub-022/func/sub-022_task-fingerTappingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: e49be718e9fb740f14a2bc7a4d3f0e3d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e49be718e9fb740f14a2bc7a4d3f0e3d
     download_url:
       - https://dataverse.nl/api/access/datafile/45797
     media_type: image/nii
   - id: exthisdsver:./sub-022/func/sub-022_task-fingerTappingImagined_events.tsv.gz
     byte_size: 177
     checksum:
-      - algorithm: md5
-        digest: ad3350bfe793a923b57adc825e721fe0
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ad3350bfe793a923b57adc825e721fe0
     download_url:
       - https://dataverse.nl/api/access/datafile/46625
     media_type: application/gzip
   - id: exthisdsver:./sub-022/func/sub-022_task-fingerTappingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 87ad0780b5acc158fd21bd4806f54b8c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 87ad0780b5acc158fd21bd4806f54b8c
     download_url:
       - https://dataverse.nl/api/access/datafile/45165
     media_type: application/json
   - id: exthisdsver:./sub-022/func/sub-022_task-fingerTappingImagined_physio.tsv.gz
     byte_size: 469899
     checksum:
-      - algorithm: md5
-        digest: 06420ff40545291d3103f32844fa3e8e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 06420ff40545291d3103f32844fa3e8e
     download_url:
       - https://dataverse.nl/api/access/datafile/45556
     media_type: application/gzip
   - id: exthisdsver:./sub-022/func/sub-022_task-fingerTapping_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 1293460b4ce9a1b3ae3e197acb543c0c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1293460b4ce9a1b3ae3e197acb543c0c
     download_url:
       - https://dataverse.nl/api/access/datafile/46109
     media_type: application/json
   - id: exthisdsver:./sub-022/func/sub-022_task-fingerTapping_physio.tsv.gz
     byte_size: 485107
     checksum:
-      - algorithm: md5
-        digest: ea398a208034c539761c427021944b9f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ea398a208034c539761c427021944b9f
     download_url:
       - https://dataverse.nl/api/access/datafile/45383
     media_type: application/gzip
   - id: exthisdsver:./sub-022/func/sub-022_task-rest_run-1_echo-1_bold.json
     byte_size: 1027
     checksum:
-      - algorithm: md5
-        digest: b5e25fbbb45223cccae01bd64ff64c06
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b5e25fbbb45223cccae01bd64ff64c06
     download_url:
       - https://dataverse.nl/api/access/datafile/46473
     media_type: application/json
   - id: exthisdsver:./sub-022/func/sub-022_task-rest_run-1_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: ad1fcb25847e6546bdd84ec40742ae27
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ad1fcb25847e6546bdd84ec40742ae27
     download_url:
       - https://dataverse.nl/api/access/datafile/45419
     media_type: image/nii
   - id: exthisdsver:./sub-022/func/sub-022_task-rest_run-1_echo-2_bold.json
     byte_size: 1027
     checksum:
-      - algorithm: md5
-        digest: 383dfc8610f1c4ac70ed6380d6024ada
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 383dfc8610f1c4ac70ed6380d6024ada
     download_url:
       - https://dataverse.nl/api/access/datafile/45781
     media_type: application/json
   - id: exthisdsver:./sub-022/func/sub-022_task-rest_run-1_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 1209b5fd6974ffee065a3a6c5767fab5
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1209b5fd6974ffee065a3a6c5767fab5
     download_url:
       - https://dataverse.nl/api/access/datafile/46213
     media_type: image/nii
   - id: exthisdsver:./sub-022/func/sub-022_task-rest_run-1_echo-3_bold.json
     byte_size: 1027
     checksum:
-      - algorithm: md5
-        digest: 6ff7e84e984a2a7a283ae0550acf5fa0
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6ff7e84e984a2a7a283ae0550acf5fa0
     download_url:
       - https://dataverse.nl/api/access/datafile/45930
     media_type: application/json
   - id: exthisdsver:./sub-022/func/sub-022_task-rest_run-1_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 215134b08c99ad535e216dce3cecef73
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 215134b08c99ad535e216dce3cecef73
     download_url:
       - https://dataverse.nl/api/access/datafile/45795
     media_type: image/nii
   - id: exthisdsver:./sub-022/func/sub-022_task-rest_run-1_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 4f6504f90de8cc8caa5ed4eec7fc7a55
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4f6504f90de8cc8caa5ed4eec7fc7a55
     download_url:
       - https://dataverse.nl/api/access/datafile/45989
     media_type: application/json
   - id: exthisdsver:./sub-022/func/sub-022_task-rest_run-1_physio.tsv.gz
     byte_size: 456033
     checksum:
-      - algorithm: md5
-        digest: dd889f338e9721209a5c7494ea542a48
+      - creator: spdx:checksumAlgorithm_md5
+        notation: dd889f338e9721209a5c7494ea542a48
     download_url:
       - https://dataverse.nl/api/access/datafile/45891
     media_type: application/gzip
   - id: exthisdsver:./sub-022/func/sub-022_task-rest_run-2_echo-1_bold.json
     byte_size: 1028
     checksum:
-      - algorithm: md5
-        digest: 8a7a7e378d88a320bc13aa573e33e9cf
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8a7a7e378d88a320bc13aa573e33e9cf
     download_url:
       - https://dataverse.nl/api/access/datafile/45988
     media_type: application/json
   - id: exthisdsver:./sub-022/func/sub-022_task-rest_run-2_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: f26b54d5131b4150f67442ba57d247e1
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f26b54d5131b4150f67442ba57d247e1
     download_url:
       - https://dataverse.nl/api/access/datafile/45375
     media_type: image/nii
   - id: exthisdsver:./sub-022/func/sub-022_task-rest_run-2_echo-2_bold.json
     byte_size: 1028
     checksum:
-      - algorithm: md5
-        digest: 794ddb9e826cd7224e77a581d33b2af5
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 794ddb9e826cd7224e77a581d33b2af5
     download_url:
       - https://dataverse.nl/api/access/datafile/46068
     media_type: application/json
   - id: exthisdsver:./sub-022/func/sub-022_task-rest_run-2_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: f65dc11611257fa72e9ae4a1fa1061f9
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f65dc11611257fa72e9ae4a1fa1061f9
     download_url:
       - https://dataverse.nl/api/access/datafile/45813
     media_type: image/nii
   - id: exthisdsver:./sub-022/func/sub-022_task-rest_run-2_echo-3_bold.json
     byte_size: 1028
     checksum:
-      - algorithm: md5
-        digest: a21e290d360f3207465b7919fe9f97c4
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a21e290d360f3207465b7919fe9f97c4
     download_url:
       - https://dataverse.nl/api/access/datafile/45513
     media_type: application/json
   - id: exthisdsver:./sub-022/func/sub-022_task-rest_run-2_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 69773a651271d49947757f38d3a8a144
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 69773a651271d49947757f38d3a8a144
     download_url:
       - https://dataverse.nl/api/access/datafile/46054
     media_type: image/nii
   - id: exthisdsver:./sub-022/func/sub-022_task-rest_run-2_physio.json
     byte_size: 142
     checksum:
-      - algorithm: md5
-        digest: 1b07b0c2da81eab7a599744912d99a4a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1b07b0c2da81eab7a599744912d99a4a
     download_url:
       - https://dataverse.nl/api/access/datafile/45850
     media_type: application/json
   - id: exthisdsver:./sub-022/func/sub-022_task-rest_run-2_physio.tsv.gz
     byte_size: 462313
     checksum:
-      - algorithm: md5
-        digest: 3ca0ba152166f56d7289348c95c3ff44
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 3ca0ba152166f56d7289348c95c3ff44
     download_url:
       - https://dataverse.nl/api/access/datafile/46035
     media_type: application/gzip
   - id: exthisdsver:./sub-023/anat/sub-023_T1w.nii
     byte_size: 20736352
     checksum:
-      - algorithm: md5
-        digest: a8bd0a40d6efca07de5655eac124c64e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a8bd0a40d6efca07de5655eac124c64e
     download_url:
       - https://dataverse.nl/api/access/datafile/46507
     media_type: image/nii
@@ -10788,8 +10788,8 @@ has_part:
   - id: exthisdsver:./sub-023/func/sub-023_task-emotionProcessing_echo-1_bold.json
     byte_size: 1039
     checksum:
-      - algorithm: md5
-        digest: f37ca22703b567972aed652faea49d66
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f37ca22703b567972aed652faea49d66
     download_url:
       - https://dataverse.nl/api/access/datafile/45202
     media_type: application/json
@@ -10908,48 +10908,48 @@ has_part:
   - id: exthisdsver:./sub-023/func/sub-023_task-emotionProcessing_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 4342d0862f957a5f96fce660bac4e3af
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4342d0862f957a5f96fce660bac4e3af
     download_url:
       - https://dataverse.nl/api/access/datafile/45222
     media_type: image/nii
   - id: exthisdsver:./sub-023/func/sub-023_task-emotionProcessing_echo-2_bold.json
     byte_size: 1039
     checksum:
-      - algorithm: md5
-        digest: 4792b52cd808c53813848c4abdd6f864
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4792b52cd808c53813848c4abdd6f864
     download_url:
       - https://dataverse.nl/api/access/datafile/46387
     media_type: application/json
   - id: exthisdsver:./sub-023/func/sub-023_task-emotionProcessing_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 7c9f2a572ffc612408e129f3cfea236d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 7c9f2a572ffc612408e129f3cfea236d
     download_url:
       - https://dataverse.nl/api/access/datafile/45621
     media_type: image/nii
   - id: exthisdsver:./sub-023/func/sub-023_task-emotionProcessing_echo-3_bold.json
     byte_size: 1039
     checksum:
-      - algorithm: md5
-        digest: 69c92241ea01045e326f37299420d86d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 69c92241ea01045e326f37299420d86d
     download_url:
       - https://dataverse.nl/api/access/datafile/45317
     media_type: application/json
   - id: exthisdsver:./sub-023/func/sub-023_task-emotionProcessing_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 51b324dfec485e2ff3e75c5cef9d20c7
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 51b324dfec485e2ff3e75c5cef9d20c7
     download_url:
       - https://dataverse.nl/api/access/datafile/45388
     media_type: image/nii
   - id: exthisdsver:./sub-023/func/sub-023_task-emotionProcessing_events.tsv.gz
     byte_size: 1906
     checksum:
-      - algorithm: md5
-        digest: abba89ac8fe77c31ff817fef92353cf6
+      - creator: spdx:checksumAlgorithm_md5
+        notation: abba89ac8fe77c31ff817fef92353cf6
     download_url:
       - https://dataverse.nl/api/access/datafile/46637
     media_type: application/gzip
@@ -10957,8 +10957,8 @@ has_part:
       exthisdsver:./sub-023/func/sub-023_task-emotionProcessingImagined_echo-1_bold.json
     byte_size: 1047
     checksum:
-      - algorithm: md5
-        digest: 7a3ccbf6ebd56048969bb4c05f2a8182
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 7a3ccbf6ebd56048969bb4c05f2a8182
     download_url:
       - https://dataverse.nl/api/access/datafile/46022
     media_type: application/json
@@ -10966,8 +10966,8 @@ has_part:
       exthisdsver:./sub-023/func/sub-023_task-emotionProcessingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: fb4709163f5988471ffbe97dad8fd3da
+      - creator: spdx:checksumAlgorithm_md5
+        notation: fb4709163f5988471ffbe97dad8fd3da
     download_url:
       - https://dataverse.nl/api/access/datafile/45187
     media_type: image/nii
@@ -10975,8 +10975,8 @@ has_part:
       exthisdsver:./sub-023/func/sub-023_task-emotionProcessingImagined_echo-2_bold.json
     byte_size: 1047
     checksum:
-      - algorithm: md5
-        digest: 693618fec310822d37d31a98f147884f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 693618fec310822d37d31a98f147884f
     download_url:
       - https://dataverse.nl/api/access/datafile/46208
     media_type: application/json
@@ -10984,8 +10984,8 @@ has_part:
       exthisdsver:./sub-023/func/sub-023_task-emotionProcessingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: daca30ebb1bc9a4f3d08dcc91cfde3a2
+      - creator: spdx:checksumAlgorithm_md5
+        notation: daca30ebb1bc9a4f3d08dcc91cfde3a2
     download_url:
       - https://dataverse.nl/api/access/datafile/45980
     media_type: image/nii
@@ -10993,8 +10993,8 @@ has_part:
       exthisdsver:./sub-023/func/sub-023_task-emotionProcessingImagined_echo-3_bold.json
     byte_size: 1047
     checksum:
-      - algorithm: md5
-        digest: 3b2916f1db199f0ca145a15e09dd1a42
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 3b2916f1db199f0ca145a15e09dd1a42
     download_url:
       - https://dataverse.nl/api/access/datafile/45739
     media_type: application/json
@@ -11002,328 +11002,328 @@ has_part:
       exthisdsver:./sub-023/func/sub-023_task-emotionProcessingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 70acf8b330aa822ed8eb3a9c15823317
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 70acf8b330aa822ed8eb3a9c15823317
     download_url:
       - https://dataverse.nl/api/access/datafile/45533
     media_type: image/nii
   - id: exthisdsver:./sub-023/func/sub-023_task-emotionProcessingImagined_events.tsv.gz
     byte_size: 177
     checksum:
-      - algorithm: md5
-        digest: 6d33cc5bb73b310d1b1e36a0d53f7aba
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6d33cc5bb73b310d1b1e36a0d53f7aba
     download_url:
       - https://dataverse.nl/api/access/datafile/46619
     media_type: application/gzip
   - id: exthisdsver:./sub-023/func/sub-023_task-emotionProcessingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 19f64e4eb05f5fb5695085f7d85ec0a1
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 19f64e4eb05f5fb5695085f7d85ec0a1
     download_url:
       - https://dataverse.nl/api/access/datafile/46323
     media_type: application/json
   - id: exthisdsver:./sub-023/func/sub-023_task-emotionProcessingImagined_physio.tsv.gz
     byte_size: 496920
     checksum:
-      - algorithm: md5
-        digest: c82c6f370103863643536b403619d87f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c82c6f370103863643536b403619d87f
     download_url:
       - https://dataverse.nl/api/access/datafile/45298
     media_type: application/gzip
   - id: exthisdsver:./sub-023/func/sub-023_task-emotionProcessing_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 3b2eb7eab727d8085bc51a521a7cd27c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 3b2eb7eab727d8085bc51a521a7cd27c
     download_url:
       - https://dataverse.nl/api/access/datafile/46053
     media_type: application/json
   - id: exthisdsver:./sub-023/func/sub-023_task-emotionProcessing_physio.tsv.gz
     byte_size: 488767
     checksum:
-      - algorithm: md5
-        digest: 3885b28dbcccae475ad7dd0e70a1227e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 3885b28dbcccae475ad7dd0e70a1227e
     download_url:
       - https://dataverse.nl/api/access/datafile/46283
     media_type: application/gzip
   - id: exthisdsver:./sub-023/func/sub-023_task-fingerTapping_echo-1_bold.json
     byte_size: 1034
     checksum:
-      - algorithm: md5
-        digest: f6862966e25b9d2d40fa354843b873de
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f6862966e25b9d2d40fa354843b873de
     download_url:
       - https://dataverse.nl/api/access/datafile/45410
     media_type: application/json
   - id: exthisdsver:./sub-023/func/sub-023_task-fingerTapping_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 44dd15ffab91487d67e8a82011de9b60
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 44dd15ffab91487d67e8a82011de9b60
     download_url:
       - https://dataverse.nl/api/access/datafile/45103
     media_type: image/nii
   - id: exthisdsver:./sub-023/func/sub-023_task-fingerTapping_echo-2_bold.json
     byte_size: 1034
     checksum:
-      - algorithm: md5
-        digest: dd25a8138eae63f4273b92f390706048
+      - creator: spdx:checksumAlgorithm_md5
+        notation: dd25a8138eae63f4273b92f390706048
     download_url:
       - https://dataverse.nl/api/access/datafile/45638
     media_type: application/json
   - id: exthisdsver:./sub-023/func/sub-023_task-fingerTapping_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: bfb8ba562c522a0c015a3df39391d4fd
+      - creator: spdx:checksumAlgorithm_md5
+        notation: bfb8ba562c522a0c015a3df39391d4fd
     download_url:
       - https://dataverse.nl/api/access/datafile/46147
     media_type: image/nii
   - id: exthisdsver:./sub-023/func/sub-023_task-fingerTapping_echo-3_bold.json
     byte_size: 1034
     checksum:
-      - algorithm: md5
-        digest: 2176277f29fc8dcc3e19f93da85b9197
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2176277f29fc8dcc3e19f93da85b9197
     download_url:
       - https://dataverse.nl/api/access/datafile/46406
     media_type: application/json
   - id: exthisdsver:./sub-023/func/sub-023_task-fingerTapping_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: dc634a1d9f10316e2278751c8473c0be
+      - creator: spdx:checksumAlgorithm_md5
+        notation: dc634a1d9f10316e2278751c8473c0be
     download_url:
       - https://dataverse.nl/api/access/datafile/46448
     media_type: image/nii
   - id: exthisdsver:./sub-023/func/sub-023_task-fingerTapping_events.tsv.gz
     byte_size: 161
     checksum:
-      - algorithm: md5
-        digest: d241154c30bcb0493e2d418d13f8c05f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d241154c30bcb0493e2d418d13f8c05f
     download_url:
       - https://dataverse.nl/api/access/datafile/46649
     media_type: application/gzip
   - id: exthisdsver:./sub-023/func/sub-023_task-fingerTappingImagined_echo-1_bold.json
     byte_size: 1043
     checksum:
-      - algorithm: md5
-        digest: b69eed079d6bccffaf00bcb2cda51f57
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b69eed079d6bccffaf00bcb2cda51f57
     download_url:
       - https://dataverse.nl/api/access/datafile/45847
     media_type: application/json
   - id: exthisdsver:./sub-023/func/sub-023_task-fingerTappingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 8d92bad5d493f07867d69f7c5f6051b8
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8d92bad5d493f07867d69f7c5f6051b8
     download_url:
       - https://dataverse.nl/api/access/datafile/45690
     media_type: image/nii
   - id: exthisdsver:./sub-023/func/sub-023_task-fingerTappingImagined_echo-2_bold.json
     byte_size: 1043
     checksum:
-      - algorithm: md5
-        digest: 44a46805d160d5767824d8cd4b070d58
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 44a46805d160d5767824d8cd4b070d58
     download_url:
       - https://dataverse.nl/api/access/datafile/46212
     media_type: application/json
   - id: exthisdsver:./sub-023/func/sub-023_task-fingerTappingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 00b2cad2433c881267fdfa02a43a2e45
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 00b2cad2433c881267fdfa02a43a2e45
     download_url:
       - https://dataverse.nl/api/access/datafile/45457
     media_type: image/nii
   - id: exthisdsver:./sub-023/func/sub-023_task-fingerTappingImagined_echo-3_bold.json
     byte_size: 1043
     checksum:
-      - algorithm: md5
-        digest: 183ab485778295db7fd46441eacc886c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 183ab485778295db7fd46441eacc886c
     download_url:
       - https://dataverse.nl/api/access/datafile/45785
     media_type: application/json
   - id: exthisdsver:./sub-023/func/sub-023_task-fingerTappingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 4d944b7ac858f2e9662476c1bf995b42
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4d944b7ac858f2e9662476c1bf995b42
     download_url:
       - https://dataverse.nl/api/access/datafile/45219
     media_type: image/nii
   - id: exthisdsver:./sub-023/func/sub-023_task-fingerTappingImagined_events.tsv.gz
     byte_size: 178
     checksum:
-      - algorithm: md5
-        digest: 70e60fa9882a8d30488b374824af6499
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 70e60fa9882a8d30488b374824af6499
     download_url:
       - https://dataverse.nl/api/access/datafile/46592
     media_type: application/gzip
   - id: exthisdsver:./sub-023/func/sub-023_task-fingerTappingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 0f0086173d1dcc8bb7d8ec9bdceeb315
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 0f0086173d1dcc8bb7d8ec9bdceeb315
     download_url:
       - https://dataverse.nl/api/access/datafile/46366
     media_type: application/json
   - id: exthisdsver:./sub-023/func/sub-023_task-fingerTappingImagined_physio.tsv.gz
     byte_size: 512377
     checksum:
-      - algorithm: md5
-        digest: 042cbbfef09292ac25d134d9135742b4
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 042cbbfef09292ac25d134d9135742b4
     download_url:
       - https://dataverse.nl/api/access/datafile/45932
     media_type: application/gzip
   - id: exthisdsver:./sub-023/func/sub-023_task-fingerTapping_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 3c151582dfa12935a3e94fa555464670
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 3c151582dfa12935a3e94fa555464670
     download_url:
       - https://dataverse.nl/api/access/datafile/46375
     media_type: application/json
   - id: exthisdsver:./sub-023/func/sub-023_task-fingerTapping_physio.tsv.gz
     byte_size: 573250
     checksum:
-      - algorithm: md5
-        digest: e31a50e5585dac5f86b14c40c44c4641
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e31a50e5585dac5f86b14c40c44c4641
     download_url:
       - https://dataverse.nl/api/access/datafile/46026
     media_type: application/gzip
   - id: exthisdsver:./sub-023/func/sub-023_task-rest_run-1_echo-1_bold.json
     byte_size: 1026
     checksum:
-      - algorithm: md5
-        digest: 09d9cda61bdca32169b87036a74e4493
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 09d9cda61bdca32169b87036a74e4493
     download_url:
       - https://dataverse.nl/api/access/datafile/45468
     media_type: application/json
   - id: exthisdsver:./sub-023/func/sub-023_task-rest_run-1_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: b184d8b79dfd12b9faf0ab04261a1a8b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b184d8b79dfd12b9faf0ab04261a1a8b
     download_url:
       - https://dataverse.nl/api/access/datafile/45849
     media_type: image/nii
   - id: exthisdsver:./sub-023/func/sub-023_task-rest_run-1_echo-2_bold.json
     byte_size: 1026
     checksum:
-      - algorithm: md5
-        digest: c528f0904f8f45b0f3439a80555fe137
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c528f0904f8f45b0f3439a80555fe137
     download_url:
       - https://dataverse.nl/api/access/datafile/45499
     media_type: application/json
   - id: exthisdsver:./sub-023/func/sub-023_task-rest_run-1_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: b0a4fb582ff06cb91fc852ae7e8c12c8
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b0a4fb582ff06cb91fc852ae7e8c12c8
     download_url:
       - https://dataverse.nl/api/access/datafile/46210
     media_type: image/nii
   - id: exthisdsver:./sub-023/func/sub-023_task-rest_run-1_echo-3_bold.json
     byte_size: 1026
     checksum:
-      - algorithm: md5
-        digest: 02b896802ac19ea84fb72bee5a6c5fa0
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 02b896802ac19ea84fb72bee5a6c5fa0
     download_url:
       - https://dataverse.nl/api/access/datafile/46452
     media_type: application/json
   - id: exthisdsver:./sub-023/func/sub-023_task-rest_run-1_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 5e311054a6aca83fedd5d9f8b2569212
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5e311054a6aca83fedd5d9f8b2569212
     download_url:
       - https://dataverse.nl/api/access/datafile/46135
     media_type: image/nii
   - id: exthisdsver:./sub-023/func/sub-023_task-rest_run-1_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: e030b0f4a3d319892d065cd5d6bc7494
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e030b0f4a3d319892d065cd5d6bc7494
     download_url:
       - https://dataverse.nl/api/access/datafile/45127
     media_type: application/json
   - id: exthisdsver:./sub-023/func/sub-023_task-rest_run-1_physio.tsv.gz
     byte_size: 464020
     checksum:
-      - algorithm: md5
-        digest: 9a120a93187292ef4529d19b1f18066a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 9a120a93187292ef4529d19b1f18066a
     download_url:
       - https://dataverse.nl/api/access/datafile/46312
     media_type: application/gzip
   - id: exthisdsver:./sub-023/func/sub-023_task-rest_run-2_echo-1_bold.json
     byte_size: 1026
     checksum:
-      - algorithm: md5
-        digest: 8bbcfc3a334247aa457bb6a6933500d4
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8bbcfc3a334247aa457bb6a6933500d4
     download_url:
       - https://dataverse.nl/api/access/datafile/46167
     media_type: application/json
   - id: exthisdsver:./sub-023/func/sub-023_task-rest_run-2_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 8b2d236b9fc049bc1e73c5f272803665
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8b2d236b9fc049bc1e73c5f272803665
     download_url:
       - https://dataverse.nl/api/access/datafile/45755
     media_type: image/nii
   - id: exthisdsver:./sub-023/func/sub-023_task-rest_run-2_echo-2_bold.json
     byte_size: 1026
     checksum:
-      - algorithm: md5
-        digest: 1560ffeb235caa9c32ac0b9fcb036329
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1560ffeb235caa9c32ac0b9fcb036329
     download_url:
       - https://dataverse.nl/api/access/datafile/46424
     media_type: application/json
   - id: exthisdsver:./sub-023/func/sub-023_task-rest_run-2_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: eb6400394e46f8e946cac3f4ab9a9801
+      - creator: spdx:checksumAlgorithm_md5
+        notation: eb6400394e46f8e946cac3f4ab9a9801
     download_url:
       - https://dataverse.nl/api/access/datafile/46482
     media_type: image/nii
   - id: exthisdsver:./sub-023/func/sub-023_task-rest_run-2_echo-3_bold.json
     byte_size: 1026
     checksum:
-      - algorithm: md5
-        digest: 059ef7e442bd839ee701943a2610491b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 059ef7e442bd839ee701943a2610491b
     download_url:
       - https://dataverse.nl/api/access/datafile/45909
     media_type: application/json
   - id: exthisdsver:./sub-023/func/sub-023_task-rest_run-2_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: cfba33beea207804ebb08ce5671d388f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: cfba33beea207804ebb08ce5671d388f
     download_url:
       - https://dataverse.nl/api/access/datafile/46234
     media_type: image/nii
   - id: exthisdsver:./sub-023/func/sub-023_task-rest_run-2_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 21df412a6b8ed1f09cdcaa771100053e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 21df412a6b8ed1f09cdcaa771100053e
     download_url:
       - https://dataverse.nl/api/access/datafile/46072
     media_type: application/json
   - id: exthisdsver:./sub-023/func/sub-023_task-rest_run-2_physio.tsv.gz
     byte_size: 472513
     checksum:
-      - algorithm: md5
-        digest: df611445b7a2a0b8c819f3f22303e501
+      - creator: spdx:checksumAlgorithm_md5
+        notation: df611445b7a2a0b8c819f3f22303e501
     download_url:
       - https://dataverse.nl/api/access/datafile/45943
     media_type: application/gzip
   - id: exthisdsver:./sub-024/anat/sub-024_T1w.nii
     byte_size: 20736352
     checksum:
-      - algorithm: md5
-        digest: 190f6c4c0377b05944ce2878ec313e21
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 190f6c4c0377b05944ce2878ec313e21
     download_url:
       - https://dataverse.nl/api/access/datafile/45183
     media_type: image/nii
@@ -11340,8 +11340,8 @@ has_part:
   - id: exthisdsver:./sub-024/func/sub-024_task-emotionProcessing_echo-1_bold.json
     byte_size: 1034
     checksum:
-      - algorithm: md5
-        digest: 68900c5905293046b114fca82ab7d937
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 68900c5905293046b114fca82ab7d937
     download_url:
       - https://dataverse.nl/api/access/datafile/45242
     media_type: application/json
@@ -11460,48 +11460,48 @@ has_part:
   - id: exthisdsver:./sub-024/func/sub-024_task-emotionProcessing_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 851427f1f7c032e5906507f7d0405bd5
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 851427f1f7c032e5906507f7d0405bd5
     download_url:
       - https://dataverse.nl/api/access/datafile/45597
     media_type: image/nii
   - id: exthisdsver:./sub-024/func/sub-024_task-emotionProcessing_echo-2_bold.json
     byte_size: 1034
     checksum:
-      - algorithm: md5
-        digest: e596a8ec961747ea3d4b3b1de556d7b0
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e596a8ec961747ea3d4b3b1de556d7b0
     download_url:
       - https://dataverse.nl/api/access/datafile/45549
     media_type: application/json
   - id: exthisdsver:./sub-024/func/sub-024_task-emotionProcessing_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 4d38e51a3708d660e41987da08c79983
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4d38e51a3708d660e41987da08c79983
     download_url:
       - https://dataverse.nl/api/access/datafile/45641
     media_type: image/nii
   - id: exthisdsver:./sub-024/func/sub-024_task-emotionProcessing_echo-3_bold.json
     byte_size: 1034
     checksum:
-      - algorithm: md5
-        digest: 5745803b05c755cfd680e0f53019ef27
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5745803b05c755cfd680e0f53019ef27
     download_url:
       - https://dataverse.nl/api/access/datafile/45512
     media_type: application/json
   - id: exthisdsver:./sub-024/func/sub-024_task-emotionProcessing_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: e15de8fbb70e212620b8493fd6ecc49b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e15de8fbb70e212620b8493fd6ecc49b
     download_url:
       - https://dataverse.nl/api/access/datafile/45518
     media_type: image/nii
   - id: exthisdsver:./sub-024/func/sub-024_task-emotionProcessing_events.tsv.gz
     byte_size: 1897
     checksum:
-      - algorithm: md5
-        digest: 701119b52cf299609c5a915e6e2ffd51
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 701119b52cf299609c5a915e6e2ffd51
     download_url:
       - https://dataverse.nl/api/access/datafile/46606
     media_type: application/gzip
@@ -11509,8 +11509,8 @@ has_part:
       exthisdsver:./sub-024/func/sub-024_task-emotionProcessingImagined_echo-1_bold.json
     byte_size: 1042
     checksum:
-      - algorithm: md5
-        digest: 4a8d9600a8bf9a814c53283b0a8ff9be
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4a8d9600a8bf9a814c53283b0a8ff9be
     download_url:
       - https://dataverse.nl/api/access/datafile/46201
     media_type: application/json
@@ -11518,8 +11518,8 @@ has_part:
       exthisdsver:./sub-024/func/sub-024_task-emotionProcessingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: d3bf097795db1903df7186d7f1e0bf1c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d3bf097795db1903df7186d7f1e0bf1c
     download_url:
       - https://dataverse.nl/api/access/datafile/45421
     media_type: image/nii
@@ -11527,8 +11527,8 @@ has_part:
       exthisdsver:./sub-024/func/sub-024_task-emotionProcessingImagined_echo-2_bold.json
     byte_size: 1042
     checksum:
-      - algorithm: md5
-        digest: 33809dec60e32503256f7c45c17797b3
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 33809dec60e32503256f7c45c17797b3
     download_url:
       - https://dataverse.nl/api/access/datafile/45979
     media_type: application/json
@@ -11536,8 +11536,8 @@ has_part:
       exthisdsver:./sub-024/func/sub-024_task-emotionProcessingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 67d380c3bd9daeeb8460387ed87a29e8
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 67d380c3bd9daeeb8460387ed87a29e8
     download_url:
       - https://dataverse.nl/api/access/datafile/45260
     media_type: image/nii
@@ -11545,8 +11545,8 @@ has_part:
       exthisdsver:./sub-024/func/sub-024_task-emotionProcessingImagined_echo-3_bold.json
     byte_size: 1042
     checksum:
-      - algorithm: md5
-        digest: f62132b9d9a3dba3780c37681502185f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f62132b9d9a3dba3780c37681502185f
     download_url:
       - https://dataverse.nl/api/access/datafile/46287
     media_type: application/json
@@ -11554,328 +11554,328 @@ has_part:
       exthisdsver:./sub-024/func/sub-024_task-emotionProcessingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 639095cdb453f2822378e0bb565d37e4
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 639095cdb453f2822378e0bb565d37e4
     download_url:
       - https://dataverse.nl/api/access/datafile/45766
     media_type: image/nii
   - id: exthisdsver:./sub-024/func/sub-024_task-emotionProcessingImagined_events.tsv.gz
     byte_size: 180
     checksum:
-      - algorithm: md5
-        digest: ce6d682d4ed61ae643a4a035008d7815
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ce6d682d4ed61ae643a4a035008d7815
     download_url:
       - https://dataverse.nl/api/access/datafile/46551
     media_type: application/gzip
   - id: exthisdsver:./sub-024/func/sub-024_task-emotionProcessingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 5688150bd72bd5aaaf6d4356ecafcf4a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5688150bd72bd5aaaf6d4356ecafcf4a
     download_url:
       - https://dataverse.nl/api/access/datafile/46309
     media_type: application/json
   - id: exthisdsver:./sub-024/func/sub-024_task-emotionProcessingImagined_physio.tsv.gz
     byte_size: 456438
     checksum:
-      - algorithm: md5
-        digest: 39de7e6e8e2d3f2cfc6444da6338b4dd
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 39de7e6e8e2d3f2cfc6444da6338b4dd
     download_url:
       - https://dataverse.nl/api/access/datafile/45481
     media_type: application/gzip
   - id: exthisdsver:./sub-024/func/sub-024_task-emotionProcessing_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 569846b608131148ba2ff54e8d610d04
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 569846b608131148ba2ff54e8d610d04
     download_url:
       - https://dataverse.nl/api/access/datafile/45353
     media_type: application/json
   - id: exthisdsver:./sub-024/func/sub-024_task-emotionProcessing_physio.tsv.gz
     byte_size: 524926
     checksum:
-      - algorithm: md5
-        digest: 0cf2d5a06375a9955838110f934deb1b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 0cf2d5a06375a9955838110f934deb1b
     download_url:
       - https://dataverse.nl/api/access/datafile/46080
     media_type: application/gzip
   - id: exthisdsver:./sub-024/func/sub-024_task-fingerTapping_echo-1_bold.json
     byte_size: 1031
     checksum:
-      - algorithm: md5
-        digest: 3642c5b258b8fe806138da050fab7577
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 3642c5b258b8fe806138da050fab7577
     download_url:
       - https://dataverse.nl/api/access/datafile/45441
     media_type: application/json
   - id: exthisdsver:./sub-024/func/sub-024_task-fingerTapping_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 867676e8bda9acb30d89a4f7ddbb270d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 867676e8bda9acb30d89a4f7ddbb270d
     download_url:
       - https://dataverse.nl/api/access/datafile/46486
     media_type: image/nii
   - id: exthisdsver:./sub-024/func/sub-024_task-fingerTapping_echo-2_bold.json
     byte_size: 1031
     checksum:
-      - algorithm: md5
-        digest: 9dc29fcf832822fde8f681b6915eba97
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 9dc29fcf832822fde8f681b6915eba97
     download_url:
       - https://dataverse.nl/api/access/datafile/45453
     media_type: application/json
   - id: exthisdsver:./sub-024/func/sub-024_task-fingerTapping_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: fba3ceef317bd3f6b4e952fbe8e95f60
+      - creator: spdx:checksumAlgorithm_md5
+        notation: fba3ceef317bd3f6b4e952fbe8e95f60
     download_url:
       - https://dataverse.nl/api/access/datafile/45546
     media_type: image/nii
   - id: exthisdsver:./sub-024/func/sub-024_task-fingerTapping_echo-3_bold.json
     byte_size: 1031
     checksum:
-      - algorithm: md5
-        digest: e8b15f05c6532ff094f30434e58ecd54
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e8b15f05c6532ff094f30434e58ecd54
     download_url:
       - https://dataverse.nl/api/access/datafile/45565
     media_type: application/json
   - id: exthisdsver:./sub-024/func/sub-024_task-fingerTapping_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 1926d0d618f52d3002e1e66a5760b540
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1926d0d618f52d3002e1e66a5760b540
     download_url:
       - https://dataverse.nl/api/access/datafile/45679
     media_type: image/nii
   - id: exthisdsver:./sub-024/func/sub-024_task-fingerTapping_events.tsv.gz
     byte_size: 168
     checksum:
-      - algorithm: md5
-        digest: 2f57b6782192a800c7065db2a988071c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2f57b6782192a800c7065db2a988071c
     download_url:
       - https://dataverse.nl/api/access/datafile/46654
     media_type: application/gzip
   - id: exthisdsver:./sub-024/func/sub-024_task-fingerTappingImagined_echo-1_bold.json
     byte_size: 1039
     checksum:
-      - algorithm: md5
-        digest: 25d5c66a770a017ee0ae4663c77b1bd7
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 25d5c66a770a017ee0ae4663c77b1bd7
     download_url:
       - https://dataverse.nl/api/access/datafile/45602
     media_type: application/json
   - id: exthisdsver:./sub-024/func/sub-024_task-fingerTappingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 1cbb35815c5f6630a1a068598f67da0c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1cbb35815c5f6630a1a068598f67da0c
     download_url:
       - https://dataverse.nl/api/access/datafile/45794
     media_type: image/nii
   - id: exthisdsver:./sub-024/func/sub-024_task-fingerTappingImagined_echo-2_bold.json
     byte_size: 1039
     checksum:
-      - algorithm: md5
-        digest: 6c1a5de28e56da183e2ee15608671ed1
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6c1a5de28e56da183e2ee15608671ed1
     download_url:
       - https://dataverse.nl/api/access/datafile/45511
     media_type: application/json
   - id: exthisdsver:./sub-024/func/sub-024_task-fingerTappingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: ad84562e4b9beb78396c96c2e1fda3d4
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ad84562e4b9beb78396c96c2e1fda3d4
     download_url:
       - https://dataverse.nl/api/access/datafile/46254
     media_type: image/nii
   - id: exthisdsver:./sub-024/func/sub-024_task-fingerTappingImagined_echo-3_bold.json
     byte_size: 1039
     checksum:
-      - algorithm: md5
-        digest: c59422134a338595b729c746363dbfaf
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c59422134a338595b729c746363dbfaf
     download_url:
       - https://dataverse.nl/api/access/datafile/46268
     media_type: application/json
   - id: exthisdsver:./sub-024/func/sub-024_task-fingerTappingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: e6e1463f8a5543ce4211ea9434bb0f84
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e6e1463f8a5543ce4211ea9434bb0f84
     download_url:
       - https://dataverse.nl/api/access/datafile/45870
     media_type: image/nii
   - id: exthisdsver:./sub-024/func/sub-024_task-fingerTappingImagined_events.tsv.gz
     byte_size: 180
     checksum:
-      - algorithm: md5
-        digest: 1112eaa2187cf14649e60accef58ce48
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1112eaa2187cf14649e60accef58ce48
     download_url:
       - https://dataverse.nl/api/access/datafile/46622
     media_type: application/gzip
   - id: exthisdsver:./sub-024/func/sub-024_task-fingerTappingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 7de904e51a84a1e94f4080c9dc80bae7
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 7de904e51a84a1e94f4080c9dc80bae7
     download_url:
       - https://dataverse.nl/api/access/datafile/46104
     media_type: application/json
   - id: exthisdsver:./sub-024/func/sub-024_task-fingerTappingImagined_physio.tsv.gz
     byte_size: 459731
     checksum:
-      - algorithm: md5
-        digest: dbc6c08de56357e98e8fab751ec459ae
+      - creator: spdx:checksumAlgorithm_md5
+        notation: dbc6c08de56357e98e8fab751ec459ae
     download_url:
       - https://dataverse.nl/api/access/datafile/45215
     media_type: application/gzip
   - id: exthisdsver:./sub-024/func/sub-024_task-fingerTapping_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 96cd7e0c51001877967102a056c08652
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 96cd7e0c51001877967102a056c08652
     download_url:
       - https://dataverse.nl/api/access/datafile/46182
     media_type: application/json
   - id: exthisdsver:./sub-024/func/sub-024_task-fingerTapping_physio.tsv.gz
     byte_size: 473161
     checksum:
-      - algorithm: md5
-        digest: 5bb5eb74cb99f2cc266f3439c9f1240e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5bb5eb74cb99f2cc266f3439c9f1240e
     download_url:
       - https://dataverse.nl/api/access/datafile/45405
     media_type: application/gzip
   - id: exthisdsver:./sub-024/func/sub-024_task-rest_run-1_echo-1_bold.json
     byte_size: 1022
     checksum:
-      - algorithm: md5
-        digest: f5c7158e1de14a6243ccb67928bf4a15
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f5c7158e1de14a6243ccb67928bf4a15
     download_url:
       - https://dataverse.nl/api/access/datafile/46189
     media_type: application/json
   - id: exthisdsver:./sub-024/func/sub-024_task-rest_run-1_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: c7bf87ca41c8aa7eb8018a8b4e9c6571
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c7bf87ca41c8aa7eb8018a8b4e9c6571
     download_url:
       - https://dataverse.nl/api/access/datafile/46019
     media_type: image/nii
   - id: exthisdsver:./sub-024/func/sub-024_task-rest_run-1_echo-2_bold.json
     byte_size: 1022
     checksum:
-      - algorithm: md5
-        digest: 0500137347eae1b221aa40a87a900413
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 0500137347eae1b221aa40a87a900413
     download_url:
       - https://dataverse.nl/api/access/datafile/46085
     media_type: application/json
   - id: exthisdsver:./sub-024/func/sub-024_task-rest_run-1_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 1d131b1c3c9d87d0260bcc1618485fe1
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1d131b1c3c9d87d0260bcc1618485fe1
     download_url:
       - https://dataverse.nl/api/access/datafile/45413
     media_type: image/nii
   - id: exthisdsver:./sub-024/func/sub-024_task-rest_run-1_echo-3_bold.json
     byte_size: 1022
     checksum:
-      - algorithm: md5
-        digest: 4141f90fef546e2fb5c9aad9ddd7b774
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4141f90fef546e2fb5c9aad9ddd7b774
     download_url:
       - https://dataverse.nl/api/access/datafile/45310
     media_type: application/json
   - id: exthisdsver:./sub-024/func/sub-024_task-rest_run-1_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: d0faca977d58aa06eff58b637cf9b906
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d0faca977d58aa06eff58b637cf9b906
     download_url:
       - https://dataverse.nl/api/access/datafile/45726
     media_type: image/nii
   - id: exthisdsver:./sub-024/func/sub-024_task-rest_run-1_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 7784a62a3163771005cac907491c3151
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 7784a62a3163771005cac907491c3151
     download_url:
       - https://dataverse.nl/api/access/datafile/46221
     media_type: application/json
   - id: exthisdsver:./sub-024/func/sub-024_task-rest_run-1_physio.tsv.gz
     byte_size: 447685
     checksum:
-      - algorithm: md5
-        digest: eb419260bf47beaac73513690fbd877e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: eb419260bf47beaac73513690fbd877e
     download_url:
       - https://dataverse.nl/api/access/datafile/45352
     media_type: application/gzip
   - id: exthisdsver:./sub-024/func/sub-024_task-rest_run-2_echo-1_bold.json
     byte_size: 1022
     checksum:
-      - algorithm: md5
-        digest: 1494bc84b63d4b5f16a1111227e6034d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1494bc84b63d4b5f16a1111227e6034d
     download_url:
       - https://dataverse.nl/api/access/datafile/46310
     media_type: application/json
   - id: exthisdsver:./sub-024/func/sub-024_task-rest_run-2_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 132d374f5df768f4109ad49ebc68b957
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 132d374f5df768f4109ad49ebc68b957
     download_url:
       - https://dataverse.nl/api/access/datafile/45289
     media_type: image/nii
   - id: exthisdsver:./sub-024/func/sub-024_task-rest_run-2_echo-2_bold.json
     byte_size: 1022
     checksum:
-      - algorithm: md5
-        digest: 70c0a25802f20891aca37f2086d2f36d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 70c0a25802f20891aca37f2086d2f36d
     download_url:
       - https://dataverse.nl/api/access/datafile/45214
     media_type: application/json
   - id: exthisdsver:./sub-024/func/sub-024_task-rest_run-2_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 20b27c94c65afe4b35f4c69463b27f7c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 20b27c94c65afe4b35f4c69463b27f7c
     download_url:
       - https://dataverse.nl/api/access/datafile/45236
     media_type: image/nii
   - id: exthisdsver:./sub-024/func/sub-024_task-rest_run-2_echo-3_bold.json
     byte_size: 1022
     checksum:
-      - algorithm: md5
-        digest: c8ee7ca3c82e8aeeee940a21ea760fd9
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c8ee7ca3c82e8aeeee940a21ea760fd9
     download_url:
       - https://dataverse.nl/api/access/datafile/45894
     media_type: application/json
   - id: exthisdsver:./sub-024/func/sub-024_task-rest_run-2_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 681bd5c0caa8ab71f905c238ce037af3
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 681bd5c0caa8ab71f905c238ce037af3
     download_url:
       - https://dataverse.nl/api/access/datafile/45267
     media_type: image/nii
   - id: exthisdsver:./sub-024/func/sub-024_task-rest_run-2_physio.json
     byte_size: 141
     checksum:
-      - algorithm: md5
-        digest: 15cc74fd2352e18be8675e2ffd1a327a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 15cc74fd2352e18be8675e2ffd1a327a
     download_url:
       - https://dataverse.nl/api/access/datafile/45125
     media_type: application/json
   - id: exthisdsver:./sub-024/func/sub-024_task-rest_run-2_physio.tsv.gz
     byte_size: 462496
     checksum:
-      - algorithm: md5
-        digest: 32435ea664e7ada98f766f86540c042a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 32435ea664e7ada98f766f86540c042a
     download_url:
       - https://dataverse.nl/api/access/datafile/45692
     media_type: application/gzip
   - id: exthisdsver:./sub-025/anat/sub-025_T1w.nii
     byte_size: 20736352
     checksum:
-      - algorithm: md5
-        digest: 7f7a942231041371976b996b0baadb9e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 7f7a942231041371976b996b0baadb9e
     download_url:
       - https://dataverse.nl/api/access/datafile/45306
     media_type: image/nii
@@ -11892,8 +11892,8 @@ has_part:
   - id: exthisdsver:./sub-025/func/sub-025_task-emotionProcessing_echo-1_bold.json
     byte_size: 1042
     checksum:
-      - algorithm: md5
-        digest: 73a60ea9762e960d7701531a74a2ed9d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 73a60ea9762e960d7701531a74a2ed9d
     download_url:
       - https://dataverse.nl/api/access/datafile/45958
     media_type: application/json
@@ -12012,48 +12012,48 @@ has_part:
   - id: exthisdsver:./sub-025/func/sub-025_task-emotionProcessing_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 240a45381b94d5ca4d4ade6eaaf7c534
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 240a45381b94d5ca4d4ade6eaaf7c534
     download_url:
       - https://dataverse.nl/api/access/datafile/45351
     media_type: image/nii
   - id: exthisdsver:./sub-025/func/sub-025_task-emotionProcessing_echo-2_bold.json
     byte_size: 1042
     checksum:
-      - algorithm: md5
-        digest: 18f17176166efa9151bb8ca293698c6c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 18f17176166efa9151bb8ca293698c6c
     download_url:
       - https://dataverse.nl/api/access/datafile/45198
     media_type: application/json
   - id: exthisdsver:./sub-025/func/sub-025_task-emotionProcessing_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: feca4cabeb9b08cf58eeb4c8ba952f77
+      - creator: spdx:checksumAlgorithm_md5
+        notation: feca4cabeb9b08cf58eeb4c8ba952f77
     download_url:
       - https://dataverse.nl/api/access/datafile/46275
     media_type: image/nii
   - id: exthisdsver:./sub-025/func/sub-025_task-emotionProcessing_echo-3_bold.json
     byte_size: 1042
     checksum:
-      - algorithm: md5
-        digest: 79a76423364b453c79bee24ab27fddaa
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 79a76423364b453c79bee24ab27fddaa
     download_url:
       - https://dataverse.nl/api/access/datafile/46298
     media_type: application/json
   - id: exthisdsver:./sub-025/func/sub-025_task-emotionProcessing_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 9f4e28cd101143505ac5185185124158
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 9f4e28cd101143505ac5185185124158
     download_url:
       - https://dataverse.nl/api/access/datafile/45341
     media_type: image/nii
   - id: exthisdsver:./sub-025/func/sub-025_task-emotionProcessing_events.tsv.gz
     byte_size: 1896
     checksum:
-      - algorithm: md5
-        digest: 74b10e4d7333f58ed1b380af45c84266
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 74b10e4d7333f58ed1b380af45c84266
     download_url:
       - https://dataverse.nl/api/access/datafile/46576
     media_type: application/gzip
@@ -12061,8 +12061,8 @@ has_part:
       exthisdsver:./sub-025/func/sub-025_task-emotionProcessingImagined_echo-1_bold.json
     byte_size: 1050
     checksum:
-      - algorithm: md5
-        digest: f53925e9fa6a24259e91d0537d5d725b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f53925e9fa6a24259e91d0537d5d725b
     download_url:
       - https://dataverse.nl/api/access/datafile/46037
     media_type: application/json
@@ -12070,8 +12070,8 @@ has_part:
       exthisdsver:./sub-025/func/sub-025_task-emotionProcessingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 0577b1e7ea6786bae61031a06220a810
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 0577b1e7ea6786bae61031a06220a810
     download_url:
       - https://dataverse.nl/api/access/datafile/45491
     media_type: image/nii
@@ -12079,8 +12079,8 @@ has_part:
       exthisdsver:./sub-025/func/sub-025_task-emotionProcessingImagined_echo-2_bold.json
     byte_size: 1050
     checksum:
-      - algorithm: md5
-        digest: e13ebf196f9e07478266674ac5ead24e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e13ebf196f9e07478266674ac5ead24e
     download_url:
       - https://dataverse.nl/api/access/datafile/45898
     media_type: application/json
@@ -12088,8 +12088,8 @@ has_part:
       exthisdsver:./sub-025/func/sub-025_task-emotionProcessingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: a994b10225ee41df351809c9358faf85
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a994b10225ee41df351809c9358faf85
     download_url:
       - https://dataverse.nl/api/access/datafile/45929
     media_type: image/nii
@@ -12097,8 +12097,8 @@ has_part:
       exthisdsver:./sub-025/func/sub-025_task-emotionProcessingImagined_echo-3_bold.json
     byte_size: 1050
     checksum:
-      - algorithm: md5
-        digest: c7b24e636a25b4d08c411f949ab0ef5a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c7b24e636a25b4d08c411f949ab0ef5a
     download_url:
       - https://dataverse.nl/api/access/datafile/45743
     media_type: application/json
@@ -12106,328 +12106,328 @@ has_part:
       exthisdsver:./sub-025/func/sub-025_task-emotionProcessingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 15d6eaa340a866de7e64b32cee611a03
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 15d6eaa340a866de7e64b32cee611a03
     download_url:
       - https://dataverse.nl/api/access/datafile/46194
     media_type: image/nii
   - id: exthisdsver:./sub-025/func/sub-025_task-emotionProcessingImagined_events.tsv.gz
     byte_size: 180
     checksum:
-      - algorithm: md5
-        digest: 037993522fb30018c40367a704483687
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 037993522fb30018c40367a704483687
     download_url:
       - https://dataverse.nl/api/access/datafile/46641
     media_type: application/gzip
   - id: exthisdsver:./sub-025/func/sub-025_task-emotionProcessingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: f2ea0de36ad20fbd34744be2686ef790
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f2ea0de36ad20fbd34744be2686ef790
     download_url:
       - https://dataverse.nl/api/access/datafile/46062
     media_type: application/json
   - id: exthisdsver:./sub-025/func/sub-025_task-emotionProcessingImagined_physio.tsv.gz
     byte_size: 450969
     checksum:
-      - algorithm: md5
-        digest: 5aeaf61ce59c611def6ca7200925fcad
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5aeaf61ce59c611def6ca7200925fcad
     download_url:
       - https://dataverse.nl/api/access/datafile/45662
     media_type: application/gzip
   - id: exthisdsver:./sub-025/func/sub-025_task-emotionProcessing_physio.json
     byte_size: 142
     checksum:
-      - algorithm: md5
-        digest: 495e70560c2f494854fc9dcac2abf81b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 495e70560c2f494854fc9dcac2abf81b
     download_url:
       - https://dataverse.nl/api/access/datafile/45584
     media_type: application/json
   - id: exthisdsver:./sub-025/func/sub-025_task-emotionProcessing_physio.tsv.gz
     byte_size: 505872
     checksum:
-      - algorithm: md5
-        digest: ca9ef6362d3c02e157aa2b5b31663737
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ca9ef6362d3c02e157aa2b5b31663737
     download_url:
       - https://dataverse.nl/api/access/datafile/46348
     media_type: application/gzip
   - id: exthisdsver:./sub-025/func/sub-025_task-fingerTapping_echo-1_bold.json
     byte_size: 1038
     checksum:
-      - algorithm: md5
-        digest: 2a4112c592ddeeffa7b0d609eaa48472
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2a4112c592ddeeffa7b0d609eaa48472
     download_url:
       - https://dataverse.nl/api/access/datafile/45888
     media_type: application/json
   - id: exthisdsver:./sub-025/func/sub-025_task-fingerTapping_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 7a4989302353c2507229aa6e1a36a2d9
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 7a4989302353c2507229aa6e1a36a2d9
     download_url:
       - https://dataverse.nl/api/access/datafile/45181
     media_type: image/nii
   - id: exthisdsver:./sub-025/func/sub-025_task-fingerTapping_echo-2_bold.json
     byte_size: 1038
     checksum:
-      - algorithm: md5
-        digest: 049d6292f471d9725b1bb562b3f48b20
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 049d6292f471d9725b1bb562b3f48b20
     download_url:
       - https://dataverse.nl/api/access/datafile/45500
     media_type: application/json
   - id: exthisdsver:./sub-025/func/sub-025_task-fingerTapping_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 62d567a6946e8f2f95e45e70b33da544
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 62d567a6946e8f2f95e45e70b33da544
     download_url:
       - https://dataverse.nl/api/access/datafile/45463
     media_type: image/nii
   - id: exthisdsver:./sub-025/func/sub-025_task-fingerTapping_echo-3_bold.json
     byte_size: 1038
     checksum:
-      - algorithm: md5
-        digest: 9b661b4cd4ef743034cfef2427b76d08
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 9b661b4cd4ef743034cfef2427b76d08
     download_url:
       - https://dataverse.nl/api/access/datafile/45337
     media_type: application/json
   - id: exthisdsver:./sub-025/func/sub-025_task-fingerTapping_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 91b40c8fead0371648bd2b77154f9dd1
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 91b40c8fead0371648bd2b77154f9dd1
     download_url:
       - https://dataverse.nl/api/access/datafile/45204
     media_type: image/nii
   - id: exthisdsver:./sub-025/func/sub-025_task-fingerTapping_events.tsv.gz
     byte_size: 167
     checksum:
-      - algorithm: md5
-        digest: 575dcf28dc7c1641f5117121b99bfb5b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 575dcf28dc7c1641f5117121b99bfb5b
     download_url:
       - https://dataverse.nl/api/access/datafile/46632
     media_type: application/gzip
   - id: exthisdsver:./sub-025/func/sub-025_task-fingerTappingImagined_echo-1_bold.json
     byte_size: 1046
     checksum:
-      - algorithm: md5
-        digest: c2ba2164df29bcb46e163701354cc111
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c2ba2164df29bcb46e163701354cc111
     download_url:
       - https://dataverse.nl/api/access/datafile/45925
     media_type: application/json
   - id: exthisdsver:./sub-025/func/sub-025_task-fingerTappingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 065a74091eb867a4b9165209bd271403
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 065a74091eb867a4b9165209bd271403
     download_url:
       - https://dataverse.nl/api/access/datafile/45927
     media_type: image/nii
   - id: exthisdsver:./sub-025/func/sub-025_task-fingerTappingImagined_echo-2_bold.json
     byte_size: 1046
     checksum:
-      - algorithm: md5
-        digest: 45d501c3ef2f6c388b26b5165818aa51
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 45d501c3ef2f6c388b26b5165818aa51
     download_url:
       - https://dataverse.nl/api/access/datafile/45340
     media_type: application/json
   - id: exthisdsver:./sub-025/func/sub-025_task-fingerTappingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 18bd02a9fc512830f0a2a0f00f23023a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 18bd02a9fc512830f0a2a0f00f23023a
     download_url:
       - https://dataverse.nl/api/access/datafile/45567
     media_type: image/nii
   - id: exthisdsver:./sub-025/func/sub-025_task-fingerTappingImagined_echo-3_bold.json
     byte_size: 1046
     checksum:
-      - algorithm: md5
-        digest: b555c9c1024633c1267d0bb87060f4a5
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b555c9c1024633c1267d0bb87060f4a5
     download_url:
       - https://dataverse.nl/api/access/datafile/45978
     media_type: application/json
   - id: exthisdsver:./sub-025/func/sub-025_task-fingerTappingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 2152b72ca956bf7a8c9ba8392fe4dcf7
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2152b72ca956bf7a8c9ba8392fe4dcf7
     download_url:
       - https://dataverse.nl/api/access/datafile/45096
     media_type: image/nii
   - id: exthisdsver:./sub-025/func/sub-025_task-fingerTappingImagined_events.tsv.gz
     byte_size: 179
     checksum:
-      - algorithm: md5
-        digest: c3721d501643fa74c63a2849bbe0fc29
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c3721d501643fa74c63a2849bbe0fc29
     download_url:
       - https://dataverse.nl/api/access/datafile/46555
     media_type: application/gzip
   - id: exthisdsver:./sub-025/func/sub-025_task-fingerTappingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: bc7ea47540ecc5fd483cea3751596558
+      - creator: spdx:checksumAlgorithm_md5
+        notation: bc7ea47540ecc5fd483cea3751596558
     download_url:
       - https://dataverse.nl/api/access/datafile/45250
     media_type: application/json
   - id: exthisdsver:./sub-025/func/sub-025_task-fingerTappingImagined_physio.tsv.gz
     byte_size: 479333
     checksum:
-      - algorithm: md5
-        digest: 2ddca451eda2d8d03218a82b70c566ca
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2ddca451eda2d8d03218a82b70c566ca
     download_url:
       - https://dataverse.nl/api/access/datafile/45534
     media_type: application/gzip
   - id: exthisdsver:./sub-025/func/sub-025_task-fingerTapping_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 8ef8c83c58f8e3b5b6118e0b84e00404
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8ef8c83c58f8e3b5b6118e0b84e00404
     download_url:
       - https://dataverse.nl/api/access/datafile/45823
     media_type: application/json
   - id: exthisdsver:./sub-025/func/sub-025_task-fingerTapping_physio.tsv.gz
     byte_size: 496050
     checksum:
-      - algorithm: md5
-        digest: ce57f859bfd8c3ce710253e4daa4dd60
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ce57f859bfd8c3ce710253e4daa4dd60
     download_url:
       - https://dataverse.nl/api/access/datafile/46039
     media_type: application/gzip
   - id: exthisdsver:./sub-025/func/sub-025_task-rest_run-1_echo-1_bold.json
     byte_size: 1029
     checksum:
-      - algorithm: md5
-        digest: 2c9dcd69ba60afc1907ff85b249312b6
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2c9dcd69ba60afc1907ff85b249312b6
     download_url:
       - https://dataverse.nl/api/access/datafile/45938
     media_type: application/json
   - id: exthisdsver:./sub-025/func/sub-025_task-rest_run-1_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 60d5dd81c35de9876e0f66908461cbc6
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 60d5dd81c35de9876e0f66908461cbc6
     download_url:
       - https://dataverse.nl/api/access/datafile/45311
     media_type: image/nii
   - id: exthisdsver:./sub-025/func/sub-025_task-rest_run-1_echo-2_bold.json
     byte_size: 1029
     checksum:
-      - algorithm: md5
-        digest: c8e33ac93b50f58fa0687b474791e7d3
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c8e33ac93b50f58fa0687b474791e7d3
     download_url:
       - https://dataverse.nl/api/access/datafile/45475
     media_type: application/json
   - id: exthisdsver:./sub-025/func/sub-025_task-rest_run-1_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 3a646ee3c1b543a56a0f21176be2efdd
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 3a646ee3c1b543a56a0f21176be2efdd
     download_url:
       - https://dataverse.nl/api/access/datafile/46370
     media_type: image/nii
   - id: exthisdsver:./sub-025/func/sub-025_task-rest_run-1_echo-3_bold.json
     byte_size: 1029
     checksum:
-      - algorithm: md5
-        digest: 8c21a8507b6cb565588c0140180d2772
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8c21a8507b6cb565588c0140180d2772
     download_url:
       - https://dataverse.nl/api/access/datafile/45753
     media_type: application/json
   - id: exthisdsver:./sub-025/func/sub-025_task-rest_run-1_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: a147274fd35661aa0c1fa1d7f0b308b1
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a147274fd35661aa0c1fa1d7f0b308b1
     download_url:
       - https://dataverse.nl/api/access/datafile/46272
     media_type: image/nii
   - id: exthisdsver:./sub-025/func/sub-025_task-rest_run-1_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: e53241984863a44ace80f7ae64b587ef
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e53241984863a44ace80f7ae64b587ef
     download_url:
       - https://dataverse.nl/api/access/datafile/45211
     media_type: application/json
   - id: exthisdsver:./sub-025/func/sub-025_task-rest_run-1_physio.tsv.gz
     byte_size: 457356
     checksum:
-      - algorithm: md5
-        digest: 807f681d4fd68b0f5b7bd9a208e0619f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 807f681d4fd68b0f5b7bd9a208e0619f
     download_url:
       - https://dataverse.nl/api/access/datafile/46116
     media_type: application/gzip
   - id: exthisdsver:./sub-025/func/sub-025_task-rest_run-2_echo-1_bold.json
     byte_size: 1029
     checksum:
-      - algorithm: md5
-        digest: b2ef37dc700fe8774b2c78aa3033676b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b2ef37dc700fe8774b2c78aa3033676b
     download_url:
       - https://dataverse.nl/api/access/datafile/46521
     media_type: application/json
   - id: exthisdsver:./sub-025/func/sub-025_task-rest_run-2_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 86f7de0aab6e037b267cb59be01522e9
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 86f7de0aab6e037b267cb59be01522e9
     download_url:
       - https://dataverse.nl/api/access/datafile/45322
     media_type: image/nii
   - id: exthisdsver:./sub-025/func/sub-025_task-rest_run-2_echo-2_bold.json
     byte_size: 1029
     checksum:
-      - algorithm: md5
-        digest: 77076e6d43c5ef3e1c1fd7bd96098a54
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 77076e6d43c5ef3e1c1fd7bd96098a54
     download_url:
       - https://dataverse.nl/api/access/datafile/45656
     media_type: application/json
   - id: exthisdsver:./sub-025/func/sub-025_task-rest_run-2_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 27a372721c92ce378d24b66dc45177a2
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 27a372721c92ce378d24b66dc45177a2
     download_url:
       - https://dataverse.nl/api/access/datafile/45931
     media_type: image/nii
   - id: exthisdsver:./sub-025/func/sub-025_task-rest_run-2_echo-3_bold.json
     byte_size: 1029
     checksum:
-      - algorithm: md5
-        digest: a26b09276b6ebf55dcafcc93a40391a9
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a26b09276b6ebf55dcafcc93a40391a9
     download_url:
       - https://dataverse.nl/api/access/datafile/46458
     media_type: application/json
   - id: exthisdsver:./sub-025/func/sub-025_task-rest_run-2_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 2c415447bbfe53ac60adf92aad2d998e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2c415447bbfe53ac60adf92aad2d998e
     download_url:
       - https://dataverse.nl/api/access/datafile/45113
     media_type: image/nii
   - id: exthisdsver:./sub-025/func/sub-025_task-rest_run-2_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 7dd438d04b16055b2fd0ae4459538b3a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 7dd438d04b16055b2fd0ae4459538b3a
     download_url:
       - https://dataverse.nl/api/access/datafile/45592
     media_type: application/json
   - id: exthisdsver:./sub-025/func/sub-025_task-rest_run-2_physio.tsv.gz
     byte_size: 448369
     checksum:
-      - algorithm: md5
-        digest: 56668a26291c7bd6af6901f2942bc7ba
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 56668a26291c7bd6af6901f2942bc7ba
     download_url:
       - https://dataverse.nl/api/access/datafile/45367
     media_type: application/gzip
   - id: exthisdsver:./sub-026/anat/sub-026_T1w.nii
     byte_size: 20736352
     checksum:
-      - algorithm: md5
-        digest: b0393dbc149581f72e5faec4f4010dd1
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b0393dbc149581f72e5faec4f4010dd1
     download_url:
       - https://dataverse.nl/api/access/datafile/45775
     media_type: image/nii
@@ -12444,8 +12444,8 @@ has_part:
   - id: exthisdsver:./sub-026/func/sub-026_task-emotionProcessing_echo-1_bold.json
     byte_size: 1041
     checksum:
-      - algorithm: md5
-        digest: c3c5a4acf31d2c108256ac46d603f2e0
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c3c5a4acf31d2c108256ac46d603f2e0
     download_url:
       - https://dataverse.nl/api/access/datafile/46180
     media_type: application/json
@@ -12564,48 +12564,48 @@ has_part:
   - id: exthisdsver:./sub-026/func/sub-026_task-emotionProcessing_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 770c0aab148ac49b357464c9b08789c1
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 770c0aab148ac49b357464c9b08789c1
     download_url:
       - https://dataverse.nl/api/access/datafile/45720
     media_type: image/nii
   - id: exthisdsver:./sub-026/func/sub-026_task-emotionProcessing_echo-2_bold.json
     byte_size: 1041
     checksum:
-      - algorithm: md5
-        digest: 22ff64eb37754e5c041c65e50d73e027
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 22ff64eb37754e5c041c65e50d73e027
     download_url:
       - https://dataverse.nl/api/access/datafile/45124
     media_type: application/json
   - id: exthisdsver:./sub-026/func/sub-026_task-emotionProcessing_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: e0745a6a4926df590506751ab2f87f2f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e0745a6a4926df590506751ab2f87f2f
     download_url:
       - https://dataverse.nl/api/access/datafile/46126
     media_type: image/nii
   - id: exthisdsver:./sub-026/func/sub-026_task-emotionProcessing_echo-3_bold.json
     byte_size: 1041
     checksum:
-      - algorithm: md5
-        digest: 61bcc9bddf6122c8bf7713df4eeca7ae
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 61bcc9bddf6122c8bf7713df4eeca7ae
     download_url:
       - https://dataverse.nl/api/access/datafile/45191
     media_type: application/json
   - id: exthisdsver:./sub-026/func/sub-026_task-emotionProcessing_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 02180f5df7a7e039eb6be0af5fd144b9
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 02180f5df7a7e039eb6be0af5fd144b9
     download_url:
       - https://dataverse.nl/api/access/datafile/45717
     media_type: image/nii
   - id: exthisdsver:./sub-026/func/sub-026_task-emotionProcessing_events.tsv.gz
     byte_size: 1902
     checksum:
-      - algorithm: md5
-        digest: ad78412b62e046c2d7f46e70c84f0a35
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ad78412b62e046c2d7f46e70c84f0a35
     download_url:
       - https://dataverse.nl/api/access/datafile/46627
     media_type: application/gzip
@@ -12613,8 +12613,8 @@ has_part:
       exthisdsver:./sub-026/func/sub-026_task-emotionProcessingImagined_echo-1_bold.json
     byte_size: 1049
     checksum:
-      - algorithm: md5
-        digest: 5b9a67934af122a9f8a7046d14aac605
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5b9a67934af122a9f8a7046d14aac605
     download_url:
       - https://dataverse.nl/api/access/datafile/45316
     media_type: application/json
@@ -12622,8 +12622,8 @@ has_part:
       exthisdsver:./sub-026/func/sub-026_task-emotionProcessingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 8604e9da34c047ae16fdeaa56782c720
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8604e9da34c047ae16fdeaa56782c720
     download_url:
       - https://dataverse.nl/api/access/datafile/45407
     media_type: image/nii
@@ -12631,8 +12631,8 @@ has_part:
       exthisdsver:./sub-026/func/sub-026_task-emotionProcessingImagined_echo-2_bold.json
     byte_size: 1049
     checksum:
-      - algorithm: md5
-        digest: 636b783ce7993c116e8df06a0868f804
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 636b783ce7993c116e8df06a0868f804
     download_url:
       - https://dataverse.nl/api/access/datafile/45443
     media_type: application/json
@@ -12640,8 +12640,8 @@ has_part:
       exthisdsver:./sub-026/func/sub-026_task-emotionProcessingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 1d0165578e7797307cf5b82d6b546298
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1d0165578e7797307cf5b82d6b546298
     download_url:
       - https://dataverse.nl/api/access/datafile/45736
     media_type: image/nii
@@ -12649,8 +12649,8 @@ has_part:
       exthisdsver:./sub-026/func/sub-026_task-emotionProcessingImagined_echo-3_bold.json
     byte_size: 1049
     checksum:
-      - algorithm: md5
-        digest: 51c9f9c4f068f84d0d6fc62daae340dd
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 51c9f9c4f068f84d0d6fc62daae340dd
     download_url:
       - https://dataverse.nl/api/access/datafile/46207
     media_type: application/json
@@ -12658,328 +12658,328 @@ has_part:
       exthisdsver:./sub-026/func/sub-026_task-emotionProcessingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 40e7a5baf0522ff99a61028781f06564
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 40e7a5baf0522ff99a61028781f06564
     download_url:
       - https://dataverse.nl/api/access/datafile/45784
     media_type: image/nii
   - id: exthisdsver:./sub-026/func/sub-026_task-emotionProcessingImagined_events.tsv.gz
     byte_size: 178
     checksum:
-      - algorithm: md5
-        digest: 66f9c2461d4904750d29717f18771847
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 66f9c2461d4904750d29717f18771847
     download_url:
       - https://dataverse.nl/api/access/datafile/46572
     media_type: application/gzip
   - id: exthisdsver:./sub-026/func/sub-026_task-emotionProcessingImagined_physio.json
     byte_size: 142
     checksum:
-      - algorithm: md5
-        digest: cf612fd13dec932183d848f4b1c211a5
+      - creator: spdx:checksumAlgorithm_md5
+        notation: cf612fd13dec932183d848f4b1c211a5
     download_url:
       - https://dataverse.nl/api/access/datafile/45802
     media_type: application/json
   - id: exthisdsver:./sub-026/func/sub-026_task-emotionProcessingImagined_physio.tsv.gz
     byte_size: 464619
     checksum:
-      - algorithm: md5
-        digest: 60bca3447bb980e7b21b9d5d84ac16d0
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 60bca3447bb980e7b21b9d5d84ac16d0
     download_url:
       - https://dataverse.nl/api/access/datafile/45361
     media_type: application/gzip
   - id: exthisdsver:./sub-026/func/sub-026_task-emotionProcessing_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: a47ab5b3cf57e4d1dc9923f36acfb62b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a47ab5b3cf57e4d1dc9923f36acfb62b
     download_url:
       - https://dataverse.nl/api/access/datafile/45748
     media_type: application/json
   - id: exthisdsver:./sub-026/func/sub-026_task-emotionProcessing_physio.tsv.gz
     byte_size: 476434
     checksum:
-      - algorithm: md5
-        digest: bd2ef171a4203d82411f72eddb69bb55
+      - creator: spdx:checksumAlgorithm_md5
+        notation: bd2ef171a4203d82411f72eddb69bb55
     download_url:
       - https://dataverse.nl/api/access/datafile/45752
     media_type: application/gzip
   - id: exthisdsver:./sub-026/func/sub-026_task-fingerTapping_echo-1_bold.json
     byte_size: 1037
     checksum:
-      - algorithm: md5
-        digest: 16cd0167b36edbc8355d6eddf70652a0
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 16cd0167b36edbc8355d6eddf70652a0
     download_url:
       - https://dataverse.nl/api/access/datafile/45356
     media_type: application/json
   - id: exthisdsver:./sub-026/func/sub-026_task-fingerTapping_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 4e8e0e382d40a67f712be2ddf6978c68
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4e8e0e382d40a67f712be2ddf6978c68
     download_url:
       - https://dataverse.nl/api/access/datafile/45358
     media_type: image/nii
   - id: exthisdsver:./sub-026/func/sub-026_task-fingerTapping_echo-2_bold.json
     byte_size: 1037
     checksum:
-      - algorithm: md5
-        digest: 1f7fbd1bd9df0d59e61c5a951a193129
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1f7fbd1bd9df0d59e61c5a951a193129
     download_url:
       - https://dataverse.nl/api/access/datafile/45706
     media_type: application/json
   - id: exthisdsver:./sub-026/func/sub-026_task-fingerTapping_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 584623c4e56b1e15ba62c79455eb934c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 584623c4e56b1e15ba62c79455eb934c
     download_url:
       - https://dataverse.nl/api/access/datafile/46203
     media_type: image/nii
   - id: exthisdsver:./sub-026/func/sub-026_task-fingerTapping_echo-3_bold.json
     byte_size: 1037
     checksum:
-      - algorithm: md5
-        digest: 380c897d6ec1474bc749b4f529ac5648
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 380c897d6ec1474bc749b4f529ac5648
     download_url:
       - https://dataverse.nl/api/access/datafile/46197
     media_type: application/json
   - id: exthisdsver:./sub-026/func/sub-026_task-fingerTapping_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 54414da1d6c300555e243927fd85fa04
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 54414da1d6c300555e243927fd85fa04
     download_url:
       - https://dataverse.nl/api/access/datafile/46500
     media_type: image/nii
   - id: exthisdsver:./sub-026/func/sub-026_task-fingerTapping_events.tsv.gz
     byte_size: 166
     checksum:
-      - algorithm: md5
-        digest: b758cca6a704f1302b8830893618918b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b758cca6a704f1302b8830893618918b
     download_url:
       - https://dataverse.nl/api/access/datafile/46657
     media_type: application/gzip
   - id: exthisdsver:./sub-026/func/sub-026_task-fingerTappingImagined_echo-1_bold.json
     byte_size: 1045
     checksum:
-      - algorithm: md5
-        digest: 4d3fdda5ac93b7abaded38f5dcb36a1a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4d3fdda5ac93b7abaded38f5dcb36a1a
     download_url:
       - https://dataverse.nl/api/access/datafile/45863
     media_type: application/json
   - id: exthisdsver:./sub-026/func/sub-026_task-fingerTappingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: a2d337bf912bd286970e48b179d1eb67
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a2d337bf912bd286970e48b179d1eb67
     download_url:
       - https://dataverse.nl/api/access/datafile/46003
     media_type: image/nii
   - id: exthisdsver:./sub-026/func/sub-026_task-fingerTappingImagined_echo-2_bold.json
     byte_size: 1045
     checksum:
-      - algorithm: md5
-        digest: 61aaeafeb068f2e4474db1ddc062709f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 61aaeafeb068f2e4474db1ddc062709f
     download_url:
       - https://dataverse.nl/api/access/datafile/45207
     media_type: application/json
   - id: exthisdsver:./sub-026/func/sub-026_task-fingerTappingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 43469f452f999528b527ddbb5781ca8c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 43469f452f999528b527ddbb5781ca8c
     download_url:
       - https://dataverse.nl/api/access/datafile/45593
     media_type: image/nii
   - id: exthisdsver:./sub-026/func/sub-026_task-fingerTappingImagined_echo-3_bold.json
     byte_size: 1045
     checksum:
-      - algorithm: md5
-        digest: ec8247219a8d162e6b41a79edb16b048
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ec8247219a8d162e6b41a79edb16b048
     download_url:
       - https://dataverse.nl/api/access/datafile/45967
     media_type: application/json
   - id: exthisdsver:./sub-026/func/sub-026_task-fingerTappingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 97553d139ca593353f3a0137b66678e3
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 97553d139ca593353f3a0137b66678e3
     download_url:
       - https://dataverse.nl/api/access/datafile/45303
     media_type: image/nii
   - id: exthisdsver:./sub-026/func/sub-026_task-fingerTappingImagined_events.tsv.gz
     byte_size: 179
     checksum:
-      - algorithm: md5
-        digest: 4a4be477b2f82edd56c569aef703b1ea
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4a4be477b2f82edd56c569aef703b1ea
     download_url:
       - https://dataverse.nl/api/access/datafile/46633
     media_type: application/gzip
   - id: exthisdsver:./sub-026/func/sub-026_task-fingerTappingImagined_physio.json
     byte_size: 142
     checksum:
-      - algorithm: md5
-        digest: 8ebb24c7fcc1281d2306572f11ab4a82
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8ebb24c7fcc1281d2306572f11ab4a82
     download_url:
       - https://dataverse.nl/api/access/datafile/45470
     media_type: application/json
   - id: exthisdsver:./sub-026/func/sub-026_task-fingerTappingImagined_physio.tsv.gz
     byte_size: 460022
     checksum:
-      - algorithm: md5
-        digest: 6950b366743ab0a636aaa9caf8acf961
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6950b366743ab0a636aaa9caf8acf961
     download_url:
       - https://dataverse.nl/api/access/datafile/46144
     media_type: application/gzip
   - id: exthisdsver:./sub-026/func/sub-026_task-fingerTapping_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 5020aca0469a7eda04d8cf6e4ef3d87d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5020aca0469a7eda04d8cf6e4ef3d87d
     download_url:
       - https://dataverse.nl/api/access/datafile/45442
     media_type: application/json
   - id: exthisdsver:./sub-026/func/sub-026_task-fingerTapping_physio.tsv.gz
     byte_size: 497401
     checksum:
-      - algorithm: md5
-        digest: 878f685f595fa9dc696feef4789bb331
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 878f685f595fa9dc696feef4789bb331
     download_url:
       - https://dataverse.nl/api/access/datafile/45266
     media_type: application/gzip
   - id: exthisdsver:./sub-026/func/sub-026_task-rest_run-1_echo-1_bold.json
     byte_size: 1028
     checksum:
-      - algorithm: md5
-        digest: 0fbbcca7138fd1ff8277c69bf9f03938
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 0fbbcca7138fd1ff8277c69bf9f03938
     download_url:
       - https://dataverse.nl/api/access/datafile/46218
     media_type: application/json
   - id: exthisdsver:./sub-026/func/sub-026_task-rest_run-1_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: fc12d511864f590534b7649311359b6e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: fc12d511864f590534b7649311359b6e
     download_url:
       - https://dataverse.nl/api/access/datafile/45210
     media_type: image/nii
   - id: exthisdsver:./sub-026/func/sub-026_task-rest_run-1_echo-2_bold.json
     byte_size: 1028
     checksum:
-      - algorithm: md5
-        digest: bf8044e98020ad358d35b4f684a2df61
+      - creator: spdx:checksumAlgorithm_md5
+        notation: bf8044e98020ad358d35b4f684a2df61
     download_url:
       - https://dataverse.nl/api/access/datafile/45201
     media_type: application/json
   - id: exthisdsver:./sub-026/func/sub-026_task-rest_run-1_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: d432804d113ad3d24db7c09eb0e4a928
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d432804d113ad3d24db7c09eb0e4a928
     download_url:
       - https://dataverse.nl/api/access/datafile/46430
     media_type: image/nii
   - id: exthisdsver:./sub-026/func/sub-026_task-rest_run-1_echo-3_bold.json
     byte_size: 1028
     checksum:
-      - algorithm: md5
-        digest: 873faf19266364b522c1d6ff010a23f4
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 873faf19266364b522c1d6ff010a23f4
     download_url:
       - https://dataverse.nl/api/access/datafile/45730
     media_type: application/json
   - id: exthisdsver:./sub-026/func/sub-026_task-rest_run-1_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: ca995fcfd80b219b2a474a351aa6256b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ca995fcfd80b219b2a474a351aa6256b
     download_url:
       - https://dataverse.nl/api/access/datafile/45899
     media_type: image/nii
   - id: exthisdsver:./sub-026/func/sub-026_task-rest_run-1_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: b1d969444e3b2cf6a637e0e401af8ed2
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b1d969444e3b2cf6a637e0e401af8ed2
     download_url:
       - https://dataverse.nl/api/access/datafile/45915
     media_type: application/json
   - id: exthisdsver:./sub-026/func/sub-026_task-rest_run-1_physio.tsv.gz
     byte_size: 465084
     checksum:
-      - algorithm: md5
-        digest: c7322b9e688232d8591496c9bacdd07f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c7322b9e688232d8591496c9bacdd07f
     download_url:
       - https://dataverse.nl/api/access/datafile/45221
     media_type: application/gzip
   - id: exthisdsver:./sub-026/func/sub-026_task-rest_run-2_echo-1_bold.json
     byte_size: 1028
     checksum:
-      - algorithm: md5
-        digest: b027df5bf2692e25e4389b3c1d61121f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b027df5bf2692e25e4389b3c1d61121f
     download_url:
       - https://dataverse.nl/api/access/datafile/46115
     media_type: application/json
   - id: exthisdsver:./sub-026/func/sub-026_task-rest_run-2_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: cfea757fd830246c0e200499328caa6f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: cfea757fd830246c0e200499328caa6f
     download_url:
       - https://dataverse.nl/api/access/datafile/46346
     media_type: image/nii
   - id: exthisdsver:./sub-026/func/sub-026_task-rest_run-2_echo-2_bold.json
     byte_size: 1028
     checksum:
-      - algorithm: md5
-        digest: 807807cadb2a53b8ab053c87c28dba77
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 807807cadb2a53b8ab053c87c28dba77
     download_url:
       - https://dataverse.nl/api/access/datafile/46495
     media_type: application/json
   - id: exthisdsver:./sub-026/func/sub-026_task-rest_run-2_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: bf5a83754588b04028a3b542c683c680
+      - creator: spdx:checksumAlgorithm_md5
+        notation: bf5a83754588b04028a3b542c683c680
     download_url:
       - https://dataverse.nl/api/access/datafile/46255
     media_type: image/nii
   - id: exthisdsver:./sub-026/func/sub-026_task-rest_run-2_echo-3_bold.json
     byte_size: 1028
     checksum:
-      - algorithm: md5
-        digest: e2bbb35ec65a1da6ac637993aed9555f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e2bbb35ec65a1da6ac637993aed9555f
     download_url:
       - https://dataverse.nl/api/access/datafile/46091
     media_type: application/json
   - id: exthisdsver:./sub-026/func/sub-026_task-rest_run-2_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: d4f0ac826307f186692d28d962a4cb33
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d4f0ac826307f186692d28d962a4cb33
     download_url:
       - https://dataverse.nl/api/access/datafile/45446
     media_type: image/nii
   - id: exthisdsver:./sub-026/func/sub-026_task-rest_run-2_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: f2ed61b872263d38fa3b3f5c35d46451
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f2ed61b872263d38fa3b3f5c35d46451
     download_url:
       - https://dataverse.nl/api/access/datafile/46504
     media_type: application/json
   - id: exthisdsver:./sub-026/func/sub-026_task-rest_run-2_physio.tsv.gz
     byte_size: 449037
     checksum:
-      - algorithm: md5
-        digest: 08050fddf8b54edcf6e8dd20ed418b49
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 08050fddf8b54edcf6e8dd20ed418b49
     download_url:
       - https://dataverse.nl/api/access/datafile/46502
     media_type: application/gzip
   - id: exthisdsver:./sub-027/anat/sub-027_T1w.nii
     byte_size: 20736352
     checksum:
-      - algorithm: md5
-        digest: 391360fed2f0ad9f464d4300b04fe8f4
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 391360fed2f0ad9f464d4300b04fe8f4
     download_url:
       - https://dataverse.nl/api/access/datafile/46196
     media_type: image/nii
@@ -12996,8 +12996,8 @@ has_part:
   - id: exthisdsver:./sub-027/func/sub-027_task-emotionProcessing_echo-1_bold.json
     byte_size: 1040
     checksum:
-      - algorithm: md5
-        digest: 9160e7408a54f19cd6943c271a0643bc
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 9160e7408a54f19cd6943c271a0643bc
     download_url:
       - https://dataverse.nl/api/access/datafile/45240
     media_type: application/json
@@ -13116,48 +13116,48 @@ has_part:
   - id: exthisdsver:./sub-027/func/sub-027_task-emotionProcessing_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: d741e2a020dc97ad80e6205bdcc1953c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d741e2a020dc97ad80e6205bdcc1953c
     download_url:
       - https://dataverse.nl/api/access/datafile/46467
     media_type: image/nii
   - id: exthisdsver:./sub-027/func/sub-027_task-emotionProcessing_echo-2_bold.json
     byte_size: 1040
     checksum:
-      - algorithm: md5
-        digest: c8397b637fc28c1468f26a8e6fca9854
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c8397b637fc28c1468f26a8e6fca9854
     download_url:
       - https://dataverse.nl/api/access/datafile/46490
     media_type: application/json
   - id: exthisdsver:./sub-027/func/sub-027_task-emotionProcessing_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: d3d77d1e8d03a761c3d9c1e29113cd46
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d3d77d1e8d03a761c3d9c1e29113cd46
     download_url:
       - https://dataverse.nl/api/access/datafile/45728
     media_type: image/nii
   - id: exthisdsver:./sub-027/func/sub-027_task-emotionProcessing_echo-3_bold.json
     byte_size: 1040
     checksum:
-      - algorithm: md5
-        digest: 2b703cf362406375d6b528f6f8eff65b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2b703cf362406375d6b528f6f8eff65b
     download_url:
       - https://dataverse.nl/api/access/datafile/46099
     media_type: application/json
   - id: exthisdsver:./sub-027/func/sub-027_task-emotionProcessing_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: b27fcc2c413af187edddb0a4d94fae78
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b27fcc2c413af187edddb0a4d94fae78
     download_url:
       - https://dataverse.nl/api/access/datafile/46270
     media_type: image/nii
   - id: exthisdsver:./sub-027/func/sub-027_task-emotionProcessing_events.tsv.gz
     byte_size: 1886
     checksum:
-      - algorithm: md5
-        digest: 64a1e3bbdc41d6cca658ff58ac0703ce
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 64a1e3bbdc41d6cca658ff58ac0703ce
     download_url:
       - https://dataverse.nl/api/access/datafile/46643
     media_type: application/gzip
@@ -13165,8 +13165,8 @@ has_part:
       exthisdsver:./sub-027/func/sub-027_task-emotionProcessingImagined_echo-1_bold.json
     byte_size: 1047
     checksum:
-      - algorithm: md5
-        digest: b340ada6fbcebfc0999e079125cde231
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b340ada6fbcebfc0999e079125cde231
     download_url:
       - https://dataverse.nl/api/access/datafile/46382
     media_type: application/json
@@ -13174,8 +13174,8 @@ has_part:
       exthisdsver:./sub-027/func/sub-027_task-emotionProcessingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 3a8b601a8da50c346c16721f01f843f3
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 3a8b601a8da50c346c16721f01f843f3
     download_url:
       - https://dataverse.nl/api/access/datafile/46132
     media_type: image/nii
@@ -13183,8 +13183,8 @@ has_part:
       exthisdsver:./sub-027/func/sub-027_task-emotionProcessingImagined_echo-2_bold.json
     byte_size: 1047
     checksum:
-      - algorithm: md5
-        digest: 10940b21e34c03e91d4f0e3b70388ab7
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 10940b21e34c03e91d4f0e3b70388ab7
     download_url:
       - https://dataverse.nl/api/access/datafile/46420
     media_type: application/json
@@ -13192,8 +13192,8 @@ has_part:
       exthisdsver:./sub-027/func/sub-027_task-emotionProcessingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 94e31e6ff6ad8b9212a23835abc46588
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 94e31e6ff6ad8b9212a23835abc46588
     download_url:
       - https://dataverse.nl/api/access/datafile/46025
     media_type: image/nii
@@ -13201,8 +13201,8 @@ has_part:
       exthisdsver:./sub-027/func/sub-027_task-emotionProcessingImagined_echo-3_bold.json
     byte_size: 1047
     checksum:
-      - algorithm: md5
-        digest: 1337be6106cbe1368eb2384d1e0614af
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1337be6106cbe1368eb2384d1e0614af
     download_url:
       - https://dataverse.nl/api/access/datafile/45551
     media_type: application/json
@@ -13210,328 +13210,328 @@ has_part:
       exthisdsver:./sub-027/func/sub-027_task-emotionProcessingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 45b90f82c23548d7c07299a03c5a219d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 45b90f82c23548d7c07299a03c5a219d
     download_url:
       - https://dataverse.nl/api/access/datafile/45301
     media_type: image/nii
   - id: exthisdsver:./sub-027/func/sub-027_task-emotionProcessingImagined_events.tsv.gz
     byte_size: 178
     checksum:
-      - algorithm: md5
-        digest: 6edd4c82ceac6be3e069f15c3613ee2e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6edd4c82ceac6be3e069f15c3613ee2e
     download_url:
       - https://dataverse.nl/api/access/datafile/46613
     media_type: application/gzip
   - id: exthisdsver:./sub-027/func/sub-027_task-emotionProcessingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 7da3a6096bb9532815b05563ec61bf57
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 7da3a6096bb9532815b05563ec61bf57
     download_url:
       - https://dataverse.nl/api/access/datafile/46179
     media_type: application/json
   - id: exthisdsver:./sub-027/func/sub-027_task-emotionProcessingImagined_physio.tsv.gz
     byte_size: 488218
     checksum:
-      - algorithm: md5
-        digest: 57b540b40cb1493e98612110fa28c93c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 57b540b40cb1493e98612110fa28c93c
     download_url:
       - https://dataverse.nl/api/access/datafile/46242
     media_type: application/gzip
   - id: exthisdsver:./sub-027/func/sub-027_task-emotionProcessing_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: ff828f0cbc209f4601b5acb666ec2e61
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ff828f0cbc209f4601b5acb666ec2e61
     download_url:
       - https://dataverse.nl/api/access/datafile/45510
     media_type: application/json
   - id: exthisdsver:./sub-027/func/sub-027_task-emotionProcessing_physio.tsv.gz
     byte_size: 516529
     checksum:
-      - algorithm: md5
-        digest: 5e2a55382b9d1cab3a0d8cee81c57b16
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5e2a55382b9d1cab3a0d8cee81c57b16
     download_url:
       - https://dataverse.nl/api/access/datafile/46489
     media_type: application/gzip
   - id: exthisdsver:./sub-027/func/sub-027_task-fingerTapping_echo-1_bold.json
     byte_size: 1036
     checksum:
-      - algorithm: md5
-        digest: e891f95434005225ed9747717d7b5606
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e891f95434005225ed9747717d7b5606
     download_url:
       - https://dataverse.nl/api/access/datafile/45803
     media_type: application/json
   - id: exthisdsver:./sub-027/func/sub-027_task-fingerTapping_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 3608b349357d99e9c57f0bebefdb5dba
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 3608b349357d99e9c57f0bebefdb5dba
     download_url:
       - https://dataverse.nl/api/access/datafile/45503
     media_type: image/nii
   - id: exthisdsver:./sub-027/func/sub-027_task-fingerTapping_echo-2_bold.json
     byte_size: 1036
     checksum:
-      - algorithm: md5
-        digest: 88ca6bae797eeef31ab85c72c8f1b83d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 88ca6bae797eeef31ab85c72c8f1b83d
     download_url:
       - https://dataverse.nl/api/access/datafile/46219
     media_type: application/json
   - id: exthisdsver:./sub-027/func/sub-027_task-fingerTapping_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 3e3c6c87080b1b228d590288ed93bf88
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 3e3c6c87080b1b228d590288ed93bf88
     download_url:
       - https://dataverse.nl/api/access/datafile/45951
     media_type: image/nii
   - id: exthisdsver:./sub-027/func/sub-027_task-fingerTapping_echo-3_bold.json
     byte_size: 1036
     checksum:
-      - algorithm: md5
-        digest: e674d6920f9c458f9afbb3ce20416156
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e674d6920f9c458f9afbb3ce20416156
     download_url:
       - https://dataverse.nl/api/access/datafile/45848
     media_type: application/json
   - id: exthisdsver:./sub-027/func/sub-027_task-fingerTapping_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: ceca9bc881d3d8c2dce5a93323a9bab8
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ceca9bc881d3d8c2dce5a93323a9bab8
     download_url:
       - https://dataverse.nl/api/access/datafile/46492
     media_type: image/nii
   - id: exthisdsver:./sub-027/func/sub-027_task-fingerTapping_events.tsv.gz
     byte_size: 167
     checksum:
-      - algorithm: md5
-        digest: 0c8eb59418ffe7b04c69942e22d446fb
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 0c8eb59418ffe7b04c69942e22d446fb
     download_url:
       - https://dataverse.nl/api/access/datafile/46573
     media_type: application/gzip
   - id: exthisdsver:./sub-027/func/sub-027_task-fingerTappingImagined_echo-1_bold.json
     byte_size: 1043
     checksum:
-      - algorithm: md5
-        digest: a093f58299db4d28fbda66cbc6182c22
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a093f58299db4d28fbda66cbc6182c22
     download_url:
       - https://dataverse.nl/api/access/datafile/46029
     media_type: application/json
   - id: exthisdsver:./sub-027/func/sub-027_task-fingerTappingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: cb6ba5d1cbb04710d9c08597388e22ec
+      - creator: spdx:checksumAlgorithm_md5
+        notation: cb6ba5d1cbb04710d9c08597388e22ec
     download_url:
       - https://dataverse.nl/api/access/datafile/46480
     media_type: image/nii
   - id: exthisdsver:./sub-027/func/sub-027_task-fingerTappingImagined_echo-2_bold.json
     byte_size: 1043
     checksum:
-      - algorithm: md5
-        digest: 4aff660c764a99132d29bedb2eeaf39c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4aff660c764a99132d29bedb2eeaf39c
     download_url:
       - https://dataverse.nl/api/access/datafile/46439
     media_type: application/json
   - id: exthisdsver:./sub-027/func/sub-027_task-fingerTappingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 7d1773442a1c6e9a171350de28e8df0d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 7d1773442a1c6e9a171350de28e8df0d
     download_url:
       - https://dataverse.nl/api/access/datafile/46328
     media_type: image/nii
   - id: exthisdsver:./sub-027/func/sub-027_task-fingerTappingImagined_echo-3_bold.json
     byte_size: 1043
     checksum:
-      - algorithm: md5
-        digest: 4722a3d37ecee2451946a7f7897fec2c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4722a3d37ecee2451946a7f7897fec2c
     download_url:
       - https://dataverse.nl/api/access/datafile/45896
     media_type: application/json
   - id: exthisdsver:./sub-027/func/sub-027_task-fingerTappingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: d1ba9ec1cca3971aa85232714599548c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d1ba9ec1cca3971aa85232714599548c
     download_url:
       - https://dataverse.nl/api/access/datafile/45174
     media_type: image/nii
   - id: exthisdsver:./sub-027/func/sub-027_task-fingerTappingImagined_events.tsv.gz
     byte_size: 179
     checksum:
-      - algorithm: md5
-        digest: 4b8a49c8748a47a811bf90760466590c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4b8a49c8748a47a811bf90760466590c
     download_url:
       - https://dataverse.nl/api/access/datafile/46565
     media_type: application/gzip
   - id: exthisdsver:./sub-027/func/sub-027_task-fingerTappingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 201ea354a8c6c2f9090f93a83c70533f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 201ea354a8c6c2f9090f93a83c70533f
     download_url:
       - https://dataverse.nl/api/access/datafile/45531
     media_type: application/json
   - id: exthisdsver:./sub-027/func/sub-027_task-fingerTappingImagined_physio.tsv.gz
     byte_size: 493219
     checksum:
-      - algorithm: md5
-        digest: 7ba98152b934f6d16a8e5f3350fe483e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 7ba98152b934f6d16a8e5f3350fe483e
     download_url:
       - https://dataverse.nl/api/access/datafile/45699
     media_type: application/gzip
   - id: exthisdsver:./sub-027/func/sub-027_task-fingerTapping_physio.json
     byte_size: 142
     checksum:
-      - algorithm: md5
-        digest: c0c17e9c4c91d0d05d553dc841d298ed
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c0c17e9c4c91d0d05d553dc841d298ed
     download_url:
       - https://dataverse.nl/api/access/datafile/45345
     media_type: application/json
   - id: exthisdsver:./sub-027/func/sub-027_task-fingerTapping_physio.tsv.gz
     byte_size: 499845
     checksum:
-      - algorithm: md5
-        digest: 009b85384195d8104c10f0df6726bb8b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 009b85384195d8104c10f0df6726bb8b
     download_url:
       - https://dataverse.nl/api/access/datafile/45659
     media_type: application/gzip
   - id: exthisdsver:./sub-027/func/sub-027_task-rest_run-1_echo-1_bold.json
     byte_size: 1026
     checksum:
-      - algorithm: md5
-        digest: 253882b38043b647b0541a58a3f82db4
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 253882b38043b647b0541a58a3f82db4
     download_url:
       - https://dataverse.nl/api/access/datafile/45839
     media_type: application/json
   - id: exthisdsver:./sub-027/func/sub-027_task-rest_run-1_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 8ffcf3f54f89836cae1c0bbc17020b3e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8ffcf3f54f89836cae1c0bbc17020b3e
     download_url:
       - https://dataverse.nl/api/access/datafile/46239
     media_type: image/nii
   - id: exthisdsver:./sub-027/func/sub-027_task-rest_run-1_echo-2_bold.json
     byte_size: 1026
     checksum:
-      - algorithm: md5
-        digest: 686d54fb051d3f88ea343fcc3c95275b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 686d54fb051d3f88ea343fcc3c95275b
     download_url:
       - https://dataverse.nl/api/access/datafile/45876
     media_type: application/json
   - id: exthisdsver:./sub-027/func/sub-027_task-rest_run-1_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 25adaf8e38e816070776d127d853c399
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 25adaf8e38e816070776d127d853c399
     download_url:
       - https://dataverse.nl/api/access/datafile/45762
     media_type: image/nii
   - id: exthisdsver:./sub-027/func/sub-027_task-rest_run-1_echo-3_bold.json
     byte_size: 1026
     checksum:
-      - algorithm: md5
-        digest: e5f7167edc3dfaf10919d8371c6239ed
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e5f7167edc3dfaf10919d8371c6239ed
     download_url:
       - https://dataverse.nl/api/access/datafile/45856
     media_type: application/json
   - id: exthisdsver:./sub-027/func/sub-027_task-rest_run-1_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 0d67d81e894e7de8301c486e78e91650
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 0d67d81e894e7de8301c486e78e91650
     download_url:
       - https://dataverse.nl/api/access/datafile/46340
     media_type: image/nii
   - id: exthisdsver:./sub-027/func/sub-027_task-rest_run-1_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: ad035f41a9d628c3a43837a17ffc50f7
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ad035f41a9d628c3a43837a17ffc50f7
     download_url:
       - https://dataverse.nl/api/access/datafile/46462
     media_type: application/json
   - id: exthisdsver:./sub-027/func/sub-027_task-rest_run-1_physio.tsv.gz
     byte_size: 473633
     checksum:
-      - algorithm: md5
-        digest: cedec6211e60ce688cdb00403a795c16
+      - creator: spdx:checksumAlgorithm_md5
+        notation: cedec6211e60ce688cdb00403a795c16
     download_url:
       - https://dataverse.nl/api/access/datafile/45296
     media_type: application/gzip
   - id: exthisdsver:./sub-027/func/sub-027_task-rest_run-2_echo-1_bold.json
     byte_size: 1027
     checksum:
-      - algorithm: md5
-        digest: 9634dc297777a27ef17e67ff2f31b423
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 9634dc297777a27ef17e67ff2f31b423
     download_url:
       - https://dataverse.nl/api/access/datafile/45555
     media_type: application/json
   - id: exthisdsver:./sub-027/func/sub-027_task-rest_run-2_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 839e798f0209fb7dd87cc483ee4f3b78
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 839e798f0209fb7dd87cc483ee4f3b78
     download_url:
       - https://dataverse.nl/api/access/datafile/46536
     media_type: image/nii
   - id: exthisdsver:./sub-027/func/sub-027_task-rest_run-2_echo-2_bold.json
     byte_size: 1027
     checksum:
-      - algorithm: md5
-        digest: 9f79bf08427dd6445dcc5198eadead64
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 9f79bf08427dd6445dcc5198eadead64
     download_url:
       - https://dataverse.nl/api/access/datafile/46009
     media_type: application/json
   - id: exthisdsver:./sub-027/func/sub-027_task-rest_run-2_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 935489062a230bd4231076feba9393cd
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 935489062a230bd4231076feba9393cd
     download_url:
       - https://dataverse.nl/api/access/datafile/46460
     media_type: image/nii
   - id: exthisdsver:./sub-027/func/sub-027_task-rest_run-2_echo-3_bold.json
     byte_size: 1027
     checksum:
-      - algorithm: md5
-        digest: ce58fa531efd9f62eb4b75982de83e5a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ce58fa531efd9f62eb4b75982de83e5a
     download_url:
       - https://dataverse.nl/api/access/datafile/46526
     media_type: application/json
   - id: exthisdsver:./sub-027/func/sub-027_task-rest_run-2_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 7f3c62626662b3d21664314518af4ddc
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 7f3c62626662b3d21664314518af4ddc
     download_url:
       - https://dataverse.nl/api/access/datafile/45789
     media_type: image/nii
   - id: exthisdsver:./sub-027/func/sub-027_task-rest_run-2_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 3a52de0bfc90eef9cd273d188e194ff5
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 3a52de0bfc90eef9cd273d188e194ff5
     download_url:
       - https://dataverse.nl/api/access/datafile/45150
     media_type: application/json
   - id: exthisdsver:./sub-027/func/sub-027_task-rest_run-2_physio.tsv.gz
     byte_size: 487715
     checksum:
-      - algorithm: md5
-        digest: e6481ed05c3fa687ffa6f9d8388cde2e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e6481ed05c3fa687ffa6f9d8388cde2e
     download_url:
       - https://dataverse.nl/api/access/datafile/46046
     media_type: application/gzip
   - id: exthisdsver:./sub-029/anat/sub-029_T1w.nii
     byte_size: 20736352
     checksum:
-      - algorithm: md5
-        digest: 06483989167b850081d0eab5e4e9d75f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 06483989167b850081d0eab5e4e9d75f
     download_url:
       - https://dataverse.nl/api/access/datafile/45117
     media_type: image/nii
@@ -13548,8 +13548,8 @@ has_part:
   - id: exthisdsver:./sub-029/func/sub-029_task-emotionProcessing_echo-1_bold.json
     byte_size: 1041
     checksum:
-      - algorithm: md5
-        digest: 8ca710b33f86c36e67dab5765f551546
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8ca710b33f86c36e67dab5765f551546
     download_url:
       - https://dataverse.nl/api/access/datafile/46096
     media_type: application/json
@@ -13668,48 +13668,48 @@ has_part:
   - id: exthisdsver:./sub-029/func/sub-029_task-emotionProcessing_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 2ea82caf66be69b706e8da251f3db1d0
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2ea82caf66be69b706e8da251f3db1d0
     download_url:
       - https://dataverse.nl/api/access/datafile/46345
     media_type: image/nii
   - id: exthisdsver:./sub-029/func/sub-029_task-emotionProcessing_echo-2_bold.json
     byte_size: 1041
     checksum:
-      - algorithm: md5
-        digest: c642a1f2033af0aa25af0f8106ea516e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c642a1f2033af0aa25af0f8106ea516e
     download_url:
       - https://dataverse.nl/api/access/datafile/45707
     media_type: application/json
   - id: exthisdsver:./sub-029/func/sub-029_task-emotionProcessing_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 98f88deb44a64198f93800a8c567fe7c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 98f88deb44a64198f93800a8c567fe7c
     download_url:
       - https://dataverse.nl/api/access/datafile/45348
     media_type: image/nii
   - id: exthisdsver:./sub-029/func/sub-029_task-emotionProcessing_echo-3_bold.json
     byte_size: 1041
     checksum:
-      - algorithm: md5
-        digest: aef317b5b3098ea2d40de1ce8b9cfc53
+      - creator: spdx:checksumAlgorithm_md5
+        notation: aef317b5b3098ea2d40de1ce8b9cfc53
     download_url:
       - https://dataverse.nl/api/access/datafile/46391
     media_type: application/json
   - id: exthisdsver:./sub-029/func/sub-029_task-emotionProcessing_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 86949512bb0e3dc1ccb8f6881b62c9e9
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 86949512bb0e3dc1ccb8f6881b62c9e9
     download_url:
       - https://dataverse.nl/api/access/datafile/46488
     media_type: image/nii
   - id: exthisdsver:./sub-029/func/sub-029_task-emotionProcessing_events.tsv.gz
     byte_size: 1947
     checksum:
-      - algorithm: md5
-        digest: d363bda5a57ca4e2a170fb7db38fb98a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d363bda5a57ca4e2a170fb7db38fb98a
     download_url:
       - https://dataverse.nl/api/access/datafile/46611
     media_type: application/gzip
@@ -13717,8 +13717,8 @@ has_part:
       exthisdsver:./sub-029/func/sub-029_task-emotionProcessingImagined_echo-1_bold.json
     byte_size: 1049
     checksum:
-      - algorithm: md5
-        digest: 4b5ebeecc9bfc412bbb6e6207e2ed6d5
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4b5ebeecc9bfc412bbb6e6207e2ed6d5
     download_url:
       - https://dataverse.nl/api/access/datafile/45357
     media_type: application/json
@@ -13726,8 +13726,8 @@ has_part:
       exthisdsver:./sub-029/func/sub-029_task-emotionProcessingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: dc9b6f33e0ae0b074310728fdd5fe572
+      - creator: spdx:checksumAlgorithm_md5
+        notation: dc9b6f33e0ae0b074310728fdd5fe572
     download_url:
       - https://dataverse.nl/api/access/datafile/45972
     media_type: image/nii
@@ -13735,8 +13735,8 @@ has_part:
       exthisdsver:./sub-029/func/sub-029_task-emotionProcessingImagined_echo-2_bold.json
     byte_size: 1049
     checksum:
-      - algorithm: md5
-        digest: 0e9ef021458d12f51f4e91f110661ff9
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 0e9ef021458d12f51f4e91f110661ff9
     download_url:
       - https://dataverse.nl/api/access/datafile/45760
     media_type: application/json
@@ -13744,8 +13744,8 @@ has_part:
       exthisdsver:./sub-029/func/sub-029_task-emotionProcessingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 6f3194817a8e84239182251ad1fd57c8
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6f3194817a8e84239182251ad1fd57c8
     download_url:
       - https://dataverse.nl/api/access/datafile/46102
     media_type: image/nii
@@ -13753,8 +13753,8 @@ has_part:
       exthisdsver:./sub-029/func/sub-029_task-emotionProcessingImagined_echo-3_bold.json
     byte_size: 1049
     checksum:
-      - algorithm: md5
-        digest: c1fca06fbd4937b40f45ab3c82e20e69
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c1fca06fbd4937b40f45ab3c82e20e69
     download_url:
       - https://dataverse.nl/api/access/datafile/46330
     media_type: application/json
@@ -13762,328 +13762,328 @@ has_part:
       exthisdsver:./sub-029/func/sub-029_task-emotionProcessingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 6a8b3989f7b59fb6989d366b27e6ec00
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6a8b3989f7b59fb6989d366b27e6ec00
     download_url:
       - https://dataverse.nl/api/access/datafile/45886
     media_type: image/nii
   - id: exthisdsver:./sub-029/func/sub-029_task-emotionProcessingImagined_events.tsv.gz
     byte_size: 178
     checksum:
-      - algorithm: md5
-        digest: 3dd04e9279353a82d5fc7e98460a239f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 3dd04e9279353a82d5fc7e98460a239f
     download_url:
       - https://dataverse.nl/api/access/datafile/46630
     media_type: application/gzip
   - id: exthisdsver:./sub-029/func/sub-029_task-emotionProcessingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 72c92178962a931773723d1358fca1bc
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 72c92178962a931773723d1358fca1bc
     download_url:
       - https://dataverse.nl/api/access/datafile/45563
     media_type: application/json
   - id: exthisdsver:./sub-029/func/sub-029_task-emotionProcessingImagined_physio.tsv.gz
     byte_size: 509090
     checksum:
-      - algorithm: md5
-        digest: ab3c13026db0130f0f23bcdbf62a9e6f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ab3c13026db0130f0f23bcdbf62a9e6f
     download_url:
       - https://dataverse.nl/api/access/datafile/45919
     media_type: application/gzip
   - id: exthisdsver:./sub-029/func/sub-029_task-emotionProcessing_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: f3bb13d436264f3d9b208761a7af1463
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f3bb13d436264f3d9b208761a7af1463
     download_url:
       - https://dataverse.nl/api/access/datafile/46198
     media_type: application/json
   - id: exthisdsver:./sub-029/func/sub-029_task-emotionProcessing_physio.tsv.gz
     byte_size: 614680
     checksum:
-      - algorithm: md5
-        digest: 6cdf0fecde4d7226e248dc44fcb1836c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6cdf0fecde4d7226e248dc44fcb1836c
     download_url:
       - https://dataverse.nl/api/access/datafile/45976
     media_type: application/gzip
   - id: exthisdsver:./sub-029/func/sub-029_task-fingerTapping_echo-1_bold.json
     byte_size: 1037
     checksum:
-      - algorithm: md5
-        digest: cc0ff9e49a4e54f8654e4ccfd3aaa3f1
+      - creator: spdx:checksumAlgorithm_md5
+        notation: cc0ff9e49a4e54f8654e4ccfd3aaa3f1
     download_url:
       - https://dataverse.nl/api/access/datafile/46484
     media_type: application/json
   - id: exthisdsver:./sub-029/func/sub-029_task-fingerTapping_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: daa2747d5a5ab3547278063606409baf
+      - creator: spdx:checksumAlgorithm_md5
+        notation: daa2747d5a5ab3547278063606409baf
     download_url:
       - https://dataverse.nl/api/access/datafile/46123
     media_type: image/nii
   - id: exthisdsver:./sub-029/func/sub-029_task-fingerTapping_echo-2_bold.json
     byte_size: 1037
     checksum:
-      - algorithm: md5
-        digest: 9a52040f6152d9f9b714816a1a601a9e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 9a52040f6152d9f9b714816a1a601a9e
     download_url:
       - https://dataverse.nl/api/access/datafile/46381
     media_type: application/json
   - id: exthisdsver:./sub-029/func/sub-029_task-fingerTapping_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: d77cb3cddfca2a2523a46553d9d6fb2c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d77cb3cddfca2a2523a46553d9d6fb2c
     download_url:
       - https://dataverse.nl/api/access/datafile/45759
     media_type: image/nii
   - id: exthisdsver:./sub-029/func/sub-029_task-fingerTapping_echo-3_bold.json
     byte_size: 1037
     checksum:
-      - algorithm: md5
-        digest: e9b328f4103fc80bbb330d963750caa2
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e9b328f4103fc80bbb330d963750caa2
     download_url:
       - https://dataverse.nl/api/access/datafile/45651
     media_type: application/json
   - id: exthisdsver:./sub-029/func/sub-029_task-fingerTapping_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 5da88cf257ba32d596e009edb8574ef8
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5da88cf257ba32d596e009edb8574ef8
     download_url:
       - https://dataverse.nl/api/access/datafile/45220
     media_type: image/nii
   - id: exthisdsver:./sub-029/func/sub-029_task-fingerTapping_events.tsv.gz
     byte_size: 168
     checksum:
-      - algorithm: md5
-        digest: fd56c77f281c86a9ffb0ddfb09edad97
+      - creator: spdx:checksumAlgorithm_md5
+        notation: fd56c77f281c86a9ffb0ddfb09edad97
     download_url:
       - https://dataverse.nl/api/access/datafile/46566
     media_type: application/gzip
   - id: exthisdsver:./sub-029/func/sub-029_task-fingerTappingImagined_echo-1_bold.json
     byte_size: 1044
     checksum:
-      - algorithm: md5
-        digest: dc98a0fa52e322063b98f2f45fd9fba6
+      - creator: spdx:checksumAlgorithm_md5
+        notation: dc98a0fa52e322063b98f2f45fd9fba6
     download_url:
       - https://dataverse.nl/api/access/datafile/45974
     media_type: application/json
   - id: exthisdsver:./sub-029/func/sub-029_task-fingerTappingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: a40d4b6f350974a9298ac88ddaa3d84b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a40d4b6f350974a9298ac88ddaa3d84b
     download_url:
       - https://dataverse.nl/api/access/datafile/45477
     media_type: image/nii
   - id: exthisdsver:./sub-029/func/sub-029_task-fingerTappingImagined_echo-2_bold.json
     byte_size: 1044
     checksum:
-      - algorithm: md5
-        digest: 759d73ec6bb1a2c407609dc8dddbb704
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 759d73ec6bb1a2c407609dc8dddbb704
     download_url:
       - https://dataverse.nl/api/access/datafile/46077
     media_type: application/json
   - id: exthisdsver:./sub-029/func/sub-029_task-fingerTappingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: abe0243354e2355bdf1786b8e6bcae36
+      - creator: spdx:checksumAlgorithm_md5
+        notation: abe0243354e2355bdf1786b8e6bcae36
     download_url:
       - https://dataverse.nl/api/access/datafile/45973
     media_type: image/nii
   - id: exthisdsver:./sub-029/func/sub-029_task-fingerTappingImagined_echo-3_bold.json
     byte_size: 1044
     checksum:
-      - algorithm: md5
-        digest: d6934052b107e29a3db3e7fc8fba735a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d6934052b107e29a3db3e7fc8fba735a
     download_url:
       - https://dataverse.nl/api/access/datafile/46173
     media_type: application/json
   - id: exthisdsver:./sub-029/func/sub-029_task-fingerTappingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: e056ceee63a8590f083810062f4c34a6
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e056ceee63a8590f083810062f4c34a6
     download_url:
       - https://dataverse.nl/api/access/datafile/46260
     media_type: image/nii
   - id: exthisdsver:./sub-029/func/sub-029_task-fingerTappingImagined_events.tsv.gz
     byte_size: 179
     checksum:
-      - algorithm: md5
-        digest: 85c94ae6f5fc3b8115d2d419476970cf
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 85c94ae6f5fc3b8115d2d419476970cf
     download_url:
       - https://dataverse.nl/api/access/datafile/46642
     media_type: application/gzip
   - id: exthisdsver:./sub-029/func/sub-029_task-fingerTappingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 672a4fffbdb16d51499b7930064e1859
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 672a4fffbdb16d51499b7930064e1859
     download_url:
       - https://dataverse.nl/api/access/datafile/45801
     media_type: application/json
   - id: exthisdsver:./sub-029/func/sub-029_task-fingerTappingImagined_physio.tsv.gz
     byte_size: 526633
     checksum:
-      - algorithm: md5
-        digest: f71826f74749fe71b7800028c9db1673
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f71826f74749fe71b7800028c9db1673
     download_url:
       - https://dataverse.nl/api/access/datafile/45434
     media_type: application/gzip
   - id: exthisdsver:./sub-029/func/sub-029_task-fingerTapping_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 8be2efff90b216f6acd2809951cf8be6
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8be2efff90b216f6acd2809951cf8be6
     download_url:
       - https://dataverse.nl/api/access/datafile/45128
     media_type: application/json
   - id: exthisdsver:./sub-029/func/sub-029_task-fingerTapping_physio.tsv.gz
     byte_size: 602444
     checksum:
-      - algorithm: md5
-        digest: a54c4190dc3c0ecc5beb2b8c9e14735d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a54c4190dc3c0ecc5beb2b8c9e14735d
     download_url:
       - https://dataverse.nl/api/access/datafile/46271
     media_type: application/gzip
   - id: exthisdsver:./sub-029/func/sub-029_task-rest_run-1_echo-1_bold.json
     byte_size: 1028
     checksum:
-      - algorithm: md5
-        digest: 2872c86e9bacbf82a565dd634ea72386
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2872c86e9bacbf82a565dd634ea72386
     download_url:
       - https://dataverse.nl/api/access/datafile/45838
     media_type: application/json
   - id: exthisdsver:./sub-029/func/sub-029_task-rest_run-1_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 0402d0c1b534383c18c909cc1ad31274
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 0402d0c1b534383c18c909cc1ad31274
     download_url:
       - https://dataverse.nl/api/access/datafile/45854
     media_type: image/nii
   - id: exthisdsver:./sub-029/func/sub-029_task-rest_run-1_echo-2_bold.json
     byte_size: 1028
     checksum:
-      - algorithm: md5
-        digest: ebde01f4f6faf37078c2ff7590b5d256
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ebde01f4f6faf37078c2ff7590b5d256
     download_url:
       - https://dataverse.nl/api/access/datafile/46175
     media_type: application/json
   - id: exthisdsver:./sub-029/func/sub-029_task-rest_run-1_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 666119314daf509245b75a6254078361
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 666119314daf509245b75a6254078361
     download_url:
       - https://dataverse.nl/api/access/datafile/45329
     media_type: image/nii
   - id: exthisdsver:./sub-029/func/sub-029_task-rest_run-1_echo-3_bold.json
     byte_size: 1028
     checksum:
-      - algorithm: md5
-        digest: 638328d8f9a7083428279da196b3e8c4
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 638328d8f9a7083428279da196b3e8c4
     download_url:
       - https://dataverse.nl/api/access/datafile/45864
     media_type: application/json
   - id: exthisdsver:./sub-029/func/sub-029_task-rest_run-1_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 55aa6d4913b1d6be0e2fcf1c9bbb4333
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 55aa6d4913b1d6be0e2fcf1c9bbb4333
     download_url:
       - https://dataverse.nl/api/access/datafile/46055
     media_type: image/nii
   - id: exthisdsver:./sub-029/func/sub-029_task-rest_run-1_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 605ad92271ca46ea0eb86d118616eea9
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 605ad92271ca46ea0eb86d118616eea9
     download_url:
       - https://dataverse.nl/api/access/datafile/45263
     media_type: application/json
   - id: exthisdsver:./sub-029/func/sub-029_task-rest_run-1_physio.tsv.gz
     byte_size: 453530
     checksum:
-      - algorithm: md5
-        digest: 0dd5ef126996587d16cbce6bd84c2171
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 0dd5ef126996587d16cbce6bd84c2171
     download_url:
       - https://dataverse.nl/api/access/datafile/45671
     media_type: application/gzip
   - id: exthisdsver:./sub-029/func/sub-029_task-rest_run-2_echo-1_bold.json
     byte_size: 1028
     checksum:
-      - algorithm: md5
-        digest: e5533ef3787593680c32ca4c1f6c846a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e5533ef3787593680c32ca4c1f6c846a
     download_url:
       - https://dataverse.nl/api/access/datafile/46040
     media_type: application/json
   - id: exthisdsver:./sub-029/func/sub-029_task-rest_run-2_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: a1803f1a402f76f74b955542462d8955
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a1803f1a402f76f74b955542462d8955
     download_url:
       - https://dataverse.nl/api/access/datafile/45749
     media_type: image/nii
   - id: exthisdsver:./sub-029/func/sub-029_task-rest_run-2_echo-2_bold.json
     byte_size: 1028
     checksum:
-      - algorithm: md5
-        digest: f66d20f3812cf38f3e58aec4c2920f9b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f66d20f3812cf38f3e58aec4c2920f9b
     download_url:
       - https://dataverse.nl/api/access/datafile/45829
     media_type: application/json
   - id: exthisdsver:./sub-029/func/sub-029_task-rest_run-2_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 287aff701204899813a052aae55231e3
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 287aff701204899813a052aae55231e3
     download_url:
       - https://dataverse.nl/api/access/datafile/46335
     media_type: image/nii
   - id: exthisdsver:./sub-029/func/sub-029_task-rest_run-2_echo-3_bold.json
     byte_size: 1028
     checksum:
-      - algorithm: md5
-        digest: 31c3bd8364753cc3a49b352afb2a040a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 31c3bd8364753cc3a49b352afb2a040a
     download_url:
       - https://dataverse.nl/api/access/datafile/45613
     media_type: application/json
   - id: exthisdsver:./sub-029/func/sub-029_task-rest_run-2_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: d274d9901dba8b51a96692e93beef094
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d274d9901dba8b51a96692e93beef094
     download_url:
       - https://dataverse.nl/api/access/datafile/46059
     media_type: image/nii
   - id: exthisdsver:./sub-029/func/sub-029_task-rest_run-2_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: dcf2960a303745514d4365f102d11dca
+      - creator: spdx:checksumAlgorithm_md5
+        notation: dcf2960a303745514d4365f102d11dca
     download_url:
       - https://dataverse.nl/api/access/datafile/46013
     media_type: application/json
   - id: exthisdsver:./sub-029/func/sub-029_task-rest_run-2_physio.tsv.gz
     byte_size: 493637
     checksum:
-      - algorithm: md5
-        digest: b9e8a26a359147c508c9aacaad33c4b4
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b9e8a26a359147c508c9aacaad33c4b4
     download_url:
       - https://dataverse.nl/api/access/datafile/45135
     media_type: application/gzip
   - id: exthisdsver:./sub-030/anat/sub-030_T1w.nii
     byte_size: 20736352
     checksum:
-      - algorithm: md5
-        digest: 7d49af0678a253f050888f0d5c5b9a7c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 7d49af0678a253f050888f0d5c5b9a7c
     download_url:
       - https://dataverse.nl/api/access/datafile/45964
     media_type: image/nii
@@ -14100,8 +14100,8 @@ has_part:
   - id: exthisdsver:./sub-030/func/sub-030_task-emotionProcessing_echo-1_bold.json
     byte_size: 1042
     checksum:
-      - algorithm: md5
-        digest: 6284fd8caa795a3542e92047539225bb
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6284fd8caa795a3542e92047539225bb
     download_url:
       - https://dataverse.nl/api/access/datafile/45716
     media_type: application/json
@@ -14220,48 +14220,48 @@ has_part:
   - id: exthisdsver:./sub-030/func/sub-030_task-emotionProcessing_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 5153f6c8dda335e5e4afdd07b49d3d16
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5153f6c8dda335e5e4afdd07b49d3d16
     download_url:
       - https://dataverse.nl/api/access/datafile/45675
     media_type: image/nii
   - id: exthisdsver:./sub-030/func/sub-030_task-emotionProcessing_echo-2_bold.json
     byte_size: 1042
     checksum:
-      - algorithm: md5
-        digest: 5f346e95cfacb71285559c08ffa801e0
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5f346e95cfacb71285559c08ffa801e0
     download_url:
       - https://dataverse.nl/api/access/datafile/46140
     media_type: application/json
   - id: exthisdsver:./sub-030/func/sub-030_task-emotionProcessing_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 27e5d2456721906e1515d9da26871f8e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 27e5d2456721906e1515d9da26871f8e
     download_url:
       - https://dataverse.nl/api/access/datafile/45997
     media_type: image/nii
   - id: exthisdsver:./sub-030/func/sub-030_task-emotionProcessing_echo-3_bold.json
     byte_size: 1042
     checksum:
-      - algorithm: md5
-        digest: 5c0a009bb87d5dee80253bcccc3ba026
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5c0a009bb87d5dee80253bcccc3ba026
     download_url:
       - https://dataverse.nl/api/access/datafile/45514
     media_type: application/json
   - id: exthisdsver:./sub-030/func/sub-030_task-emotionProcessing_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 61294fe08c7d78a6cb629dc8786deb4c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 61294fe08c7d78a6cb629dc8786deb4c
     download_url:
       - https://dataverse.nl/api/access/datafile/45648
     media_type: image/nii
   - id: exthisdsver:./sub-030/func/sub-030_task-emotionProcessing_events.tsv.gz
     byte_size: 1887
     checksum:
-      - algorithm: md5
-        digest: cdf3ae06fc8eb4745cf011b0817fbc32
+      - creator: spdx:checksumAlgorithm_md5
+        notation: cdf3ae06fc8eb4745cf011b0817fbc32
     download_url:
       - https://dataverse.nl/api/access/datafile/46648
     media_type: application/gzip
@@ -14269,8 +14269,8 @@ has_part:
       exthisdsver:./sub-030/func/sub-030_task-emotionProcessingImagined_echo-1_bold.json
     byte_size: 1052
     checksum:
-      - algorithm: md5
-        digest: a947de9eba6d81991eed24943542c2c7
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a947de9eba6d81991eed24943542c2c7
     download_url:
       - https://dataverse.nl/api/access/datafile/46410
     media_type: application/json
@@ -14278,8 +14278,8 @@ has_part:
       exthisdsver:./sub-030/func/sub-030_task-emotionProcessingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 249dd14e1e023cf98361813e8fe2c8ce
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 249dd14e1e023cf98361813e8fe2c8ce
     download_url:
       - https://dataverse.nl/api/access/datafile/45682
     media_type: image/nii
@@ -14287,8 +14287,8 @@ has_part:
       exthisdsver:./sub-030/func/sub-030_task-emotionProcessingImagined_echo-2_bold.json
     byte_size: 1052
     checksum:
-      - algorithm: md5
-        digest: 3bf5e0d06f4c0b44684708016ead2384
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 3bf5e0d06f4c0b44684708016ead2384
     download_url:
       - https://dataverse.nl/api/access/datafile/45957
     media_type: application/json
@@ -14296,8 +14296,8 @@ has_part:
       exthisdsver:./sub-030/func/sub-030_task-emotionProcessingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 1545d6a2710463db6f31a9b18522b4f2
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1545d6a2710463db6f31a9b18522b4f2
     download_url:
       - https://dataverse.nl/api/access/datafile/45196
     media_type: image/nii
@@ -14305,8 +14305,8 @@ has_part:
       exthisdsver:./sub-030/func/sub-030_task-emotionProcessingImagined_echo-3_bold.json
     byte_size: 1052
     checksum:
-      - algorithm: md5
-        digest: dde2c167088d531a025f0a0e94388f5a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: dde2c167088d531a025f0a0e94388f5a
     download_url:
       - https://dataverse.nl/api/access/datafile/45772
     media_type: application/json
@@ -14314,328 +14314,328 @@ has_part:
       exthisdsver:./sub-030/func/sub-030_task-emotionProcessingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 5a8bb9ec0d6adb579068cab4e90878c2
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5a8bb9ec0d6adb579068cab4e90878c2
     download_url:
       - https://dataverse.nl/api/access/datafile/45129
     media_type: image/nii
   - id: exthisdsver:./sub-030/func/sub-030_task-emotionProcessingImagined_events.tsv.gz
     byte_size: 180
     checksum:
-      - algorithm: md5
-        digest: 16fb8a49a30a04a40eb1d884275bff57
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 16fb8a49a30a04a40eb1d884275bff57
     download_url:
       - https://dataverse.nl/api/access/datafile/46588
     media_type: application/gzip
   - id: exthisdsver:./sub-030/func/sub-030_task-emotionProcessingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 33dc5896a50bc63493bab3f0743b3465
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 33dc5896a50bc63493bab3f0743b3465
     download_url:
       - https://dataverse.nl/api/access/datafile/45620
     media_type: application/json
   - id: exthisdsver:./sub-030/func/sub-030_task-emotionProcessingImagined_physio.tsv.gz
     byte_size: 495292
     checksum:
-      - algorithm: md5
-        digest: fd5ee5ea81e0249b03683f0d656d4c70
+      - creator: spdx:checksumAlgorithm_md5
+        notation: fd5ee5ea81e0249b03683f0d656d4c70
     download_url:
       - https://dataverse.nl/api/access/datafile/45121
     media_type: application/gzip
   - id: exthisdsver:./sub-030/func/sub-030_task-emotionProcessing_physio.json
     byte_size: 142
     checksum:
-      - algorithm: md5
-        digest: ad740656f44d82f4bd7b9cd85cfa75b6
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ad740656f44d82f4bd7b9cd85cfa75b6
     download_url:
       - https://dataverse.nl/api/access/datafile/45771
     media_type: application/json
   - id: exthisdsver:./sub-030/func/sub-030_task-emotionProcessing_physio.tsv.gz
     byte_size: 491529
     checksum:
-      - algorithm: md5
-        digest: e0560ed1d249cadf942ed068312f4074
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e0560ed1d249cadf942ed068312f4074
     download_url:
       - https://dataverse.nl/api/access/datafile/45718
     media_type: application/gzip
   - id: exthisdsver:./sub-030/func/sub-030_task-fingerTapping_echo-1_bold.json
     byte_size: 1040
     checksum:
-      - algorithm: md5
-        digest: 87b01272f0d3aec042a70c89cb64c610
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 87b01272f0d3aec042a70c89cb64c610
     download_url:
       - https://dataverse.nl/api/access/datafile/46349
     media_type: application/json
   - id: exthisdsver:./sub-030/func/sub-030_task-fingerTapping_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 70c2c565c57410becebcb81c2743b366
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 70c2c565c57410becebcb81c2743b366
     download_url:
       - https://dataverse.nl/api/access/datafile/45483
     media_type: image/nii
   - id: exthisdsver:./sub-030/func/sub-030_task-fingerTapping_echo-2_bold.json
     byte_size: 1040
     checksum:
-      - algorithm: md5
-        digest: d2ad0551f289c82c784c0311cbda5868
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d2ad0551f289c82c784c0311cbda5868
     download_url:
       - https://dataverse.nl/api/access/datafile/45429
     media_type: application/json
   - id: exthisdsver:./sub-030/func/sub-030_task-fingerTapping_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 0a985477a760a6866461a8503d29841f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 0a985477a760a6866461a8503d29841f
     download_url:
       - https://dataverse.nl/api/access/datafile/45395
     media_type: image/nii
   - id: exthisdsver:./sub-030/func/sub-030_task-fingerTapping_echo-3_bold.json
     byte_size: 1040
     checksum:
-      - algorithm: md5
-        digest: 5d7912fb3c00c49ab445f37d023fabde
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5d7912fb3c00c49ab445f37d023fabde
     download_url:
       - https://dataverse.nl/api/access/datafile/45733
     media_type: application/json
   - id: exthisdsver:./sub-030/func/sub-030_task-fingerTapping_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 8d8f176db5374b8f5312c07b3868f190
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8d8f176db5374b8f5312c07b3868f190
     download_url:
       - https://dataverse.nl/api/access/datafile/45466
     media_type: image/nii
   - id: exthisdsver:./sub-030/func/sub-030_task-fingerTapping_events.tsv.gz
     byte_size: 167
     checksum:
-      - algorithm: md5
-        digest: 10274748238e4edb1cacbc5ff8c4efb4
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 10274748238e4edb1cacbc5ff8c4efb4
     download_url:
       - https://dataverse.nl/api/access/datafile/46581
     media_type: application/gzip
   - id: exthisdsver:./sub-030/func/sub-030_task-fingerTappingImagined_echo-1_bold.json
     byte_size: 1046
     checksum:
-      - algorithm: md5
-        digest: 6deb98259db82a9bb337c44e78e221fe
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6deb98259db82a9bb337c44e78e221fe
     download_url:
       - https://dataverse.nl/api/access/datafile/46463
     media_type: application/json
   - id: exthisdsver:./sub-030/func/sub-030_task-fingerTappingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 9206830373a50d76fa9be72699a45be2
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 9206830373a50d76fa9be72699a45be2
     download_url:
       - https://dataverse.nl/api/access/datafile/45985
     media_type: image/nii
   - id: exthisdsver:./sub-030/func/sub-030_task-fingerTappingImagined_echo-2_bold.json
     byte_size: 1046
     checksum:
-      - algorithm: md5
-        digest: 1e119f9dea2d0f2266fdba2f09099eba
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1e119f9dea2d0f2266fdba2f09099eba
     download_url:
       - https://dataverse.nl/api/access/datafile/46334
     media_type: application/json
   - id: exthisdsver:./sub-030/func/sub-030_task-fingerTappingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 3b8d8099ff221a24e6f8c2c6e4b5570c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 3b8d8099ff221a24e6f8c2c6e4b5570c
     download_url:
       - https://dataverse.nl/api/access/datafile/45532
     media_type: image/nii
   - id: exthisdsver:./sub-030/func/sub-030_task-fingerTappingImagined_echo-3_bold.json
     byte_size: 1046
     checksum:
-      - algorithm: md5
-        digest: ca1f88e3755c369289b2c59316feabd1
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ca1f88e3755c369289b2c59316feabd1
     download_url:
       - https://dataverse.nl/api/access/datafile/45545
     media_type: application/json
   - id: exthisdsver:./sub-030/func/sub-030_task-fingerTappingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 54ab340987d511300097fd979ba2500a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 54ab340987d511300097fd979ba2500a
     download_url:
       - https://dataverse.nl/api/access/datafile/45934
     media_type: image/nii
   - id: exthisdsver:./sub-030/func/sub-030_task-fingerTappingImagined_events.tsv.gz
     byte_size: 179
     checksum:
-      - algorithm: md5
-        digest: aed4fce2a1c6cef0f89684bbf389f48a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: aed4fce2a1c6cef0f89684bbf389f48a
     download_url:
       - https://dataverse.nl/api/access/datafile/46600
     media_type: application/gzip
   - id: exthisdsver:./sub-030/func/sub-030_task-fingerTappingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: ed88005c127d5f5aef4342a0dee22e4a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ed88005c127d5f5aef4342a0dee22e4a
     download_url:
       - https://dataverse.nl/api/access/datafile/46468
     media_type: application/json
   - id: exthisdsver:./sub-030/func/sub-030_task-fingerTappingImagined_physio.tsv.gz
     byte_size: 476319
     checksum:
-      - algorithm: md5
-        digest: 803e662ede5ba87711a0e764a4dc5e00
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 803e662ede5ba87711a0e764a4dc5e00
     download_url:
       - https://dataverse.nl/api/access/datafile/45108
     media_type: application/gzip
   - id: exthisdsver:./sub-030/func/sub-030_task-fingerTapping_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: bcd7d4cca00199ced81ffacc4c34ec31
+      - creator: spdx:checksumAlgorithm_md5
+        notation: bcd7d4cca00199ced81ffacc4c34ec31
     download_url:
       - https://dataverse.nl/api/access/datafile/45489
     media_type: application/json
   - id: exthisdsver:./sub-030/func/sub-030_task-fingerTapping_physio.tsv.gz
     byte_size: 476107
     checksum:
-      - algorithm: md5
-        digest: 50fbda51cbb53ef16f3fb3597d76d674
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 50fbda51cbb53ef16f3fb3597d76d674
     download_url:
       - https://dataverse.nl/api/access/datafile/46465
     media_type: application/gzip
   - id: exthisdsver:./sub-030/func/sub-030_task-rest_run-1_echo-1_bold.json
     byte_size: 1030
     checksum:
-      - algorithm: md5
-        digest: 0e9ab4d23523465646ff1a1fff65dc25
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 0e9ab4d23523465646ff1a1fff65dc25
     download_url:
       - https://dataverse.nl/api/access/datafile/46403
     media_type: application/json
   - id: exthisdsver:./sub-030/func/sub-030_task-rest_run-1_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 7b7d78156f700cae33926db5aa2f0d04
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 7b7d78156f700cae33926db5aa2f0d04
     download_url:
       - https://dataverse.nl/api/access/datafile/46414
     media_type: image/nii
   - id: exthisdsver:./sub-030/func/sub-030_task-rest_run-1_echo-2_bold.json
     byte_size: 1030
     checksum:
-      - algorithm: md5
-        digest: 7e85df7221171f6b2372643486c02bcb
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 7e85df7221171f6b2372643486c02bcb
     download_url:
       - https://dataverse.nl/api/access/datafile/45541
     media_type: application/json
   - id: exthisdsver:./sub-030/func/sub-030_task-rest_run-1_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 122692ec73aa0497ec013677ce2cb7e0
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 122692ec73aa0497ec013677ce2cb7e0
     download_url:
       - https://dataverse.nl/api/access/datafile/45377
     media_type: image/nii
   - id: exthisdsver:./sub-030/func/sub-030_task-rest_run-1_echo-3_bold.json
     byte_size: 1030
     checksum:
-      - algorithm: md5
-        digest: 43e86c28283bc8009c9d97276c233295
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 43e86c28283bc8009c9d97276c233295
     download_url:
       - https://dataverse.nl/api/access/datafile/45564
     media_type: application/json
   - id: exthisdsver:./sub-030/func/sub-030_task-rest_run-1_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: d91741896d318dc2ed2b04cb0d9278c5
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d91741896d318dc2ed2b04cb0d9278c5
     download_url:
       - https://dataverse.nl/api/access/datafile/46280
     media_type: image/nii
   - id: exthisdsver:./sub-030/func/sub-030_task-rest_run-1_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 51211fa4e8939015647398b0c8c7e679
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 51211fa4e8939015647398b0c8c7e679
     download_url:
       - https://dataverse.nl/api/access/datafile/45408
     media_type: application/json
   - id: exthisdsver:./sub-030/func/sub-030_task-rest_run-1_physio.tsv.gz
     byte_size: 462755
     checksum:
-      - algorithm: md5
-        digest: e68ffa789f92076c93d66148afd5cd89
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e68ffa789f92076c93d66148afd5cd89
     download_url:
       - https://dataverse.nl/api/access/datafile/45321
     media_type: application/gzip
   - id: exthisdsver:./sub-030/func/sub-030_task-rest_run-2_echo-1_bold.json
     byte_size: 1031
     checksum:
-      - algorithm: md5
-        digest: 956ae391decb81c3c0b4696c2f95ac4b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 956ae391decb81c3c0b4696c2f95ac4b
     download_url:
       - https://dataverse.nl/api/access/datafile/45596
     media_type: application/json
   - id: exthisdsver:./sub-030/func/sub-030_task-rest_run-2_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 747a22e06891ce5b95226b442fead6f6
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 747a22e06891ce5b95226b442fead6f6
     download_url:
       - https://dataverse.nl/api/access/datafile/46211
     media_type: image/nii
   - id: exthisdsver:./sub-030/func/sub-030_task-rest_run-2_echo-2_bold.json
     byte_size: 1031
     checksum:
-      - algorithm: md5
-        digest: 04d3584fb830f7a8ef784728c17e630e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 04d3584fb830f7a8ef784728c17e630e
     download_url:
       - https://dataverse.nl/api/access/datafile/45133
     media_type: application/json
   - id: exthisdsver:./sub-030/func/sub-030_task-rest_run-2_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 1597ff009b5f28a228d4dfd9ebc0e93e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1597ff009b5f28a228d4dfd9ebc0e93e
     download_url:
       - https://dataverse.nl/api/access/datafile/45715
     media_type: image/nii
   - id: exthisdsver:./sub-030/func/sub-030_task-rest_run-2_echo-3_bold.json
     byte_size: 1031
     checksum:
-      - algorithm: md5
-        digest: 7c4457b85550d91fae95d072a4cc570b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 7c4457b85550d91fae95d072a4cc570b
     download_url:
       - https://dataverse.nl/api/access/datafile/45131
     media_type: application/json
   - id: exthisdsver:./sub-030/func/sub-030_task-rest_run-2_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 62d1d1ee187bcf3bb58bf391bf188b32
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 62d1d1ee187bcf3bb58bf391bf188b32
     download_url:
       - https://dataverse.nl/api/access/datafile/46137
     media_type: image/nii
   - id: exthisdsver:./sub-030/func/sub-030_task-rest_run-2_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: a652f7b56ad758609c5310ef0fab2937
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a652f7b56ad758609c5310ef0fab2937
     download_url:
       - https://dataverse.nl/api/access/datafile/46122
     media_type: application/json
   - id: exthisdsver:./sub-030/func/sub-030_task-rest_run-2_physio.tsv.gz
     byte_size: 476195
     checksum:
-      - algorithm: md5
-        digest: 4cf99739f118bfd9a0997fe0ae604bcc
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4cf99739f118bfd9a0997fe0ae604bcc
     download_url:
       - https://dataverse.nl/api/access/datafile/46286
     media_type: application/gzip
   - id: exthisdsver:./sub-031/anat/sub-031_T1w.nii
     byte_size: 20736352
     checksum:
-      - algorithm: md5
-        digest: eb385669721030b98836830b7000b0b5
+      - creator: spdx:checksumAlgorithm_md5
+        notation: eb385669721030b98836830b7000b0b5
     download_url:
       - https://dataverse.nl/api/access/datafile/45544
     media_type: image/nii
@@ -14652,8 +14652,8 @@ has_part:
   - id: exthisdsver:./sub-031/func/sub-031_task-emotionProcessing_echo-1_bold.json
     byte_size: 1037
     checksum:
-      - algorithm: md5
-        digest: 42a0650f24e5e4d1ceef8d63789c07e0
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 42a0650f24e5e4d1ceef8d63789c07e0
     download_url:
       - https://dataverse.nl/api/access/datafile/45851
     media_type: application/json
@@ -14772,48 +14772,48 @@ has_part:
   - id: exthisdsver:./sub-031/func/sub-031_task-emotionProcessing_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: a2d2a978cab262ecef9ec66c647675ab
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a2d2a978cab262ecef9ec66c647675ab
     download_url:
       - https://dataverse.nl/api/access/datafile/46256
     media_type: image/nii
   - id: exthisdsver:./sub-031/func/sub-031_task-emotionProcessing_echo-2_bold.json
     byte_size: 1037
     checksum:
-      - algorithm: md5
-        digest: 4e1fca6683a7845b0eabcf07a9a7fc73
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4e1fca6683a7845b0eabcf07a9a7fc73
     download_url:
       - https://dataverse.nl/api/access/datafile/45639
     media_type: application/json
   - id: exthisdsver:./sub-031/func/sub-031_task-emotionProcessing_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 0fec398f1ec3542a99bf6970f7926670
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 0fec398f1ec3542a99bf6970f7926670
     download_url:
       - https://dataverse.nl/api/access/datafile/45812
     media_type: image/nii
   - id: exthisdsver:./sub-031/func/sub-031_task-emotionProcessing_echo-3_bold.json
     byte_size: 1037
     checksum:
-      - algorithm: md5
-        digest: 2fae64eda1ad8304bc639b6399a6ac21
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2fae64eda1ad8304bc639b6399a6ac21
     download_url:
       - https://dataverse.nl/api/access/datafile/46538
     media_type: application/json
   - id: exthisdsver:./sub-031/func/sub-031_task-emotionProcessing_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: edd04104a9525374da16af5ac8444a6e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: edd04104a9525374da16af5ac8444a6e
     download_url:
       - https://dataverse.nl/api/access/datafile/45486
     media_type: image/nii
   - id: exthisdsver:./sub-031/func/sub-031_task-emotionProcessing_events.tsv.gz
     byte_size: 1854
     checksum:
-      - algorithm: md5
-        digest: 5277d970321107e4ff62110a5efa36b2
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5277d970321107e4ff62110a5efa36b2
     download_url:
       - https://dataverse.nl/api/access/datafile/46628
     media_type: application/gzip
@@ -14821,8 +14821,8 @@ has_part:
       exthisdsver:./sub-031/func/sub-031_task-emotionProcessingImagined_echo-1_bold.json
     byte_size: 1045
     checksum:
-      - algorithm: md5
-        digest: 8217cc3d23c0c41e5e906b5425eef056
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8217cc3d23c0c41e5e906b5425eef056
     download_url:
       - https://dataverse.nl/api/access/datafile/45355
     media_type: application/json
@@ -14830,8 +14830,8 @@ has_part:
       exthisdsver:./sub-031/func/sub-031_task-emotionProcessingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: ec54f11a2ea08dcb739e1882ed99ff43
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ec54f11a2ea08dcb739e1882ed99ff43
     download_url:
       - https://dataverse.nl/api/access/datafile/46380
     media_type: image/nii
@@ -14839,8 +14839,8 @@ has_part:
       exthisdsver:./sub-031/func/sub-031_task-emotionProcessingImagined_echo-2_bold.json
     byte_size: 1045
     checksum:
-      - algorithm: md5
-        digest: 08a4ef57345695af6df33685c7d16c1f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 08a4ef57345695af6df33685c7d16c1f
     download_url:
       - https://dataverse.nl/api/access/datafile/45918
     media_type: application/json
@@ -14848,8 +14848,8 @@ has_part:
       exthisdsver:./sub-031/func/sub-031_task-emotionProcessingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 6b3e0bc231406bf13779757fd84ea449
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6b3e0bc231406bf13779757fd84ea449
     download_url:
       - https://dataverse.nl/api/access/datafile/45373
     media_type: image/nii
@@ -14857,8 +14857,8 @@ has_part:
       exthisdsver:./sub-031/func/sub-031_task-emotionProcessingImagined_echo-3_bold.json
     byte_size: 1045
     checksum:
-      - algorithm: md5
-        digest: d12cf12c33775533eddb629c61308042
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d12cf12c33775533eddb629c61308042
     download_url:
       - https://dataverse.nl/api/access/datafile/46363
     media_type: application/json
@@ -14866,328 +14866,328 @@ has_part:
       exthisdsver:./sub-031/func/sub-031_task-emotionProcessingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: b886908aeaa472357d3c9b59bcf37a34
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b886908aeaa472357d3c9b59bcf37a34
     download_url:
       - https://dataverse.nl/api/access/datafile/45194
     media_type: image/nii
   - id: exthisdsver:./sub-031/func/sub-031_task-emotionProcessingImagined_events.tsv.gz
     byte_size: 178
     checksum:
-      - algorithm: md5
-        digest: 880d5e26a7c1025b0f921cf8c4ee76d2
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 880d5e26a7c1025b0f921cf8c4ee76d2
     download_url:
       - https://dataverse.nl/api/access/datafile/46614
     media_type: application/gzip
   - id: exthisdsver:./sub-031/func/sub-031_task-emotionProcessingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 99890ebb90e3ff583aaae8a7c96dd4c6
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 99890ebb90e3ff583aaae8a7c96dd4c6
     download_url:
       - https://dataverse.nl/api/access/datafile/46092
     media_type: application/json
   - id: exthisdsver:./sub-031/func/sub-031_task-emotionProcessingImagined_physio.tsv.gz
     byte_size: 474191
     checksum:
-      - algorithm: md5
-        digest: 80331e9333eae550dbfac06eecaff7f7
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 80331e9333eae550dbfac06eecaff7f7
     download_url:
       - https://dataverse.nl/api/access/datafile/45397
     media_type: application/gzip
   - id: exthisdsver:./sub-031/func/sub-031_task-emotionProcessing_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: a9ec1300d617c185be53ecc4378dd2a9
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a9ec1300d617c185be53ecc4378dd2a9
     download_url:
       - https://dataverse.nl/api/access/datafile/45831
     media_type: application/json
   - id: exthisdsver:./sub-031/func/sub-031_task-emotionProcessing_physio.tsv.gz
     byte_size: 486789
     checksum:
-      - algorithm: md5
-        digest: b76ec0da0d71f3fcc24208db6c777034
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b76ec0da0d71f3fcc24208db6c777034
     download_url:
       - https://dataverse.nl/api/access/datafile/45874
     media_type: application/gzip
   - id: exthisdsver:./sub-031/func/sub-031_task-fingerTapping_echo-1_bold.json
     byte_size: 1033
     checksum:
-      - algorithm: md5
-        digest: 3719f2d5fb9e27010773993f60836e39
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 3719f2d5fb9e27010773993f60836e39
     download_url:
       - https://dataverse.nl/api/access/datafile/46449
     media_type: application/json
   - id: exthisdsver:./sub-031/func/sub-031_task-fingerTapping_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 16236c6dd29c2d773c5fe63d9b5733fa
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 16236c6dd29c2d773c5fe63d9b5733fa
     download_url:
       - https://dataverse.nl/api/access/datafile/46236
     media_type: image/nii
   - id: exthisdsver:./sub-031/func/sub-031_task-fingerTapping_echo-2_bold.json
     byte_size: 1033
     checksum:
-      - algorithm: md5
-        digest: 0db5e7ae1cb6627feeb54be3ba822b84
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 0db5e7ae1cb6627feeb54be3ba822b84
     download_url:
       - https://dataverse.nl/api/access/datafile/45259
     media_type: application/json
   - id: exthisdsver:./sub-031/func/sub-031_task-fingerTapping_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: bd54aedb7810b5b36460e00d483aedbe
+      - creator: spdx:checksumAlgorithm_md5
+        notation: bd54aedb7810b5b36460e00d483aedbe
     download_url:
       - https://dataverse.nl/api/access/datafile/45452
     media_type: image/nii
   - id: exthisdsver:./sub-031/func/sub-031_task-fingerTapping_echo-3_bold.json
     byte_size: 1033
     checksum:
-      - algorithm: md5
-        digest: d4c69055b292ca4302ca0f04c7169c8b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d4c69055b292ca4302ca0f04c7169c8b
     download_url:
       - https://dataverse.nl/api/access/datafile/45908
     media_type: application/json
   - id: exthisdsver:./sub-031/func/sub-031_task-fingerTapping_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: e72425e7c2aee7afe5d96859729f9fb7
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e72425e7c2aee7afe5d96859729f9fb7
     download_url:
       - https://dataverse.nl/api/access/datafile/45721
     media_type: image/nii
   - id: exthisdsver:./sub-031/func/sub-031_task-fingerTapping_events.tsv.gz
     byte_size: 167
     checksum:
-      - algorithm: md5
-        digest: fc88d5449bdfef5f0eb7a528f33b27bb
+      - creator: spdx:checksumAlgorithm_md5
+        notation: fc88d5449bdfef5f0eb7a528f33b27bb
     download_url:
       - https://dataverse.nl/api/access/datafile/46618
     media_type: application/gzip
   - id: exthisdsver:./sub-031/func/sub-031_task-fingerTappingImagined_echo-1_bold.json
     byte_size: 1041
     checksum:
-      - algorithm: md5
-        digest: 5e7da551bf765343ced4a55abc97db70
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5e7da551bf765343ced4a55abc97db70
     download_url:
       - https://dataverse.nl/api/access/datafile/45506
     media_type: application/json
   - id: exthisdsver:./sub-031/func/sub-031_task-fingerTappingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: ee7c5e607a7a996daf5935a1234fdb37
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ee7c5e607a7a996daf5935a1234fdb37
     download_url:
       - https://dataverse.nl/api/access/datafile/45279
     media_type: image/nii
   - id: exthisdsver:./sub-031/func/sub-031_task-fingerTappingImagined_echo-2_bold.json
     byte_size: 1041
     checksum:
-      - algorithm: md5
-        digest: 17ac41ef430199c10cae34b9edfca197
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 17ac41ef430199c10cae34b9edfca197
     download_url:
       - https://dataverse.nl/api/access/datafile/46103
     media_type: application/json
   - id: exthisdsver:./sub-031/func/sub-031_task-fingerTappingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: a501d0464c22f726e6f5f1faad45ed5d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a501d0464c22f726e6f5f1faad45ed5d
     download_url:
       - https://dataverse.nl/api/access/datafile/45542
     media_type: image/nii
   - id: exthisdsver:./sub-031/func/sub-031_task-fingerTappingImagined_echo-3_bold.json
     byte_size: 1041
     checksum:
-      - algorithm: md5
-        digest: 4cb2a766010ebf0ca6721331b9529591
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4cb2a766010ebf0ca6721331b9529591
     download_url:
       - https://dataverse.nl/api/access/datafile/45130
     media_type: application/json
   - id: exthisdsver:./sub-031/func/sub-031_task-fingerTappingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 5df5194d728d639ebd1029b09f1f0411
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5df5194d728d639ebd1029b09f1f0411
     download_url:
       - https://dataverse.nl/api/access/datafile/45152
     media_type: image/nii
   - id: exthisdsver:./sub-031/func/sub-031_task-fingerTappingImagined_events.tsv.gz
     byte_size: 179
     checksum:
-      - algorithm: md5
-        digest: 6691789fd6206ed061aa23750b11b927
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6691789fd6206ed061aa23750b11b927
     download_url:
       - https://dataverse.nl/api/access/datafile/46598
     media_type: application/gzip
   - id: exthisdsver:./sub-031/func/sub-031_task-fingerTappingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: c623115320f634efcaefb2b0a5d75288
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c623115320f634efcaefb2b0a5d75288
     download_url:
       - https://dataverse.nl/api/access/datafile/45821
     media_type: application/json
   - id: exthisdsver:./sub-031/func/sub-031_task-fingerTappingImagined_physio.tsv.gz
     byte_size: 468033
     checksum:
-      - algorithm: md5
-        digest: 4a16ec80d015060631add147e0a6fd74
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4a16ec80d015060631add147e0a6fd74
     download_url:
       - https://dataverse.nl/api/access/datafile/46024
     media_type: application/gzip
   - id: exthisdsver:./sub-031/func/sub-031_task-fingerTapping_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 31b4170baec18b2be5621e9f2d3bf577
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 31b4170baec18b2be5621e9f2d3bf577
     download_url:
       - https://dataverse.nl/api/access/datafile/45770
     media_type: application/json
   - id: exthisdsver:./sub-031/func/sub-031_task-fingerTapping_physio.tsv.gz
     byte_size: 499366
     checksum:
-      - algorithm: md5
-        digest: 66a719fb58313de8f23285c9e364d41b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 66a719fb58313de8f23285c9e364d41b
     download_url:
       - https://dataverse.nl/api/access/datafile/45176
     media_type: application/gzip
   - id: exthisdsver:./sub-031/func/sub-031_task-rest_run-1_echo-1_bold.json
     byte_size: 1024
     checksum:
-      - algorithm: md5
-        digest: 881dda2fa595fb1e83732f6baa916c6d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 881dda2fa595fb1e83732f6baa916c6d
     download_url:
       - https://dataverse.nl/api/access/datafile/45871
     media_type: application/json
   - id: exthisdsver:./sub-031/func/sub-031_task-rest_run-1_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 586bfe19d96be1d7ffb8235acee74d5c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 586bfe19d96be1d7ffb8235acee74d5c
     download_url:
       - https://dataverse.nl/api/access/datafile/45833
     media_type: image/nii
   - id: exthisdsver:./sub-031/func/sub-031_task-rest_run-1_echo-2_bold.json
     byte_size: 1024
     checksum:
-      - algorithm: md5
-        digest: fa4292ec53aa27a9950dd945ad649149
+      - creator: spdx:checksumAlgorithm_md5
+        notation: fa4292ec53aa27a9950dd945ad649149
     download_url:
       - https://dataverse.nl/api/access/datafile/45328
     media_type: application/json
   - id: exthisdsver:./sub-031/func/sub-031_task-rest_run-1_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: afba70a659537be0515ef3c082820c98
+      - creator: spdx:checksumAlgorithm_md5
+        notation: afba70a659537be0515ef3c082820c98
     download_url:
       - https://dataverse.nl/api/access/datafile/45178
     media_type: image/nii
   - id: exthisdsver:./sub-031/func/sub-031_task-rest_run-1_echo-3_bold.json
     byte_size: 1024
     checksum:
-      - algorithm: md5
-        digest: c284b2a35f671ff7526c69854c2bb564
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c284b2a35f671ff7526c69854c2bb564
     download_url:
       - https://dataverse.nl/api/access/datafile/46433
     media_type: application/json
   - id: exthisdsver:./sub-031/func/sub-031_task-rest_run-1_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 3f3c28f7447a7cd0f183073bbe401b13
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 3f3c28f7447a7cd0f183073bbe401b13
     download_url:
       - https://dataverse.nl/api/access/datafile/45751
     media_type: image/nii
   - id: exthisdsver:./sub-031/func/sub-031_task-rest_run-1_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: b676a72f00b1dc65fc19563863766991
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b676a72f00b1dc65fc19563863766991
     download_url:
       - https://dataverse.nl/api/access/datafile/45806
     media_type: application/json
   - id: exthisdsver:./sub-031/func/sub-031_task-rest_run-1_physio.tsv.gz
     byte_size: 466931
     checksum:
-      - algorithm: md5
-        digest: e50bd35a460c3654ea0d49fe55028b06
+      - creator: spdx:checksumAlgorithm_md5
+        notation: e50bd35a460c3654ea0d49fe55028b06
     download_url:
       - https://dataverse.nl/api/access/datafile/45912
     media_type: application/gzip
   - id: exthisdsver:./sub-031/func/sub-031_task-rest_run-2_echo-1_bold.json
     byte_size: 1024
     checksum:
-      - algorithm: md5
-        digest: bc778928ec86b0b101244f24aaa164bd
+      - creator: spdx:checksumAlgorithm_md5
+        notation: bc778928ec86b0b101244f24aaa164bd
     download_url:
       - https://dataverse.nl/api/access/datafile/45635
     media_type: application/json
   - id: exthisdsver:./sub-031/func/sub-031_task-rest_run-2_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 1d1746b3ff6e6a7a056c7649e7a440a7
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1d1746b3ff6e6a7a056c7649e7a440a7
     download_url:
       - https://dataverse.nl/api/access/datafile/46364
     media_type: image/nii
   - id: exthisdsver:./sub-031/func/sub-031_task-rest_run-2_echo-2_bold.json
     byte_size: 1024
     checksum:
-      - algorithm: md5
-        digest: 1ea98acf6dc9275f88d7f22b4c723adc
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1ea98acf6dc9275f88d7f22b4c723adc
     download_url:
       - https://dataverse.nl/api/access/datafile/46291
     media_type: application/json
   - id: exthisdsver:./sub-031/func/sub-031_task-rest_run-2_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 706ff57f1edd078131e4ce97ad5bb0cd
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 706ff57f1edd078131e4ce97ad5bb0cd
     download_url:
       - https://dataverse.nl/api/access/datafile/45144
     media_type: image/nii
   - id: exthisdsver:./sub-031/func/sub-031_task-rest_run-2_echo-3_bold.json
     byte_size: 1024
     checksum:
-      - algorithm: md5
-        digest: 5d4b834cc7ba0ac83167972984bed1f6
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5d4b834cc7ba0ac83167972984bed1f6
     download_url:
       - https://dataverse.nl/api/access/datafile/45998
     media_type: application/json
   - id: exthisdsver:./sub-031/func/sub-031_task-rest_run-2_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: bea921c5cb404c38ee939c51b8c586a8
+      - creator: spdx:checksumAlgorithm_md5
+        notation: bea921c5cb404c38ee939c51b8c586a8
     download_url:
       - https://dataverse.nl/api/access/datafile/45186
     media_type: image/nii
   - id: exthisdsver:./sub-031/func/sub-031_task-rest_run-2_physio.json
     byte_size: 142
     checksum:
-      - algorithm: md5
-        digest: a5d69e35f3340276d6be92b975f206d9
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a5d69e35f3340276d6be92b975f206d9
     download_url:
       - https://dataverse.nl/api/access/datafile/46319
     media_type: application/json
   - id: exthisdsver:./sub-031/func/sub-031_task-rest_run-2_physio.tsv.gz
     byte_size: 464210
     checksum:
-      - algorithm: md5
-        digest: 184f7866445f619c0c067be193c1e215
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 184f7866445f619c0c067be193c1e215
     download_url:
       - https://dataverse.nl/api/access/datafile/46204
     media_type: application/gzip
   - id: exthisdsver:./sub-032/anat/sub-032_T1w.nii
     byte_size: 20736352
     checksum:
-      - algorithm: md5
-        digest: 48e60100ea298d4d4c8c8d3cbfd04b0e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 48e60100ea298d4d4c8c8d3cbfd04b0e
     download_url:
       - https://dataverse.nl/api/access/datafile/46200
     media_type: image/nii
@@ -15204,8 +15204,8 @@ has_part:
   - id: exthisdsver:./sub-032/func/sub-032_task-emotionProcessing_echo-1_bold.json
     byte_size: 1041
     checksum:
-      - algorithm: md5
-        digest: 06416007e86d197a6940d678e8136bca
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 06416007e86d197a6940d678e8136bca
     download_url:
       - https://dataverse.nl/api/access/datafile/45609
     media_type: application/json
@@ -15324,48 +15324,48 @@ has_part:
   - id: exthisdsver:./sub-032/func/sub-032_task-emotionProcessing_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 1b89791e8c1aee44164213034f192b63
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1b89791e8c1aee44164213034f192b63
     download_url:
       - https://dataverse.nl/api/access/datafile/46352
     media_type: image/nii
   - id: exthisdsver:./sub-032/func/sub-032_task-emotionProcessing_echo-2_bold.json
     byte_size: 1041
     checksum:
-      - algorithm: md5
-        digest: 2b3b3996277ade762410715cfd47431a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 2b3b3996277ade762410715cfd47431a
     download_url:
       - https://dataverse.nl/api/access/datafile/45817
     media_type: application/json
   - id: exthisdsver:./sub-032/func/sub-032_task-emotionProcessing_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 65365545508eabb82cc566e36be4ac34
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 65365545508eabb82cc566e36be4ac34
     download_url:
       - https://dataverse.nl/api/access/datafile/46478
     media_type: image/nii
   - id: exthisdsver:./sub-032/func/sub-032_task-emotionProcessing_echo-3_bold.json
     byte_size: 1041
     checksum:
-      - algorithm: md5
-        digest: ed07bf52a32bd33053c0bb04e686972a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ed07bf52a32bd33053c0bb04e686972a
     download_url:
       - https://dataverse.nl/api/access/datafile/45529
     media_type: application/json
   - id: exthisdsver:./sub-032/func/sub-032_task-emotionProcessing_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: b1e6f7903c2a3150438d9a23616504af
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b1e6f7903c2a3150438d9a23616504af
     download_url:
       - https://dataverse.nl/api/access/datafile/45522
     media_type: image/nii
   - id: exthisdsver:./sub-032/func/sub-032_task-emotionProcessing_events.tsv.gz
     byte_size: 1873
     checksum:
-      - algorithm: md5
-        digest: 8e174c8a66696c7906ba1dcf98d2cc68
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 8e174c8a66696c7906ba1dcf98d2cc68
     download_url:
       - https://dataverse.nl/api/access/datafile/46638
     media_type: application/gzip
@@ -15373,8 +15373,8 @@ has_part:
       exthisdsver:./sub-032/func/sub-032_task-emotionProcessingImagined_echo-1_bold.json
     byte_size: 1049
     checksum:
-      - algorithm: md5
-        digest: 61c5e521e58b82e36d53844980c06b63
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 61c5e521e58b82e36d53844980c06b63
     download_url:
       - https://dataverse.nl/api/access/datafile/46238
     media_type: application/json
@@ -15382,8 +15382,8 @@ has_part:
       exthisdsver:./sub-032/func/sub-032_task-emotionProcessingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 1bf02155e4fcab9c3684175c291dcb3f
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 1bf02155e4fcab9c3684175c291dcb3f
     download_url:
       - https://dataverse.nl/api/access/datafile/45335
     media_type: image/nii
@@ -15391,8 +15391,8 @@ has_part:
       exthisdsver:./sub-032/func/sub-032_task-emotionProcessingImagined_echo-2_bold.json
     byte_size: 1049
     checksum:
-      - algorithm: md5
-        digest: 0eefb1536ee550ab938735426c2eef11
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 0eefb1536ee550ab938735426c2eef11
     download_url:
       - https://dataverse.nl/api/access/datafile/45203
     media_type: application/json
@@ -15400,8 +15400,8 @@ has_part:
       exthisdsver:./sub-032/func/sub-032_task-emotionProcessingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 4c609570fd448c9b71abec081fa6d7b4
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 4c609570fd448c9b71abec081fa6d7b4
     download_url:
       - https://dataverse.nl/api/access/datafile/46106
     media_type: image/nii
@@ -15409,8 +15409,8 @@ has_part:
       exthisdsver:./sub-032/func/sub-032_task-emotionProcessingImagined_echo-3_bold.json
     byte_size: 1049
     checksum:
-      - algorithm: md5
-        digest: 02b818204856fea23ce0f54e4dc1dd19
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 02b818204856fea23ce0f54e4dc1dd19
     download_url:
       - https://dataverse.nl/api/access/datafile/45223
     media_type: application/json
@@ -15418,352 +15418,352 @@ has_part:
       exthisdsver:./sub-032/func/sub-032_task-emotionProcessingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 80eba72ec6b10e3cf388f9ca45f341f3
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 80eba72ec6b10e3cf388f9ca45f341f3
     download_url:
       - https://dataverse.nl/api/access/datafile/45526
     media_type: image/nii
   - id: exthisdsver:./sub-032/func/sub-032_task-emotionProcessingImagined_events.tsv.gz
     byte_size: 178
     checksum:
-      - algorithm: md5
-        digest: ecf9cf82ebb51b7bf4b02c480273f2a4
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ecf9cf82ebb51b7bf4b02c480273f2a4
     download_url:
       - https://dataverse.nl/api/access/datafile/46634
     media_type: application/gzip
   - id: exthisdsver:./sub-032/func/sub-032_task-emotionProcessingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: a608105dd96eab86ce9ec6496e59f96b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a608105dd96eab86ce9ec6496e59f96b
     download_url:
       - https://dataverse.nl/api/access/datafile/46401
     media_type: application/json
   - id: exthisdsver:./sub-032/func/sub-032_task-emotionProcessingImagined_physio.tsv.gz
     byte_size: 466464
     checksum:
-      - algorithm: md5
-        digest: fdf331a186d1c0bcf29afe86797af8aa
+      - creator: spdx:checksumAlgorithm_md5
+        notation: fdf331a186d1c0bcf29afe86797af8aa
     download_url:
       - https://dataverse.nl/api/access/datafile/45291
     media_type: application/gzip
   - id: exthisdsver:./sub-032/func/sub-032_task-emotionProcessing_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: a980a7103affd6f65d96e06212a0a3b0
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a980a7103affd6f65d96e06212a0a3b0
     download_url:
       - https://dataverse.nl/api/access/datafile/45756
     media_type: application/json
   - id: exthisdsver:./sub-032/func/sub-032_task-emotionProcessing_physio.tsv.gz
     byte_size: 493060
     checksum:
-      - algorithm: md5
-        digest: 679f51d4a7e2989403d6b807fad9e7d2
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 679f51d4a7e2989403d6b807fad9e7d2
     download_url:
       - https://dataverse.nl/api/access/datafile/46248
     media_type: application/gzip
   - id: exthisdsver:./sub-032/func/sub-032_task-fingerTapping_echo-1_bold.json
     byte_size: 1037
     checksum:
-      - algorithm: md5
-        digest: ce389476e87c994f77aaa2158f41ea8d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ce389476e87c994f77aaa2158f41ea8d
     download_url:
       - https://dataverse.nl/api/access/datafile/46405
     media_type: application/json
   - id: exthisdsver:./sub-032/func/sub-032_task-fingerTapping_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: aa3c6b2b266c7d0f9231892fb30c232c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: aa3c6b2b266c7d0f9231892fb30c232c
     download_url:
       - https://dataverse.nl/api/access/datafile/46318
     media_type: image/nii
   - id: exthisdsver:./sub-032/func/sub-032_task-fingerTapping_echo-2_bold.json
     byte_size: 1037
     checksum:
-      - algorithm: md5
-        digest: b49a4da3a7f7bd6888b4ff407e5833b2
+      - creator: spdx:checksumAlgorithm_md5
+        notation: b49a4da3a7f7bd6888b4ff407e5833b2
     download_url:
       - https://dataverse.nl/api/access/datafile/46446
     media_type: application/json
   - id: exthisdsver:./sub-032/func/sub-032_task-fingerTapping_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 75bba51d82aee031e427861b16236775
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 75bba51d82aee031e427861b16236775
     download_url:
       - https://dataverse.nl/api/access/datafile/45773
     media_type: image/nii
   - id: exthisdsver:./sub-032/func/sub-032_task-fingerTapping_echo-3_bold.json
     byte_size: 1037
     checksum:
-      - algorithm: md5
-        digest: da255b4cbc9064e4d00bdd80bfef8e94
+      - creator: spdx:checksumAlgorithm_md5
+        notation: da255b4cbc9064e4d00bdd80bfef8e94
     download_url:
       - https://dataverse.nl/api/access/datafile/45576
     media_type: application/json
   - id: exthisdsver:./sub-032/func/sub-032_task-fingerTapping_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 04aabb3917920bbea046ca597b0c3614
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 04aabb3917920bbea046ca597b0c3614
     download_url:
       - https://dataverse.nl/api/access/datafile/46273
     media_type: image/nii
   - id: exthisdsver:./sub-032/func/sub-032_task-fingerTapping_events.tsv.gz
     byte_size: 167
     checksum:
-      - algorithm: md5
-        digest: 01dd8f6f5e013c54c0627beb86752f57
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 01dd8f6f5e013c54c0627beb86752f57
     download_url:
       - https://dataverse.nl/api/access/datafile/46605
     media_type: application/gzip
   - id: exthisdsver:./sub-032/func/sub-032_task-fingerTappingImagined_echo-1_bold.json
     byte_size: 1045
     checksum:
-      - algorithm: md5
-        digest: a3ecabae2ffc13e0a501f7f66763f221
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a3ecabae2ffc13e0a501f7f66763f221
     download_url:
       - https://dataverse.nl/api/access/datafile/45944
     media_type: application/json
   - id: exthisdsver:./sub-032/func/sub-032_task-fingerTappingImagined_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: ee6dae06d74b9429018c5e223ba18e1b
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ee6dae06d74b9429018c5e223ba18e1b
     download_url:
       - https://dataverse.nl/api/access/datafile/45399
     media_type: image/nii
   - id: exthisdsver:./sub-032/func/sub-032_task-fingerTappingImagined_echo-2_bold.json
     byte_size: 1045
     checksum:
-      - algorithm: md5
-        digest: feb865a25268a697bba12a00e056e9e8
+      - creator: spdx:checksumAlgorithm_md5
+        notation: feb865a25268a697bba12a00e056e9e8
     download_url:
       - https://dataverse.nl/api/access/datafile/46258
     media_type: application/json
   - id: exthisdsver:./sub-032/func/sub-032_task-fingerTappingImagined_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: bf036104b3012772a84b6beef452198e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: bf036104b3012772a84b6beef452198e
     download_url:
       - https://dataverse.nl/api/access/datafile/45458
     media_type: image/nii
   - id: exthisdsver:./sub-032/func/sub-032_task-fingerTappingImagined_echo-3_bold.json
     byte_size: 1045
     checksum:
-      - algorithm: md5
-        digest: 5a6937a8c9385dd4b229505d0e0eb9b3
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 5a6937a8c9385dd4b229505d0e0eb9b3
     download_url:
       - https://dataverse.nl/api/access/datafile/46353
     media_type: application/json
   - id: exthisdsver:./sub-032/func/sub-032_task-fingerTappingImagined_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 422b513db148567d68380c9cc0a07a96
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 422b513db148567d68380c9cc0a07a96
     download_url:
       - https://dataverse.nl/api/access/datafile/45401
     media_type: image/nii
   - id: exthisdsver:./sub-032/func/sub-032_task-fingerTappingImagined_events.tsv.gz
     byte_size: 179
     checksum:
-      - algorithm: md5
-        digest: 70c2dff6db9c2aa45696781343789c5e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 70c2dff6db9c2aa45696781343789c5e
     download_url:
       - https://dataverse.nl/api/access/datafile/46610
     media_type: application/gzip
   - id: exthisdsver:./sub-032/func/sub-032_task-fingerTappingImagined_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: ba316c86b3fd667eefdebfd6b430e537
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ba316c86b3fd667eefdebfd6b430e537
     download_url:
       - https://dataverse.nl/api/access/datafile/45630
     media_type: application/json
   - id: exthisdsver:./sub-032/func/sub-032_task-fingerTappingImagined_physio.tsv.gz
     byte_size: 467483
     checksum:
-      - algorithm: md5
-        digest: 86bb10881e3538db6a45adf4d62f2de9
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 86bb10881e3538db6a45adf4d62f2de9
     download_url:
       - https://dataverse.nl/api/access/datafile/45724
     media_type: application/gzip
   - id: exthisdsver:./sub-032/func/sub-032_task-fingerTapping_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 47c7b8a95b772ed4e9ab4579964acd98
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 47c7b8a95b772ed4e9ab4579964acd98
     download_url:
       - https://dataverse.nl/api/access/datafile/45464
     media_type: application/json
   - id: exthisdsver:./sub-032/func/sub-032_task-fingerTapping_physio.tsv.gz
     byte_size: 471716
     checksum:
-      - algorithm: md5
-        digest: 60e6c6803435ca34b8285788e22f12b6
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 60e6c6803435ca34b8285788e22f12b6
     download_url:
       - https://dataverse.nl/api/access/datafile/46193
     media_type: application/gzip
   - id: exthisdsver:./sub-032/func/sub-032_task-rest_run-1_echo-1_bold.json
     byte_size: 1028
     checksum:
-      - algorithm: md5
-        digest: 19f46f4e86b559bcff24b380d5602814
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 19f46f4e86b559bcff24b380d5602814
     download_url:
       - https://dataverse.nl/api/access/datafile/46520
     media_type: application/json
   - id: exthisdsver:./sub-032/func/sub-032_task-rest_run-1_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: f35d8a4022fa2399322f299689275089
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f35d8a4022fa2399322f299689275089
     download_url:
       - https://dataverse.nl/api/access/datafile/46065
     media_type: image/nii
   - id: exthisdsver:./sub-032/func/sub-032_task-rest_run-1_echo-2_bold.json
     byte_size: 1028
     checksum:
-      - algorithm: md5
-        digest: 7390ff359ffb6e5e7218be387777ddb5
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 7390ff359ffb6e5e7218be387777ddb5
     download_url:
       - https://dataverse.nl/api/access/datafile/46408
     media_type: application/json
   - id: exthisdsver:./sub-032/func/sub-032_task-rest_run-1_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: af3cf6a31f6988965a963fa03adb82e4
+      - creator: spdx:checksumAlgorithm_md5
+        notation: af3cf6a31f6988965a963fa03adb82e4
     download_url:
       - https://dataverse.nl/api/access/datafile/45652
     media_type: image/nii
   - id: exthisdsver:./sub-032/func/sub-032_task-rest_run-1_echo-3_bold.json
     byte_size: 1028
     checksum:
-      - algorithm: md5
-        digest: 9f4b1c3710f156c61b00783ef6e254fd
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 9f4b1c3710f156c61b00783ef6e254fd
     download_url:
       - https://dataverse.nl/api/access/datafile/45315
     media_type: application/json
   - id: exthisdsver:./sub-032/func/sub-032_task-rest_run-1_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 94572c16591270cc44701ad2af98d235
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 94572c16591270cc44701ad2af98d235
     download_url:
       - https://dataverse.nl/api/access/datafile/46171
     media_type: image/nii
   - id: exthisdsver:./sub-032/func/sub-032_task-rest_run-1_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: 601450400ed297074b76412ce41f391a
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 601450400ed297074b76412ce41f391a
     download_url:
       - https://dataverse.nl/api/access/datafile/46240
     media_type: application/json
   - id: exthisdsver:./sub-032/func/sub-032_task-rest_run-1_physio.tsv.gz
     byte_size: 462207
     checksum:
-      - algorithm: md5
-        digest: a29a480738f5ed9341c3a8cb2c35b0ce
+      - creator: spdx:checksumAlgorithm_md5
+        notation: a29a480738f5ed9341c3a8cb2c35b0ce
     download_url:
       - https://dataverse.nl/api/access/datafile/46529
     media_type: application/gzip
   - id: exthisdsver:./sub-032/func/sub-032_task-rest_run-2_echo-1_bold.json
     byte_size: 1028
     checksum:
-      - algorithm: md5
-        digest: 634a31cb6dddc913d0b5b2f36b7d7f55
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 634a31cb6dddc913d0b5b2f36b7d7f55
     download_url:
       - https://dataverse.nl/api/access/datafile/46111
     media_type: application/json
   - id: exthisdsver:./sub-032/func/sub-032_task-rest_run-2_echo-1_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 00e335fb2c52c789ddbbd47fa8577494
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 00e335fb2c52c789ddbbd47fa8577494
     download_url:
       - https://dataverse.nl/api/access/datafile/45606
     media_type: image/nii
   - id: exthisdsver:./sub-032/func/sub-032_task-rest_run-2_echo-2_bold.json
     byte_size: 1028
     checksum:
-      - algorithm: md5
-        digest: 961828cb3e667183d08bc8c50b44841e
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 961828cb3e667183d08bc8c50b44841e
     download_url:
       - https://dataverse.nl/api/access/datafile/46290
     media_type: application/json
   - id: exthisdsver:./sub-032/func/sub-032_task-rest_run-2_echo-2_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 53fa854d499812d7cd2e0c4c0bce4268
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 53fa854d499812d7cd2e0c4c0bce4268
     download_url:
       - https://dataverse.nl/api/access/datafile/45917
     media_type: image/nii
   - id: exthisdsver:./sub-032/func/sub-032_task-rest_run-2_echo-3_bold.json
     byte_size: 1028
     checksum:
-      - algorithm: md5
-        digest: f78b6a8c5bfccaefccdb712c53398c85
+      - creator: spdx:checksumAlgorithm_md5
+        notation: f78b6a8c5bfccaefccdb712c53398c85
     download_url:
       - https://dataverse.nl/api/access/datafile/46369
     media_type: application/json
   - id: exthisdsver:./sub-032/func/sub-032_task-rest_run-2_echo-3_bold.nii
     byte_size: 58491232
     checksum:
-      - algorithm: md5
-        digest: 95d20042772759ef8f1eae8342912238
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 95d20042772759ef8f1eae8342912238
     download_url:
       - https://dataverse.nl/api/access/datafile/45217
     media_type: image/nii
   - id: exthisdsver:./sub-032/func/sub-032_task-rest_run-2_physio.json
     byte_size: 143
     checksum:
-      - algorithm: md5
-        digest: c2bc90d9766475106f49a8e071e31794
+      - creator: spdx:checksumAlgorithm_md5
+        notation: c2bc90d9766475106f49a8e071e31794
     download_url:
       - https://dataverse.nl/api/access/datafile/46336
     media_type: application/json
   - id: exthisdsver:./sub-032/func/sub-032_task-rest_run-2_physio.tsv.gz
     byte_size: 456867
     checksum:
-      - algorithm: md5
-        digest: 6e52d0eed2038d116afc2504ea53551c
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 6e52d0eed2038d116afc2504ea53551c
     download_url:
       - https://dataverse.nl/api/access/datafile/46434
     media_type: application/gzip
   - id: exthisdsver:./task-emotionProcessing_events.json
     byte_size: 1893
     checksum:
-      - algorithm: md5
-        digest: eac027a2545fd2b8ee12e495d2ee6499
+      - creator: spdx:checksumAlgorithm_md5
+        notation: eac027a2545fd2b8ee12e495d2ee6499
     download_url:
       - https://dataverse.nl/api/access/datafile/46665
     media_type: application/json
   - id: exthisdsver:./task-emotionProcessingImagined_events.json
     byte_size: 821
     checksum:
-      - algorithm: md5
-        digest: d80166992bd6e82f2ccc13aea8537542
+      - creator: spdx:checksumAlgorithm_md5
+        notation: d80166992bd6e82f2ccc13aea8537542
     download_url:
       - https://dataverse.nl/api/access/datafile/46667
     media_type: application/json
   - id: exthisdsver:./task-fingerTapping_events.json
     byte_size: 872
     checksum:
-      - algorithm: md5
-        digest: ab572625ab03f4175842af1c3d52370d
+      - creator: spdx:checksumAlgorithm_md5
+        notation: ab572625ab03f4175842af1c3d52370d
     download_url:
       - https://dataverse.nl/api/access/datafile/46666
     media_type: application/json
   - id: exthisdsver:./task-fingerTappingImagined_events.json
     byte_size: 808
     checksum:
-      - algorithm: md5
-        digest: 3b708d003000956e0562d0c8f39b1786
+      - creator: spdx:checksumAlgorithm_md5
+        notation: 3b708d003000956e0562d0c8f39b1786
     download_url:
       - https://dataverse.nl/api/access/datafile/46668
     media_type: application/json

--- a/src/social/unreleased/examples/Organization-02-attributes.json
+++ b/src/social/unreleased/examples/Organization-02-attributes.json
@@ -5,11 +5,13 @@
   "identifiers": [
     {
       "notation": "Q707283",
-      "creator": "https://wikidata.org"
+      "creator": "https://wikidata.org",
+      "type": "dlidentifiers:Identifier"
     },
     {
       "notation": "501100001659",
-      "creator": "https://crossref.org"
+      "creator": "https://crossref.org",
+      "type": "dlidentifiers:Identifier"
     }
   ],
   "name": "Deutsche Forschungsgemeinschaft",

--- a/src/types/unreleased.yaml
+++ b/src/types/unreleased.yaml
@@ -40,6 +40,13 @@ imports:
   - linkml:types
 
 types:
+  HexBinary:
+    uri: xsd:hexBinary
+    base: str
+    pattern: "^[a-fA-F0-9]+$"
+    description: >-
+      hex-encoded binary data.
+
   NodeUriOrCurie:
     typeof: uriorcurie
     description: >-


### PR DESCRIPTION
This changes removes a few checksum specific slots.

The `identifiers` schema is diversified to distinguish "issued" from "computed" identifiers. A difference between the two is that one is created by an organization-agent, whereas the other is created by a software-agent.

A `Checksum` is maintained as a dedicated class, but moved from `distribution`.