### PR TITLE
Align `qualified_relations` with `relations`

### DIFF
--- a/src/distribution/unreleased.yaml
+++ b/src/distribution/unreleased.yaml
@@ -484,8 +484,6 @@ classes:
       name:
         description: >-
           The name of the part within the containing entity.
-      object:
-        range: Entity
     comments:
       - This class is a key element of the data model. It enables referencing
         a particular resource (e.g., a file's content, or versioned directory

--- a/src/distribution/unreleased/examples/Distribution-datatypes.json
+++ b/src/distribution/unreleased/examples/Distribution-datatypes.json
@@ -7,13 +7,13 @@
     }
   ],
   "type": "dldist:Distribution",
-  "qualified_relations": [
-    {
+  "qualified_relations": {
+    "obo:NCIT_C95650": {
       "object": "obo:NCIT_C95650",
       "had_roles": [
         "obo:NCIT_C42645"
       ]
     }
-  ],
+  },
   "@type": "Distribution"
 }

--- a/src/distribution/unreleased/examples/Distribution-datatypes.json
+++ b/src/distribution/unreleased/examples/Distribution-datatypes.json
@@ -10,7 +10,7 @@
   "qualified_relations": {
     "obo:NCIT_C95650": {
       "object": "obo:NCIT_C95650",
-      "had_roles": [
+      "roles": [
         "obo:NCIT_C42645"
       ]
     }

--- a/src/distribution/unreleased/examples/Distribution-datatypes.yaml
+++ b/src/distribution/unreleased/examples/Distribution-datatypes.yaml
@@ -3,7 +3,7 @@ id: exthisdsver:./file.jpeg
 # first using the common qualified-relation pattern.
 qualified_relations:
   # encapsulated image data
-  - object: obo:NCIT_C95650
+  obo:NCIT_C95650:
     had_roles:
       # data type
       - obo:NCIT_C42645

--- a/src/distribution/unreleased/examples/Distribution-datatypes.yaml
+++ b/src/distribution/unreleased/examples/Distribution-datatypes.yaml
@@ -4,7 +4,7 @@ id: exthisdsver:./file.jpeg
 qualified_relations:
   # encapsulated image data
   obo:NCIT_C95650:
-    had_roles:
+    roles:
       # data type
       - obo:NCIT_C42645
 # when standardized terms for identifying data types are not available,

--- a/src/distribution/unreleased/examples/Resource-gitcommit.json
+++ b/src/distribution/unreleased/examples/Resource-gitcommit.json
@@ -11,7 +11,7 @@
       "qualified_relations": {
         "exthisds:#gituser_doe@example.com": {
           "object": "exthisds:#gituser_doe@example.com",
-          "had_roles": [
+          "roles": [
             "marcrel:aut"
           ]
         }
@@ -27,7 +27,7 @@
       "qualified_relations": {
         "exthisds:#gituser_doe@example.com": {
           "object": "exthisds:#gituser_doe@example.com",
-          "had_roles": [
+          "roles": [
             "marcrel:cre"
           ]
         }
@@ -72,7 +72,7 @@
   "qualified_relations": {
     "gitsha:a52963ce19a3e3628e9976555ffc8c422b29f054": {
       "object": "gitsha:a52963ce19a3e3628e9976555ffc8c422b29f054",
-      "had_roles": [
+      "roles": [
         "owl:priorVersion"
       ]
     }

--- a/src/distribution/unreleased/examples/Resource-gitcommit.json
+++ b/src/distribution/unreleased/examples/Resource-gitcommit.json
@@ -8,14 +8,14 @@
       ],
       "type": "dlprov:Activity",
       "ended_at": "2001-02-28T18:27:04+02:00",
-      "qualified_relations": [
-        {
+      "qualified_relations": {
+        "exthisds:#gituser_doe@example.com": {
           "object": "exthisds:#gituser_doe@example.com",
           "had_roles": [
             "marcrel:aut"
           ]
         }
-      ]
+      }
     },
     "gitsha:8d6f033bb2a6109b2c4d64d6f27b0feb181e4d0f#committing": {
       "id": "gitsha:8d6f033bb2a6109b2c4d64d6f27b0feb181e4d0f#committing",
@@ -24,14 +24,14 @@
       ],
       "type": "dlprov:Activity",
       "ended_at": "2002-05-30T09:30:10+06:00",
-      "qualified_relations": [
-        {
+      "qualified_relations": {
+        "exthisds:#gituser_doe@example.com": {
           "object": "exthisds:#gituser_doe@example.com",
           "had_roles": [
             "marcrel:cre"
           ]
         }
-      ],
+      },
       "informed_by": [
         "gitsha:8d6f033bb2a6109b2c4d64d6f27b0feb181e4d0f#authoring"
       ]
@@ -69,14 +69,14 @@
     }
   ],
   "type": "dldist:Resource",
-  "qualified_relations": [
-    {
+  "qualified_relations": {
+    "gitsha:a52963ce19a3e3628e9976555ffc8c422b29f054": {
       "object": "gitsha:a52963ce19a3e3628e9976555ffc8c422b29f054",
       "had_roles": [
         "owl:priorVersion"
       ]
     }
-  ],
+  },
   "derived_from": [
     "gitsha:a52963ce19a3e3628e9976555ffc8c422b29f054"
   ],

--- a/src/distribution/unreleased/examples/Resource-gitcommit.yaml
+++ b/src/distribution/unreleased/examples/Resource-gitcommit.yaml
@@ -29,7 +29,7 @@ derived_from:
 qualified_relations:
   # parent commit(s)
   gitsha:a52963ce19a3e3628e9976555ffc8c422b29f054:
-    had_roles:
+    roles:
       - owl:priorVersion
 relations:
   # author activity
@@ -45,7 +45,7 @@ relations:
     qualified_relations:
       # author of the commit
       exthisds:#gituser_doe@example.com:
-        had_roles:
+        roles:
           - marcrel:aut
   # commit activity
   gitsha:8d6f033bb2a6109b2c4d64d6f27b0feb181e4d0f#committing:
@@ -58,7 +58,7 @@ relations:
     qualified_relations:
       # creator of the commit
       exthisds:#gituser_doe@example.com:
-        had_roles:
+        roles:
           - marcrel:cre
     informed_by:
       - gitsha:8d6f033bb2a6109b2c4d64d6f27b0feb181e4d0f#authoring

--- a/src/distribution/unreleased/examples/Resource-gitcommit.yaml
+++ b/src/distribution/unreleased/examples/Resource-gitcommit.yaml
@@ -28,7 +28,7 @@ derived_from:
   - gitsha:a52963ce19a3e3628e9976555ffc8c422b29f054
 qualified_relations:
   # parent commit(s)
-  - object: gitsha:a52963ce19a3e3628e9976555ffc8c422b29f054
+  gitsha:a52963ce19a3e3628e9976555ffc8c422b29f054:
     had_roles:
       - owl:priorVersion
 relations:
@@ -44,7 +44,7 @@ relations:
     ended_at: "2001-02-28T18:27:04+02:00"
     qualified_relations:
       # author of the commit
-      - object: exthisds:#gituser_doe@example.com
+      exthisds:#gituser_doe@example.com:
         had_roles:
           - marcrel:aut
   # commit activity
@@ -57,7 +57,7 @@ relations:
     ended_at: "2002-05-30T09:30:10+06:00"
     qualified_relations:
       # creator of the commit
-      - object: exthisds:#gituser_doe@example.com
+      exthisds:#gituser_doe@example.com:
         had_roles:
           - marcrel:cre
     informed_by:

--- a/src/distribution/unreleased/examples/Resource-study.json
+++ b/src/distribution/unreleased/examples/Resource-study.json
@@ -85,14 +85,14 @@
       "qualified_relations": {
         "exthisds:#s001": {
           "object": "exthisds:#s001",
-          "had_roles": [
+          "roles": [
             "obo:NCIT_C142710",
             "obo:NCIT_C94342"
           ]
         },
         "exthisds:#s002": {
           "object": "exthisds:#s002",
-          "had_roles": [
+          "roles": [
             "obo:NCIT_C142710",
             "obo:NCIT_C173188"
           ]

--- a/src/distribution/unreleased/examples/Resource-study.json
+++ b/src/distribution/unreleased/examples/Resource-study.json
@@ -82,22 +82,22 @@
         }
       ],
       "type": "dlprov:Activity",
-      "qualified_relations": [
-        {
+      "qualified_relations": {
+        "exthisds:#s001": {
           "object": "exthisds:#s001",
           "had_roles": [
             "obo:NCIT_C142710",
             "obo:NCIT_C94342"
           ]
         },
-        {
+        "exthisds:#s002": {
           "object": "exthisds:#s002",
           "had_roles": [
             "obo:NCIT_C142710",
             "obo:NCIT_C173188"
           ]
         }
-      ]
+      }
     }
   },
   "type": "dldist:Resource",

--- a/src/distribution/unreleased/examples/Resource-study.yaml
+++ b/src/distribution/unreleased/examples/Resource-study.yaml
@@ -48,13 +48,13 @@ relations:
     exact_mappings:
       - obo:NCIT_C71104
     qualified_relations:
-      - object: exthisds:#s001
+      exthisds:#s001:
         had_roles:
           # study participant
           - obo:NCIT_C142710
           # healthy control
           - obo:NCIT_C94342
-      - object: exthisds:#s002
+      exthisds:#s002:
         had_roles:
           - obo:NCIT_C142710
           # subject Assigned to Protocol Treatment Arm

--- a/src/distribution/unreleased/examples/Resource-study.yaml
+++ b/src/distribution/unreleased/examples/Resource-study.yaml
@@ -49,13 +49,13 @@ relations:
       - obo:NCIT_C71104
     qualified_relations:
       exthisds:#s001:
-        had_roles:
+        roles:
           # study participant
           - obo:NCIT_C142710
           # healthy control
           - obo:NCIT_C94342
       exthisds:#s002:
-        had_roles:
+        roles:
           - obo:NCIT_C142710
           # subject Assigned to Protocol Treatment Arm
           - obo:NCIT_C173188

--- a/src/prov/unreleased/examples/Agent-03-relations.json
+++ b/src/prov/unreleased/examples/Agent-03-relations.json
@@ -1,13 +1,13 @@
 {
   "id": "https://example.com/ns/people/jane",
   "type": "dlprov:Agent",
-  "qualified_relations": [
-    {
+  "qualified_relations": {
+    "geo:-19.738897,63.453072?z=19": {
       "object": "geo:-19.738897,63.453072?z=19",
       "had_roles": [
         "obo:NCIT_C17556"
       ]
     }
-  ],
+  },
   "@type": "Agent"
 }

--- a/src/prov/unreleased/examples/Agent-03-relations.json
+++ b/src/prov/unreleased/examples/Agent-03-relations.json
@@ -4,7 +4,7 @@
   "qualified_relations": {
     "geo:-19.738897,63.453072?z=19": {
       "object": "geo:-19.738897,63.453072?z=19",
-      "had_roles": [
+      "roles": [
         "obo:NCIT_C17556"
       ]
     }

--- a/src/prov/unreleased/examples/Agent-03-relations.yaml
+++ b/src/prov/unreleased/examples/Agent-03-relations.yaml
@@ -4,6 +4,6 @@ id: https://example.com/ns/people/jane
 qualified_relations:
   # using a GEO URI as a location identifier
   geo:-19.738897,63.453072?z=19:
-    had_roles:
+    roles:
       # worksite
       - obo:NCIT_C17556

--- a/src/prov/unreleased/examples/Agent-03-relations.yaml
+++ b/src/prov/unreleased/examples/Agent-03-relations.yaml
@@ -3,7 +3,7 @@
 id: https://example.com/ns/people/jane
 qualified_relations:
   # using a GEO URI as a location identifier
-  - object: "geo:-19.738897,63.453072?z=19"
+  geo:-19.738897,63.453072?z=19:
     had_roles:
       # worksite
       - obo:NCIT_C17556

--- a/src/publications/unreleased/examples/Publication-02-linkage.json
+++ b/src/publications/unreleased/examples/Publication-02-linkage.json
@@ -9,66 +9,66 @@
       "schema_agency": "DOI Foundation"
     }
   ],
-  "qualified_relations": [
-    {
+  "qualified_relations": {
+    "https://portal.issn.org/resource/issn/2052-4463": {
       "object": "https://portal.issn.org/resource/issn/2052-4463",
       "had_roles": [
         "marcrel:pup"
       ]
     },
-    {
-      "object": "http://orcid.org/0000-0003-2917-3450",
+    "https://orcid.org/0000-0003-2917-3450": {
+      "object": "https://orcid.org/0000-0003-2917-3450",
       "had_roles": [
         "marcrel:aut",
         "obo:NCIT_C25461",
         "obo:MS_1002034"
       ]
     },
-    {
-      "object": "http://orcid.org/0000-0003-2213-7465",
+    "https://orcid.org/0000-0003-2213-7465": {
+      "object": "https://orcid.org/0000-0003-2213-7465",
       "had_roles": [
         "marcrel:aut",
         "obo:MS_1002034"
       ]
     },
-    {
-      "object": "http://orcid.org/0000-0003-0820-2662",
+    "https://orcid.org/0000-0003-0820-2662": {
+      "object": "https://orcid.org/0000-0003-0820-2662",
       "had_roles": [
         "marcrel:aut",
         "obo:MS_1002034"
       ]
     },
-    {
-      "object": "http://orcid.org/0000-0001-7163-3110",
+    "https://orcid.org/0000-0001-7163-3110": {
+      "object": "https://orcid.org/0000-0001-7163-3110",
       "had_roles": [
         "marcrel:aut"
       ]
     },
-    {
-      "object": "http://orcid.org/0000-0002-8402-6173",
+    "https://orcid.org/0000-0002-8402-6173": {
+      "object": "https://orcid.org/0000-0002-8402-6173",
       "had_roles": [
         "marcrel:aut"
       ]
     },
-    {
-      "object": "http://orcid.org/0000-0001-7628-0801",
+    "https://orcid.org/0000-0001-7628-0801": {
+      "object": "https://orcid.org/0000-0001-7628-0801",
       "had_roles": [
         "marcrel:aut"
       ]
     },
-    {
+    "https://orcid.org/0000-0001-6363-2759": {
       "object": "https://orcid.org/0000-0001-6363-2759",
       "had_roles": [
         "marcrel:aut"
       ]
     },
-    {
-      "object": "http://orcid.org/0000-0001-6398-6370",
+    "https://orcid.org/0000-0001-6398-6370": {
+      "object": "https://orcid.org/0000-0001-6398-6370",
       "had_roles": [
         "marcrel:aut",
         "obo:MS_1002035"
       ]
     }
-  ],
+  },
   "@type": "Publication"
 }

--- a/src/publications/unreleased/examples/Publication-02-linkage.json
+++ b/src/publications/unreleased/examples/Publication-02-linkage.json
@@ -12,13 +12,13 @@
   "qualified_relations": {
     "https://portal.issn.org/resource/issn/2052-4463": {
       "object": "https://portal.issn.org/resource/issn/2052-4463",
-      "had_roles": [
+      "roles": [
         "marcrel:pup"
       ]
     },
     "https://orcid.org/0000-0003-2917-3450": {
       "object": "https://orcid.org/0000-0003-2917-3450",
-      "had_roles": [
+      "roles": [
         "marcrel:aut",
         "obo:NCIT_C25461",
         "obo:MS_1002034"
@@ -26,45 +26,45 @@
     },
     "https://orcid.org/0000-0003-2213-7465": {
       "object": "https://orcid.org/0000-0003-2213-7465",
-      "had_roles": [
+      "roles": [
         "marcrel:aut",
         "obo:MS_1002034"
       ]
     },
     "https://orcid.org/0000-0003-0820-2662": {
       "object": "https://orcid.org/0000-0003-0820-2662",
-      "had_roles": [
+      "roles": [
         "marcrel:aut",
         "obo:MS_1002034"
       ]
     },
     "https://orcid.org/0000-0001-7163-3110": {
       "object": "https://orcid.org/0000-0001-7163-3110",
-      "had_roles": [
+      "roles": [
         "marcrel:aut"
       ]
     },
     "https://orcid.org/0000-0002-8402-6173": {
       "object": "https://orcid.org/0000-0002-8402-6173",
-      "had_roles": [
+      "roles": [
         "marcrel:aut"
       ]
     },
     "https://orcid.org/0000-0001-7628-0801": {
       "object": "https://orcid.org/0000-0001-7628-0801",
-      "had_roles": [
+      "roles": [
         "marcrel:aut"
       ]
     },
     "https://orcid.org/0000-0001-6363-2759": {
       "object": "https://orcid.org/0000-0001-6363-2759",
-      "had_roles": [
+      "roles": [
         "marcrel:aut"
       ]
     },
     "https://orcid.org/0000-0001-6398-6370": {
       "object": "https://orcid.org/0000-0001-6398-6370",
-      "had_roles": [
+      "roles": [
         "marcrel:aut",
         "obo:MS_1002035"
       ]

--- a/src/publications/unreleased/examples/Publication-02-linkage.yaml
+++ b/src/publications/unreleased/examples/Publication-02-linkage.yaml
@@ -5,13 +5,13 @@ identifiers:
 qualified_relations:
   # entiry roles
   # scientific data
-  - object: https://portal.issn.org/resource/issn/2052-4463
+  https://portal.issn.org/resource/issn/2052-4463:
     had_roles:
       # publication venue
       - marcrel:pup
   # agent roles
   # adina
-  - object: http://orcid.org/0000-0003-2917-3450
+  https://orcid.org/0000-0003-2917-3450:
     had_roles:
       # author
       - marcrel:aut
@@ -20,33 +20,33 @@ qualified_relations:
       # first author
       - obo:MS_1002034
   # laura
-  - object: http://orcid.org/0000-0003-2213-7465
+  https://orcid.org/0000-0003-2213-7465:
     had_roles:
       - marcrel:aut
       - obo:MS_1002034
   # małgorzata
-  - object: http://orcid.org/0000-0003-0820-2662
+  https://orcid.org/0000-0003-0820-2662:
     had_roles:
       - marcrel:aut
       - obo:MS_1002034
   # felix
-  - object: http://orcid.org/0000-0001-7163-3110
+  https://orcid.org/0000-0001-7163-3110:
     had_roles:
       - marcrel:aut
   # alex
-  - object: http://orcid.org/0000-0002-8402-6173
+  https://orcid.org/0000-0002-8402-6173:
     had_roles:
       - marcrel:aut
   # benjamin
-  - object: http://orcid.org/0000-0001-7628-0801
+  https://orcid.org/0000-0001-7628-0801:
     had_roles:
       - marcrel:aut
   # simon
-  - object: https://orcid.org/0000-0001-6363-2759
+  https://orcid.org/0000-0001-6363-2759:
     had_roles:
       - marcrel:aut
   # michael
-  - object: http://orcid.org/0000-0001-6398-6370
+  https://orcid.org/0000-0001-6398-6370:
     had_roles:
       - marcrel:aut
       # senior author

--- a/src/publications/unreleased/examples/Publication-02-linkage.yaml
+++ b/src/publications/unreleased/examples/Publication-02-linkage.yaml
@@ -6,13 +6,13 @@ qualified_relations:
   # entiry roles
   # scientific data
   https://portal.issn.org/resource/issn/2052-4463:
-    had_roles:
+    roles:
       # publication venue
       - marcrel:pup
   # agent roles
   # adina
   https://orcid.org/0000-0003-2917-3450:
-    had_roles:
+    roles:
       # author
       - marcrel:aut
       # contact person
@@ -21,33 +21,33 @@ qualified_relations:
       - obo:MS_1002034
   # laura
   https://orcid.org/0000-0003-2213-7465:
-    had_roles:
+    roles:
       - marcrel:aut
       - obo:MS_1002034
   # małgorzata
   https://orcid.org/0000-0003-0820-2662:
-    had_roles:
+    roles:
       - marcrel:aut
       - obo:MS_1002034
   # felix
   https://orcid.org/0000-0001-7163-3110:
-    had_roles:
+    roles:
       - marcrel:aut
   # alex
   https://orcid.org/0000-0002-8402-6173:
-    had_roles:
+    roles:
       - marcrel:aut
   # benjamin
   https://orcid.org/0000-0001-7628-0801:
-    had_roles:
+    roles:
       - marcrel:aut
   # simon
   https://orcid.org/0000-0001-6363-2759:
-    had_roles:
+    roles:
       - marcrel:aut
   # michael
   https://orcid.org/0000-0001-6398-6370:
-    had_roles:
+    roles:
       - marcrel:aut
       # senior author
       - obo:MS_1002035

--- a/src/roles/unreleased.yaml
+++ b/src/roles/unreleased.yaml
@@ -67,16 +67,14 @@ slots:
   had_roles:
     slot_uri: dlroles:had_roles
     description: >-
-      The function of an entity or agent with respect to the subject.
+      Describes the function of an entity or agent (object) within the scope of
+      a `Relationship` with the subject.
     range: Role
     multivalued: true
     inlined: false
     exact_mappings:
       - prov:hadRole
       - dcat:had_role
-    comments:
-      - May be used in a qualified-attribution to specify the role of an Agent with respect to an Entity.
-      - May be used in a qualified-relation to specify the role of an Entity with respect to another Entity.
 
   qualified_relations:
     slot_uri: dlroles:qualified_relations
@@ -85,7 +83,6 @@ slots:
     domain: Thing
     range: Relationship
     inlined: true
-    inlined_as_list: true
     multivalued: true
     exact_mappings:
       - dcat:qualifiedRelation
@@ -118,6 +115,8 @@ classes:
         required: true
       object:
         required: true
+        key: true
+        range: uriorcurie
     close_mappings:
       - prov:Influence
       - dcat:Relationship

--- a/src/roles/unreleased.yaml
+++ b/src/roles/unreleased.yaml
@@ -12,7 +12,7 @@ description: |
 
   Each `Relationship` links one object (`Thing`) to a subject (`Thing`) and
   associates one or more roles ([`Role`](Role)) with this relationship via the
-  [`had_roles`](had_roles) slot.
+  [`roles`](roles) slot.
 
   A `Role` is itself a `Thing`, and can be annotated with (inline)
   attributes as needed. However, typically it should be sufficient
@@ -64,8 +64,8 @@ imports:
 
 
 slots:
-  had_roles:
-    slot_uri: dlroles:had_roles
+  roles:
+    slot_uri: dlroles:roles
     description: >-
       Describes the function of an entity or agent (object) within the scope of
       a `Relationship` with the subject.
@@ -109,9 +109,9 @@ classes:
       and also being the person who is legally responsible contact for it).
     slots:
       - object
-      - had_roles
+      - roles
     slot_usage:
-      had_roles:
+      roles:
         required: true
       object:
         required: true

--- a/src/roles/unreleased/examples/Relationship-01-topic.json
+++ b/src/roles/unreleased/examples/Relationship-01-topic.json
@@ -1,6 +1,6 @@
 {
   "object": "https://en.wikipedia.org/wiki/Vulcan_(Star_Trek)#Mind_melds",
-  "had_roles": [
+  "roles": [
     "http://purl.obolibrary.org/obo/topic_0003"
   ],
   "@type": "Relationship"

--- a/src/roles/unreleased/examples/Relationship-01-topic.yaml
+++ b/src/roles/unreleased/examples/Relationship-01-topic.yaml
@@ -1,4 +1,4 @@
 # Declare something as the topic of the subject
 object: https://en.wikipedia.org/wiki/Vulcan_(Star_Trek)#Mind_melds
-had_roles:
+roles:
   - http://purl.obolibrary.org/obo/topic_0003

--- a/src/roles/unreleased/examples/Relationship-02-author.json
+++ b/src/roles/unreleased/examples/Relationship-02-author.json
@@ -1,6 +1,6 @@
 {
   "object": "https://orcid.org/0000-0001-6398-6370",
-  "had_roles": [
+  "roles": [
     "marcrel:aut",
     "marcrel:sad"
   ],

--- a/src/roles/unreleased/examples/Relationship-02-author.yaml
+++ b/src/roles/unreleased/examples/Relationship-02-author.yaml
@@ -2,6 +2,6 @@
 # roles of an author and of a scientific advisor regarding
 # the subject
 object: https://orcid.org/0000-0001-6398-6370
-had_roles:
+roles:
   - marcrel:aut
   - marcrel:sad

--- a/src/social/unreleased/examples/Organization-03-relations.json
+++ b/src/social/unreleased/examples/Organization-03-relations.json
@@ -1,13 +1,13 @@
 {
   "id": "https://trr379.de",
   "type": "dlsocial:Organization",
-  "qualified_relations": [
-    {
+  "qualified_relations": {
+    "https://ror.org/018mejw64": {
       "object": "https://ror.org/018mejw64",
       "had_roles": [
         "marcrel:fnd"
       ]
     }
-  ],
+  },
   "@type": "Organization"
 }

--- a/src/social/unreleased/examples/Organization-03-relations.json
+++ b/src/social/unreleased/examples/Organization-03-relations.json
@@ -4,7 +4,7 @@
   "qualified_relations": {
     "https://ror.org/018mejw64": {
       "object": "https://ror.org/018mejw64",
-      "had_roles": [
+      "roles": [
         "marcrel:fnd"
       ]
     }

--- a/src/social/unreleased/examples/Organization-03-relations.yaml
+++ b/src/social/unreleased/examples/Organization-03-relations.yaml
@@ -1,6 +1,6 @@
 id: https://trr379.de
 qualified_relations:
   # DFG is a funder
-  - object: https://ror.org/018mejw64
+  https://ror.org/018mejw64:
     had_roles:
       - marcrel:fnd

--- a/src/social/unreleased/examples/Organization-03-relations.yaml
+++ b/src/social/unreleased/examples/Organization-03-relations.yaml
@@ -2,5 +2,5 @@ id: https://trr379.de
 qualified_relations:
   # DFG is a funder
   https://ror.org/018mejw64:
-    had_roles:
+    roles:
       - marcrel:fnd

--- a/src/social/unreleased/examples/Person-03-relations.json
+++ b/src/social/unreleased/examples/Person-03-relations.json
@@ -1,19 +1,19 @@
 {
   "id": "https://example.com/ns/people/jane",
   "type": "dlsocial:Person",
-  "qualified_relations": [
-    {
+  "qualified_relations": {
+    "email:jane@example.com": {
       "object": "email:jane@example.com",
       "had_roles": [
         "http://schema.org/email"
       ]
     },
-    {
+    "geo:-19.738897,63.453072?z=19": {
       "object": "geo:-19.738897,63.453072?z=19",
       "had_roles": [
         "obo:NCIT_C17556"
       ]
     }
-  ],
+  },
   "@type": "Person"
 }

--- a/src/social/unreleased/examples/Person-03-relations.json
+++ b/src/social/unreleased/examples/Person-03-relations.json
@@ -4,13 +4,13 @@
   "qualified_relations": {
     "email:jane@example.com": {
       "object": "email:jane@example.com",
-      "had_roles": [
+      "roles": [
         "http://schema.org/email"
       ]
     },
     "geo:-19.738897,63.453072?z=19": {
       "object": "geo:-19.738897,63.453072?z=19",
-      "had_roles": [
+      "roles": [
         "obo:NCIT_C17556"
       ]
     }

--- a/src/social/unreleased/examples/Person-03-relations.yaml
+++ b/src/social/unreleased/examples/Person-03-relations.yaml
@@ -5,10 +5,10 @@
 id: https://example.com/ns/people/jane
 qualified_relations:
   email:jane@example.com:
-    had_roles:
+    roles:
       - http://schema.org/email
   # using a GEO URI as a location identifier
   geo:-19.738897,63.453072?z=19:
-    had_roles:
+    roles:
       # worksite
       - obo:NCIT_C17556

--- a/src/social/unreleased/examples/Person-03-relations.yaml
+++ b/src/social/unreleased/examples/Person-03-relations.yaml
@@ -4,11 +4,11 @@
 # use of GEO URIs as identifiers for locations
 id: https://example.com/ns/people/jane
 qualified_relations:
-  - object: email:jane@example.com
+  email:jane@example.com:
     had_roles:
       - http://schema.org/email
   # using a GEO URI as a location identifier
-  - object: "geo:-19.738897,63.453072?z=19"
+  geo:-19.738897,63.453072?z=19:
     had_roles:
       # worksite
       - obo:NCIT_C17556

--- a/src/social/unreleased/examples/Project-03-relations.json
+++ b/src/social/unreleased/examples/Project-03-relations.json
@@ -7,14 +7,14 @@
     }
   ],
   "type": "dlsocial:Project",
-  "qualified_relations": [
-    {
+  "qualified_relations": {
+    "http://orcid.org/0000-0001-6398-6370": {
       "object": "http://orcid.org/0000-0001-6398-6370",
       "had_roles": [
         "marcrel:ctb"
       ]
     }
-  ],
+  },
   "associated_with": [
     "http://orcid.org/0000-0001-6398-6370"
   ],

--- a/src/social/unreleased/examples/Project-03-relations.json
+++ b/src/social/unreleased/examples/Project-03-relations.json
@@ -10,7 +10,7 @@
   "qualified_relations": {
     "http://orcid.org/0000-0001-6398-6370": {
       "object": "http://orcid.org/0000-0001-6398-6370",
-      "had_roles": [
+      "roles": [
         "marcrel:ctb"
       ]
     }

--- a/src/social/unreleased/examples/Project-03-relations.yaml
+++ b/src/social/unreleased/examples/Project-03-relations.yaml
@@ -8,6 +8,6 @@ associated_with:
   - http://orcid.org/0000-0001-6398-6370
 qualified_relations:
   http://orcid.org/0000-0001-6398-6370:
-    had_roles:
+    roles:
       # contributor
       - marcrel:ctb

--- a/src/social/unreleased/examples/Project-03-relations.yaml
+++ b/src/social/unreleased/examples/Project-03-relations.yaml
@@ -7,7 +7,7 @@ characterized_by:
 associated_with:
   - http://orcid.org/0000-0001-6398-6370
 qualified_relations:
-  - object: http://orcid.org/0000-0001-6398-6370
+  http://orcid.org/0000-0001-6398-6370:
     had_roles:
       # contributor
       - marcrel:ctb

--- a/src/things/v1.yaml
+++ b/src/things/v1.yaml
@@ -203,7 +203,7 @@ slots:
     slot_uri: rdf:object
     description: >-
       Reference to a `Thing` within a `Statement`.
-    range: Thing
+    range: uriorcurie
     inlined: false
     multivalued: false
     relational_role: OBJECT


### PR DESCRIPTION
And use inlining (of `Relationship` instances) by key. The difference is that `Relationship` is not `Thing` and does not provide `id`. However, it has `object` which we can declare to be a key.

And this is what this change does.

This implies that there can only be a single instance of `Relationship` for any given `object` within a `qualified_relations` slot.

I think that is OK, and it enables fast, dict-key based access.