### PR TITLE
Add schema dependencies to docs

### DIFF
--- a/src/identifiers/unreleased.yaml
+++ b/src/identifiers/unreleased.yaml
@@ -14,6 +14,10 @@ description: |
   an entity ([`ComputedIdentifier`](ComputedIdentifier)), and a
   [`Checksum`](Checksum) in particular.
 
+  This schema also incorporates the schema(s)
+
+  - [`types`](https://concepts.datalad.org/s/types/unreleased)
+
   The schema definition is available as
 
   - [JSON-LD context](../unreleased.jsonld)

--- a/src/prov/unreleased.yaml
+++ b/src/prov/unreleased.yaml
@@ -34,6 +34,14 @@ description: |
   example, an entity's [`was_generated_by`](was_generated_by) is implemented,
   but not an activity's `generated`.
 
+  This schema also incorporates the schemas
+
+  - [`identifiers`](https://concepts.datalad.org/s/identifiers/unreleased)
+  - [`things`](https://concepts.datalad.org/s/things/v1)
+  - [`roles`](https://concepts.datalad.org/s/roles/unreleased)
+  - [`spatial`](https://concepts.datalad.org/s/spatial/unreleased)
+  - [`temporal`](https://concepts.datalad.org/s/temporal/unreleased)
+
   The schema definition is available as
 
   - [JSON-LD context](../unreleased.jsonld)

--- a/src/publications/unreleased.yaml
+++ b/src/publications/unreleased.yaml
@@ -5,6 +5,13 @@ status: eunal:concept-status/DRAFT
 title: Schema for a describing publications
 description: |
 
+  This schema also incorporates the schemas
+
+  - [`identifiers`](https://concepts.datalad.org/s/identifiers/unreleased)
+  - [`properties`](https://concepts.datalad.org/s/properties/unreleased)
+  - [`temporal`](https://concepts.datalad.org/s/temporal/unreleased)
+  - [`prov`](https://concepts.datalad.org/s/prov/unreleased)
+
   The schema is available as
 
   - [JSON-LD context](../unreleased.jsonld)

--- a/src/resources/unreleased.yaml
+++ b/src/resources/unreleased.yaml
@@ -5,6 +5,11 @@ status: eunal:concept-status/DRAFT
 title: Schema for a describing resources
 description: |
 
+  This schema also incorporates the schemas
+
+  - [`properties`](https://concepts.datalad.org/s/properties/unreleased)
+  - [`prov`](https://concepts.datalad.org/s/prov/unreleased)
+
   The schema is available as
 
   - [JSON-LD context](../unreleased.jsonld)

--- a/src/roles/unreleased.yaml
+++ b/src/roles/unreleased.yaml
@@ -18,6 +18,10 @@ description: |
   attributes as needed. However, typically it should be sufficient
   to reference a role by a URI.
 
+  This schema also incorporates the schemas
+
+  - [`things`](https://concepts.datalad.org/s/things/v1)
+
   The schema definition is available as
 
   - [JSON-LD context](../unreleased.jsonld)

--- a/src/social/unreleased.yaml
+++ b/src/social/unreleased.yaml
@@ -15,6 +15,11 @@ description: |
   emails as suitable schema identifiers for an email address (e.g.,
   `email:me@example.com`).
 
+  This schema also incorporates the schemas
+
+  - [`properties`](https://concepts.datalad.org/s/properties/unreleased)
+  - [`prov`](https://concepts.datalad.org/s/prov/unreleased)
+
   The schema definition is available as
 
   - [JSON-LD context](../unreleased.jsonld)

--- a/src/spatial/unreleased.yaml
+++ b/src/spatial/unreleased.yaml
@@ -5,6 +5,12 @@ status: eunal:concept-status/DRAFT
 title: Schema for characterizing spatial concepts
 description: |
 
+  This schema also incorporates the schemas
+
+  - [`identifiers`](https://concepts.datalad.org/s/identifiers/unreleased)
+  - [`things`](https://concepts.datalad.org/s/things/v1)
+  - [`roles`](https://concepts.datalad.org/s/roles/unreleased)
+
   The schema definition is available as
 
   - [JSON-LD context](../unreleased.jsonld)

--- a/src/temporal/unreleased.yaml
+++ b/src/temporal/unreleased.yaml
@@ -5,6 +5,12 @@ status: eunal:concept-status/DRAFT
 title: Schema for characterizing temporal concepts
 description: |
 
+  This schema also incorporates the schemas
+
+  - [`identifiers`](https://concepts.datalad.org/s/identifiers/unreleased)
+  - [`things`](https://concepts.datalad.org/s/things/v1)
+  - [`roles`](https://concepts.datalad.org/s/roles/unreleased)
+
   The schema definition is available as
 
   - [JSON-LD context](../unreleased.jsonld)

--- a/src/things/v1.yaml
+++ b/src/things/v1.yaml
@@ -35,6 +35,10 @@ description: |
   it and built targeted derivatives of `Thing` and other classes provided here.
   See the [PROV schema](/s/prov) for an example that is built on this schema.
 
+  This schema also incorporates the schema(s)
+
+  - [`types`](https://concepts.datalad.org/s/types/unreleased)
+
   The schema definition is available as
 
   - [JSON-LD context](../v1.jsonld)

--- a/src/types/unreleased.yaml
+++ b/src/types/unreleased.yaml
@@ -2,7 +2,7 @@ id: https://concepts.datalad.org/s/types/unreleased
 name: types-schema
 version: UNRELEASED
 status: eunal:concept-status/DRAFT
-title: Collection of common types for use in schemas
+title: Collection of common types
 description: |
   This schema provides a collection of common types for use in other
   schemas. It can be imported directly into other linkml schemas, or
@@ -12,6 +12,10 @@ description: |
 
   Class definitions are only included insofar as they define ranges
   for particular property slots.
+
+  This schema also incorporates the schema(s)
+
+  - [`types`](https://concepts.datalad.org/s/types/unreleased)
 
   The schema definition is available as
 


### PR DESCRIPTION
This makes it more accessible what is a unique new component vs. what is being reused.

This could also be done automatically with a better template. Manual for now.