### PR TITLE
`dcterms:` -> `ex:` in all examples

### DIFF
--- a/src/distribution/unreleased/examples/DataService-annexremote.json
+++ b/src/distribution/unreleased/examples/DataService-annexremote.json
@@ -10,7 +10,7 @@
       "value": "box.com"
     },
     {
-      "predicate": "dcterms:identifier",
+      "predicate": "ex:identifier",
       "exact_mappings": [
         "ADMS:Identifier"
       ],

--- a/src/distribution/unreleased/examples/DataService-annexremote.yaml
+++ b/src/distribution/unreleased/examples/DataService-annexremote.yaml
@@ -7,7 +7,7 @@ exact_mappings:
 attributes:
   - predicate: foaf:name
     value: box.com
-  - predicate: dcterms:identifier
+  - predicate: ex:identifier
     exact_mappings:
       - ADMS:Identifier
     attributes:

--- a/src/distribution/unreleased/examples/Distribution-access.json
+++ b/src/distribution/unreleased/examples/Distribution-access.json
@@ -8,7 +8,7 @@
       ],
       "attributes": [
         {
-          "predicate": "dcterms:description",
+          "predicate": "ex:description",
           "type": "dlthings:AttributeSpecification",
           "value": "Central RDM service at example.org"
         }

--- a/src/distribution/unreleased/examples/Distribution-access.yaml
+++ b/src/distribution/unreleased/examples/Distribution-access.yaml
@@ -29,7 +29,7 @@ relations:
     contact_point: exthisns:coscine-admin
     # any general (human-readable) description of the dataservice
     attributes:
-      - predicate: dcterms:description
+      - predicate: ex:description
         value: "Central RDM service at example.org"
     # API description
     endpoint_description: https://coscine.rwth-aachen.de/coscine/api/swagger/v2/swagger.json

--- a/src/distribution/unreleased/examples/Distribution-formats.json
+++ b/src/distribution/unreleased/examples/Distribution-formats.json
@@ -2,7 +2,7 @@
   "id": "exthisdsver:.",
   "attributes": [
     {
-      "predicate": "dcterms:conformsTo",
+      "predicate": "ex:conformsTo",
       "type": "dlthings:AttributeSpecification",
       "range": "uri",
       "value": "https://bids-specification.readthedocs.io/en/v1.4.0"

--- a/src/distribution/unreleased/examples/Distribution-formats.yaml
+++ b/src/distribution/unreleased/examples/Distribution-formats.yaml
@@ -3,7 +3,7 @@ id: exthisdsver:.
 # identify a particular version of BIDS as the organization standard
 # used for the distribution
 attributes:
-  - predicate: dcterms:conformsTo
+  - predicate: ex:conformsTo
     value: https://bids-specification.readthedocs.io/en/v1.4.0
     range: uri
 has_part:

--- a/src/distribution/unreleased/examples/Distribution-parts.json
+++ b/src/distribution/unreleased/examples/Distribution-parts.json
@@ -6,7 +6,7 @@
       "id": "exthisdsver:./archive.zip/subdir",
       "attributes": [
         {
-          "predicate": "dcterms:description",
+          "predicate": "ex:description",
           "type": "dlthings:AttributeSpecification",
           "value": "A subdirectory"
         }
@@ -17,7 +17,7 @@
           "id": "exthisdsver:./archive.zip/subdir/file.txt",
           "attributes": [
             {
-              "predicate": "dcterms:description",
+              "predicate": "ex:description",
               "type": "dlthings:AttributeSpecification",
               "value": "A file"
             }

--- a/src/distribution/unreleased/examples/Distribution-parts.yaml
+++ b/src/distribution/unreleased/examples/Distribution-parts.yaml
@@ -10,12 +10,12 @@ has_part:
   # a part of a Distribution is also a Distribution
   - id: exthisdsver:./archive.zip/subdir
     attributes:
-      - predicate: dcterms:description
+      - predicate: ex:description
         value: "A subdirectory"
     has_part:
       - id: exthisdsver:./archive.zip/subdir/file.txt
         attributes:
-          - predicate: dcterms:description
+          - predicate: ex:description
             value: "A file"
     qualified_part:
       - name: file.txt

--- a/src/distribution/unreleased/examples/Distribution-resource.json
+++ b/src/distribution/unreleased/examples/Distribution-resource.json
@@ -5,7 +5,7 @@
       "id": "exthisdsver:#some/path",
       "attributes": [
         {
-          "predicate": "dcterms:description",
+          "predicate": "ex:description",
           "type": "dlthings:AttributeSpecification",
           "value": "Some tabular data"
         }
@@ -17,7 +17,7 @@
       "id": "exthisdsver:#",
       "attributes": [
         {
-          "predicate": "dcterms:description",
+          "predicate": "ex:description",
           "type": "dlthings:AttributeSpecification",
           "value": "A version of a collection of some data\""
         }
@@ -29,7 +29,7 @@
       "id": "exthisds:#",
       "attributes": [
         {
-          "predicate": "dcterms:description",
+          "predicate": "ex:description",
           "type": "dlthings:AttributeSpecification",
           "value": "A collection of some data"
         }

--- a/src/distribution/unreleased/examples/Distribution-resource.yaml
+++ b/src/distribution/unreleased/examples/Distribution-resource.yaml
@@ -13,17 +13,17 @@ relations:
   exthisdsver:#some/path:
     type: dldist:Resource
     attributes:
-      - predicate: dcterms:description
+      - predicate: ex:description
         value: "Some tabular data"
     is_part_of: exthisdsver:#
   exthisdsver:#:
     type: dldist:Resource
     attributes:
-      - predicate: dcterms:description
+      - predicate: ex:description
         value: A version of a collection of some data"
     is_version_of: exthisds:#
   exthisds:#:
     type: dldist:Resource
     attributes:
-      - predicate: dcterms:description
+      - predicate: ex:description
         value: "A collection of some data"

--- a/src/distribution/unreleased/examples/Resource-dataladdataset.json
+++ b/src/distribution/unreleased/examples/Resource-dataladdataset.json
@@ -2,7 +2,7 @@
   "id": "https://concepts.datalad.org/ns/dataset-uuid/cec1da92-0dbd-4df3-8602-7c72b2d12854",
   "attributes": [
     {
-      "predicate": "dcterms:identifier",
+      "predicate": "ex:identifier",
       "exact_mappings": [
         "ADMS:Identifier"
       ],

--- a/src/distribution/unreleased/examples/Resource-dataladdataset.yaml
+++ b/src/distribution/unreleased/examples/Resource-dataladdataset.yaml
@@ -2,7 +2,7 @@ id: https://concepts.datalad.org/ns/dataset-uuid/cec1da92-0dbd-4df3-8602-7c72b2d
 # we need a definition for a DataLad dataset
 #type: ...
 attributes:
-  - predicate: dcterms:identifier
+  - predicate: ex:identifier
     exact_mappings:
       - ADMS:Identifier
     attributes:

--- a/src/distribution/unreleased/examples/Resource-gitcommit.json
+++ b/src/distribution/unreleased/examples/Resource-gitcommit.json
@@ -39,7 +39,7 @@
   },
   "attributes": [
     {
-      "predicate": "dcterms:identifier",
+      "predicate": "ex:identifier",
       "attributes": [
         {
           "predicate": "ADMS:schemaAgency",
@@ -51,7 +51,7 @@
       "value": "final2"
     },
     {
-      "predicate": "dcterms:identifier",
+      "predicate": "ex:identifier",
       "attributes": [
         {
           "predicate": "ADMS:schemaAgency",
@@ -63,7 +63,7 @@
       "value": "latest"
     },
     {
-      "predicate": "dcterms:description",
+      "predicate": "ex:description",
       "type": "dlthings:AttributeSpecification",
       "value": "This message describes the changes done for this particular Dataset version.\n"
     }

--- a/src/distribution/unreleased/examples/Resource-gitcommit.yaml
+++ b/src/distribution/unreleased/examples/Resource-gitcommit.yaml
@@ -6,18 +6,18 @@ attributes:
   # they must be unique across all commits in the repo, hence we
   # use the context entity for the version-less dataset as the
   # agency/scope
-  - predicate: dcterms:identifier
+  - predicate: ex:identifier
     value: final2
     attributes:
       - predicate: ADMS:schemaAgency
         value: exthisds:#
-  - predicate: dcterms:identifier
+  - predicate: ex:identifier
     value: latest
     attributes:
       - predicate: ADMS:schemaAgency
         value: exthisds:#
   # commit message
-  - predicate: dcterms:description
+  - predicate: ex:description
     value: >
       This message describes the changes done for this particular
       Dataset version.

--- a/src/distribution/unreleased/examples/Resource-study.json
+++ b/src/distribution/unreleased/examples/Resource-study.json
@@ -60,7 +60,7 @@
       ],
       "attributes": [
         {
-          "predicate": "dcterms:title",
+          "predicate": "ex:title",
           "type": "dlthings:AttributeSpecification",
           "value": "Study about the effectiveness of a disease treatment"
         },

--- a/src/distribution/unreleased/examples/Resource-study.yaml
+++ b/src/distribution/unreleased/examples/Resource-study.yaml
@@ -36,7 +36,7 @@ relations:
   exthisds:#study_2005-004406-93:
     type: dlprov:Activity
     attributes:
-      - predicate: dcterms:title
+      - predicate: ex:title
         value: "Study about the effectiveness of a disease treatment"
       - predicate: ADMS:identifier
         attributes:

--- a/src/social/unreleased/examples/Project-03-relations.json
+++ b/src/social/unreleased/examples/Project-03-relations.json
@@ -3,7 +3,7 @@
   "characterized_by": [
     {
       "object": "ex:projects/grand-plan",
-      "predicate": "dcterms:isPartOf"
+      "predicate": "ex:isPartOf"
     }
   ],
   "type": "dlsocial:Project",

--- a/src/social/unreleased/examples/Project-03-relations.yaml
+++ b/src/social/unreleased/examples/Project-03-relations.yaml
@@ -3,7 +3,7 @@
 id: ex:projects/p1a
 characterized_by:
   - object: ex:projects/grand-plan
-    predicate: dcterms:isPartOf
+    predicate: ex:isPartOf
 associated_with:
   - http://orcid.org/0000-0001-6398-6370
 qualified_relations:

--- a/src/things/unreleased/examples/AttributeSpecification-01-minimal.json
+++ b/src/things/unreleased/examples/AttributeSpecification-01-minimal.json
@@ -1,5 +1,5 @@
 {
-  "predicate": "dcterms:title",
+  "predicate": "ex:title",
   "type": "dlthings:AttributeSpecification",
   "value": "My attribute",
   "@type": "AttributeSpecification"

--- a/src/things/unreleased/examples/AttributeSpecification-01-minimal.yaml
+++ b/src/things/unreleased/examples/AttributeSpecification-01-minimal.yaml
@@ -1,5 +1,5 @@
 # Technically, the only required aspect of an AttributeSpecification
 # is a predicate. That is because an attribute may not only have a
 # single value, but is a more complex collection of attribute facets.
-predicate: dcterms:title
+predicate: ex:title
 value: "My attribute"

--- a/src/things/unreleased/examples/AttributeSpecification-02-with-attributes.json
+++ b/src/things/unreleased/examples/AttributeSpecification-02-with-attributes.json
@@ -1,5 +1,5 @@
 {
-  "predicate": "dcterms:identifier",
+  "predicate": "ex:identifier",
   "exact_mappings": [
     "ADMS:Identifier"
   ],

--- a/src/things/unreleased/examples/AttributeSpecification-02-with-attributes.yaml
+++ b/src/things/unreleased/examples/AttributeSpecification-02-with-attributes.yaml
@@ -1,6 +1,6 @@
 # An attribute without a singular value, but attributes of it
 # own instead.
-predicate: dcterms:identifier
+predicate: ex:identifier
 exact_mappings:
   - ADMS:Identifier
 attributes:

--- a/src/things/unreleased/examples/Property-01-minimal.json
+++ b/src/things/unreleased/examples/Property-01-minimal.json
@@ -1,5 +1,5 @@
 {
-  "id": "dcterms:title",
+  "id": "ex:title",
   "type": "dlthings:Property",
   "@type": "Property"
 }

--- a/src/things/unreleased/examples/Property-01-minimal.yaml
+++ b/src/things/unreleased/examples/Property-01-minimal.yaml
@@ -1,4 +1,4 @@
 # A property is required to have an identifier, because it makes
 # little sense to work with property definitions that cannot be
 # referenced/resolved.
-id: dcterms:title
+id: ex:title

--- a/src/things/unreleased/examples/Property-02-as_a_thing.json
+++ b/src/things/unreleased/examples/Property-02-as_a_thing.json
@@ -1,13 +1,13 @@
 {
-  "id": "dcterms:modified",
+  "id": "ex:modified",
   "attributes": [
     {
-      "predicate": "dcterms:title",
+      "predicate": "ex:title",
       "type": "dlthings:AttributeSpecification",
       "value": "modified"
     },
     {
-      "predicate": "dcterms:description",
+      "predicate": "ex:description",
       "type": "dlthings:AttributeSpecification",
       "value": "Date on which the resource was changed."
     }

--- a/src/things/unreleased/examples/Property-02-as_a_thing.yaml
+++ b/src/things/unreleased/examples/Property-02-as_a_thing.yaml
@@ -3,9 +3,9 @@
 # better referenced from well-defined vocabularies. However,
 # for concrete technical applications, it can be useful to be
 # able to specify key attributes of properties inline.
-id: dcterms:modified
+id: ex:modified
 attributes:
-  - predicate: dcterms:title
+  - predicate: ex:title
     value: "modified"
-  - predicate: dcterms:description
+  - predicate: ex:description
     value: "Date on which the resource was changed."

--- a/src/things/unreleased/examples/Statement-01-minimal.json
+++ b/src/things/unreleased/examples/Statement-01-minimal.json
@@ -1,5 +1,5 @@
 {
   "object": "https://helmholtz.de",
-  "predicate": "dcterms:subject",
+  "predicate": "ex:subject",
   "@type": "Statement"
 }

--- a/src/things/unreleased/examples/Statement-01-minimal.yaml
+++ b/src/things/unreleased/examples/Statement-01-minimal.yaml
@@ -1,5 +1,5 @@
 # A statement contains the missing predicate and object to link to
 # a subject in order to form a full RDF triple. Both are required,
 # and both must be referenced (URI or CURIE) and not be inlined.
-predicate: dcterms:subject
+predicate: ex:subject
 object: https://helmholtz.de

--- a/src/things/unreleased/examples/Thing-02-identifiers.json
+++ b/src/things/unreleased/examples/Thing-02-identifiers.json
@@ -2,7 +2,7 @@
   "id": "https://ror.org/02nv7yv05",
   "attributes": [
     {
-      "predicate": "dcterms:identifier",
+      "predicate": "ex:identifier",
       "attributes": [
         {
           "predicate": "ADMS:schemaAgency",
@@ -15,7 +15,7 @@
       "value": "02nv7yv05"
     },
     {
-      "predicate": "dcterms:identifier",
+      "predicate": "ex:identifier",
       "exact_mappings": [
         "ADMS:Identifier"
       ],

--- a/src/things/unreleased/examples/Thing-02-identifiers.yaml
+++ b/src/things/unreleased/examples/Thing-02-identifiers.yaml
@@ -8,7 +8,7 @@
 id: https://ror.org/02nv7yv05
 attributes:
   # Research Organization Registry
-  - predicate: dcterms:identifier
+  - predicate: ex:identifier
     value: 02nv7yv05
     attributes:
       - predicate: ADMS:schemaAgency
@@ -17,7 +17,7 @@ attributes:
   # German National Library
   # (here not using the direct value specification, but defining
   #  a proper identifier with a `notation`)
-  - predicate: dcterms:identifier
+  - predicate: ex:identifier
     exact_mappings:
       - ADMS:Identifier
     attributes:

--- a/src/things/unreleased/examples/Thing-03-topic.json
+++ b/src/things/unreleased/examples/Thing-03-topic.json
@@ -3,7 +3,7 @@
   "characterized_by": [
     {
       "object": "https://www.scicrunch.org/resolver/SCR_003931",
-      "predicate": "dcterms:subject"
+      "predicate": "ex:subject"
     }
   ],
   "type": "dlthings:Thing",

--- a/src/things/unreleased/examples/Thing-03-topic.yaml
+++ b/src/things/unreleased/examples/Thing-03-topic.yaml
@@ -3,4 +3,4 @@ id: https://doi.org/10.21105/joss.03262
 characterized_by:
   # DataLad software
   - object: https://www.scicrunch.org/resolver/SCR_003931
-    predicate: dcterms:subject
+    predicate: ex:subject

--- a/src/things/unreleased/examples/Thing-04-relations.json
+++ b/src/things/unreleased/examples/Thing-04-relations.json
@@ -5,7 +5,7 @@
       "id": "https://portal.issn.org/resource/issn/2475-9066",
       "attributes": [
         {
-          "predicate": "dcterms:title",
+          "predicate": "ex:title",
           "type": "dlthings:AttributeSpecification",
           "value": "Journal of Open Source Software"
         }

--- a/src/things/unreleased/examples/Thing-04-relations.yaml
+++ b/src/things/unreleased/examples/Thing-04-relations.yaml
@@ -7,7 +7,7 @@ relations:
   https://portal.issn.org/resource/issn/2475-9066:
     # inlined information
     attributes:
-      - predicate: dcterms:title
+      - predicate: ex:title
         value: "Journal of Open Source Software"
   # the datalad software (no information beyond the `id` is inlined)
   https://www.scicrunch.org/resolver/SCR_003931:

--- a/src/things/unreleased/examples/Thing-05-publication.json
+++ b/src/things/unreleased/examples/Thing-05-publication.json
@@ -8,7 +8,7 @@
       ],
       "attributes": [
         {
-          "predicate": "dcterms:title",
+          "predicate": "ex:title",
           "type": "dlthings:AttributeSpecification",
           "value": "Scientific Data"
         }
@@ -21,17 +21,17 @@
   ],
   "attributes": [
     {
-      "predicate": "dcterms:title",
+      "predicate": "ex:title",
       "type": "dlthings:AttributeSpecification",
       "value": "FAIRly big: A framework for computationally reproducible processing of large-scale data"
     },
     {
-      "predicate": "dcterms:description",
+      "predicate": "ex:description",
       "type": "dlthings:AttributeSpecification",
       "value": "Large-scale datasets present unique opportunities to perform scientific investigations with unprecedented breadth. However, they also pose considerable challenges for the findability, accessibility, interoperability, and reusability (FAIR) of research outcomes due to infrastructure limitations, data usage constraints, or software license restrictions. Here we introduce a DataLad-based, domain-agnostic framework suitable for reproducible data processing in compliance with open science mandates. The framework attempts to minimize platform idiosyncrasies and performance-related complexities. It affords the capture of machine-actionable computational provenance records that can be used to retrace and verify the origins of research outcomes, as well as be re-executed independent of the original computing infrastructure. We demonstrate the framework’s performance using two showcases: one highlighting data sharing and transparency (using the studyforrest.org dataset) and another highlighting scalability (using the largest public brain imaging dataset available: the UK Biobank dataset)."
     },
     {
-      "predicate": "dcterms:identifier",
+      "predicate": "ex:identifier",
       "exact_mappings": [
         "ADMS:Identifier"
       ],
@@ -50,7 +50,7 @@
       "type": "dlthings:AttributeSpecification"
     },
     {
-      "predicate": "dcterms:bibliographicCitation",
+      "predicate": "ex:bibliographicCitation",
       "type": "dlthings:AttributeSpecification",
       "value": "Wagner, A.S., Waite, L.K., Wierzba, M. et al. FAIRly big: A framework for computationally reproducible processing of large-scale data. Sci Data 9, 80 (2022)."
     },
@@ -58,7 +58,7 @@
       "predicate": "bibo:doi",
       "attributes": [
         {
-          "predicate": "dcterms:title",
+          "predicate": "ex:title",
           "type": "dlthings:AttributeSpecification",
           "value": "DOI"
         }
@@ -70,7 +70,7 @@
       "predicate": "bibo:volume",
       "attributes": [
         {
-          "predicate": "dcterms:title",
+          "predicate": "ex:title",
           "type": "dlthings:AttributeSpecification",
           "value": "Volume"
         }
@@ -82,7 +82,7 @@
       "predicate": "bibo:number",
       "attributes": [
         {
-          "predicate": "dcterms:title",
+          "predicate": "ex:title",
           "type": "dlthings:AttributeSpecification",
           "value": "Document number"
         }
@@ -94,7 +94,7 @@
       "predicate": "bibo:numPages",
       "attributes": [
         {
-          "predicate": "dcterms:title",
+          "predicate": "ex:title",
           "type": "dlthings:AttributeSpecification",
           "value": "Number of pages"
         }
@@ -104,13 +104,13 @@
       "value": "17"
     },
     {
-      "predicate": "dcterms:modified",
+      "predicate": "ex:modified",
       "type": "dlthings:AttributeSpecification",
       "range": "xsd:date",
       "value": "2022-02-11"
     },
     {
-      "predicate": "dcterms:date",
+      "predicate": "ex:date",
       "type": "dlthings:AttributeSpecification",
       "range": "xsd:date",
       "value": "2022-03-11"
@@ -119,19 +119,19 @@
   "characterized_by": [
     {
       "object": "https://portal.issn.org/resource/issn/2052-4463",
-      "predicate": "dcterms:isPartOf"
+      "predicate": "ex:isPartOf"
     },
     {
       "object": "https://www.nature.com/subjects/data-processing",
-      "predicate": "dcterms:subject"
+      "predicate": "ex:subject"
     },
     {
       "object": "https://www.nature.com/subjects/data-publication-and-archiving",
-      "predicate": "dcterms:subject"
+      "predicate": "ex:subject"
     },
     {
       "object": "https://www.nature.com/subjects/software",
-      "predicate": "dcterms:subject"
+      "predicate": "ex:subject"
     },
     {
       "object": "https://www.nature.com/articles/s41597-022-01163-2",
@@ -139,7 +139,7 @@
     },
     {
       "object": "https://spdx.org/licenses/CC-BY-4.0",
-      "predicate": "dcterms:license"
+      "predicate": "ex:license"
     }
   ],
   "type": "dlthings:Thing",

--- a/src/things/unreleased/examples/Thing-05-publication.yaml
+++ b/src/things/unreleased/examples/Thing-05-publication.yaml
@@ -11,15 +11,15 @@ relations:
     exact_mappings:
       - bibo:Journal
     attributes:
-      - predicate: dcterms:title
+      - predicate: ex:title
         value: "Scientific Data"
 attributes:
-  - predicate: dcterms:title
+  - predicate: ex:title
     value: "FAIRly big: A framework for computationally reproducible processing of large-scale data"
-  - predicate: dcterms:description
+  - predicate: ex:description
     value: "Large-scale datasets present unique opportunities to perform scientific investigations with unprecedented breadth. However, they also pose considerable challenges for the findability, accessibility, interoperability, and reusability (FAIR) of research outcomes due to infrastructure limitations, data usage constraints, or software license restrictions. Here we introduce a DataLad-based, domain-agnostic framework suitable for reproducible data processing in compliance with open science mandates. The framework attempts to minimize platform idiosyncrasies and performance-related complexities. It affords the capture of machine-actionable computational provenance records that can be used to retrace and verify the origins of research outcomes, as well as be re-executed independent of the original computing infrastructure. We demonstrate the framework’s performance using two showcases: one highlighting data sharing and transparency (using the studyforrest.org dataset) and another highlighting scalability (using the largest public brain imaging dataset available: the UK Biobank dataset)."
   # DOI
-  - predicate: dcterms:identifier
+  - predicate: ex:identifier
     exact_mappings:
       - ADMS:Identifier
     attributes:
@@ -28,48 +28,48 @@ attributes:
       - predicate: ADMS:schemaAgency
         value: https://doi.org
   # bibliographic information
-  - predicate: dcterms:bibliographicCitation
+  - predicate: ex:bibliographicCitation
     value: "Wagner, A.S., Waite, L.K., Wierzba, M. et al. FAIRly big: A framework for computationally reproducible processing of large-scale data. Sci Data 9, 80 (2022)."
   - predicate: bibo:doi
     attributes:
-      - predicate: dcterms:title
+      - predicate: ex:title
         value: DOI
     value: https://doi.org/10.1038/s41597-022-01163-2
   - predicate: bibo:volume
     attributes:
-      - predicate: dcterms:title
+      - predicate: ex:title
         value: Volume
     value: "9"
   - predicate: bibo:number
     attributes:
-      - predicate: dcterms:title
+      - predicate: ex:title
         value: Document number
     value: "80"
   - predicate: bibo:numPages
     attributes:
-      - predicate: dcterms:title
+      - predicate: ex:title
         value: Number of pages
     value: "17"
     range: xsd:nonNegativeInteger
-  - predicate: dcterms:modified
+  - predicate: ex:modified
     range: xsd:date
     value: "2022-02-11"
-  - predicate: dcterms:date
+  - predicate: ex:date
     range: xsd:date
     value: "2022-03-11"
 characterized_by:
   # containing journal
-  - predicate: dcterms:isPartOf
+  - predicate: ex:isPartOf
     object: https://portal.issn.org/resource/issn/2052-4463
   # related topics
-  - predicate: dcterms:subject
+  - predicate: ex:subject
     object: https://www.nature.com/subjects/data-processing
-  - predicate: dcterms:subject
+  - predicate: ex:subject
     object: https://www.nature.com/subjects/data-publication-and-archiving
-  - predicate: dcterms:subject
+  - predicate: ex:subject
     object: https://www.nature.com/subjects/software
   # publisher landing page
   - predicate: owl:sameAs
     object: https://www.nature.com/articles/s41597-022-01163-2
-  - predicate: dcterms:license
+  - predicate: ex:license
     object: https://spdx.org/licenses/CC-BY-4.0

--- a/src/things/unreleased/examples/ValueSpecification-02-quantitative-measurement.json
+++ b/src/things/unreleased/examples/ValueSpecification-02-quantitative-measurement.json
@@ -2,7 +2,7 @@
   "id": "exthisns:measurement853",
   "attributes": [
     {
-      "predicate": "dcterms:title",
+      "predicate": "ex:title",
       "type": "dlthings:AttributeSpecification",
       "value": "measured mass (kg)"
     }
@@ -10,11 +10,11 @@
   "characterized_by": [
     {
       "object": "obo:IAO_0000109",
-      "predicate": "dcterms:subject"
+      "predicate": "ex:subject"
     },
     {
       "object": "obo:PATO_0000125",
-      "predicate": "dcterms:subject"
+      "predicate": "ex:subject"
     },
     {
       "object": "obo:UO_0000009",

--- a/src/things/unreleased/examples/ValueSpecification-02-quantitative-measurement.yaml
+++ b/src/things/unreleased/examples/ValueSpecification-02-quantitative-measurement.yaml
@@ -1,13 +1,13 @@
 id: exthisns:measurement853
 attributes:
-  - predicate: dcterms:title
+  - predicate: ex:title
     value: "measured mass (kg)"
 characterized_by:
   # measurement datum
-  - predicate: dcterms:subject
+  - predicate: ex:subject
     object: obo:IAO_0000109
   # mass
-  - predicate: dcterms:subject
+  - predicate: ex:subject
     object: obo:PATO_0000125
   # unit: kilogram
   - predicate: obo:UO_0000000

--- a/src/things/v1/examples/AttributeSpecification-01-minimal.json
+++ b/src/things/v1/examples/AttributeSpecification-01-minimal.json
@@ -1,5 +1,5 @@
 {
-  "predicate": "dcterms:title",
+  "predicate": "ex:title",
   "type": "dlthings:AttributeSpecification",
   "value": "My attribute",
   "@type": "AttributeSpecification"

--- a/src/things/v1/examples/AttributeSpecification-01-minimal.yaml
+++ b/src/things/v1/examples/AttributeSpecification-01-minimal.yaml
@@ -1,5 +1,5 @@
 # Technically, the only required aspect of an AttributeSpecification
 # is a predicate. That is because an attribute may not only have a
 # single value, but is a more complex collection of attribute facets.
-predicate: dcterms:title
+predicate: ex:title
 value: "My attribute"

--- a/src/things/v1/examples/AttributeSpecification-02-with-attributes.json
+++ b/src/things/v1/examples/AttributeSpecification-02-with-attributes.json
@@ -1,5 +1,5 @@
 {
-  "predicate": "dcterms:identifier",
+  "predicate": "ex:identifier",
   "exact_mappings": [
     "ADMS:Identifier"
   ],

--- a/src/things/v1/examples/AttributeSpecification-02-with-attributes.yaml
+++ b/src/things/v1/examples/AttributeSpecification-02-with-attributes.yaml
@@ -1,6 +1,6 @@
 # An attribute without a singular value, but attributes of it
 # own instead.
-predicate: dcterms:identifier
+predicate: ex:identifier
 exact_mappings:
   - ADMS:Identifier
 attributes:

--- a/src/things/v1/examples/Property-01-minimal.json
+++ b/src/things/v1/examples/Property-01-minimal.json
@@ -1,5 +1,5 @@
 {
-  "id": "dcterms:title",
+  "id": "ex:title",
   "type": "dlthings:Property",
   "@type": "Property"
 }

--- a/src/things/v1/examples/Property-01-minimal.yaml
+++ b/src/things/v1/examples/Property-01-minimal.yaml
@@ -1,4 +1,4 @@
 # A property is required to have an identifier, because it makes
 # little sense to work with property definitions that cannot be
 # referenced/resolved.
-id: dcterms:title
+id: ex:title

--- a/src/things/v1/examples/Property-02-as_a_thing.json
+++ b/src/things/v1/examples/Property-02-as_a_thing.json
@@ -1,13 +1,13 @@
 {
-  "id": "dcterms:modified",
+  "id": "ex:modified",
   "attributes": [
     {
-      "predicate": "dcterms:title",
+      "predicate": "ex:title",
       "type": "dlthings:AttributeSpecification",
       "value": "modified"
     },
     {
-      "predicate": "dcterms:description",
+      "predicate": "ex:description",
       "type": "dlthings:AttributeSpecification",
       "value": "Date on which the resource was changed."
     }

--- a/src/things/v1/examples/Property-02-as_a_thing.yaml
+++ b/src/things/v1/examples/Property-02-as_a_thing.yaml
@@ -3,9 +3,9 @@
 # better referenced from well-defined vocabularies. However,
 # for concrete technical applications, it can be useful to be
 # able to specify key attributes of properties inline.
-id: dcterms:modified
+id: ex:modified
 attributes:
-  - predicate: dcterms:title
+  - predicate: ex:title
     value: "modified"
-  - predicate: dcterms:description
+  - predicate: ex:description
     value: "Date on which the resource was changed."

--- a/src/things/v1/examples/Statement-01-minimal.json
+++ b/src/things/v1/examples/Statement-01-minimal.json
@@ -1,5 +1,5 @@
 {
   "object": "https://helmholtz.de",
-  "predicate": "dcterms:subject",
+  "predicate": "ex:subject",
   "@type": "Statement"
 }

--- a/src/things/v1/examples/Statement-01-minimal.yaml
+++ b/src/things/v1/examples/Statement-01-minimal.yaml
@@ -1,5 +1,5 @@
 # A statement contains the missing predicate and object to link to
 # a subject in order to form a full RDF triple. Both are required,
 # and both must be referenced (URI or CURIE) and not be inlined.
-predicate: dcterms:subject
+predicate: ex:subject
 object: https://helmholtz.de

--- a/src/things/v1/examples/Thing-02-identifiers.json
+++ b/src/things/v1/examples/Thing-02-identifiers.json
@@ -2,7 +2,7 @@
   "id": "https://ror.org/02nv7yv05",
   "attributes": [
     {
-      "predicate": "dcterms:identifier",
+      "predicate": "ex:identifier",
       "attributes": [
         {
           "predicate": "ADMS:schemaAgency",
@@ -15,7 +15,7 @@
       "value": "02nv7yv05"
     },
     {
-      "predicate": "dcterms:identifier",
+      "predicate": "ex:identifier",
       "exact_mappings": [
         "ADMS:Identifier"
       ],

--- a/src/things/v1/examples/Thing-02-identifiers.yaml
+++ b/src/things/v1/examples/Thing-02-identifiers.yaml
@@ -8,7 +8,7 @@
 id: https://ror.org/02nv7yv05
 attributes:
   # Research Organization Registry
-  - predicate: dcterms:identifier
+  - predicate: ex:identifier
     value: 02nv7yv05
     attributes:
       - predicate: ADMS:schemaAgency
@@ -17,7 +17,7 @@ attributes:
   # German National Library
   # (here not using the direct value specification, but defining
   #  a proper identifier with a `notation`)
-  - predicate: dcterms:identifier
+  - predicate: ex:identifier
     exact_mappings:
       - ADMS:Identifier
     attributes:

--- a/src/things/v1/examples/Thing-03-topic.json
+++ b/src/things/v1/examples/Thing-03-topic.json
@@ -3,7 +3,7 @@
   "characterized_by": [
     {
       "object": "https://www.scicrunch.org/resolver/SCR_003931",
-      "predicate": "dcterms:subject"
+      "predicate": "ex:subject"
     }
   ],
   "type": "dlthings:Thing",

--- a/src/things/v1/examples/Thing-03-topic.yaml
+++ b/src/things/v1/examples/Thing-03-topic.yaml
@@ -3,4 +3,4 @@ id: https://doi.org/10.21105/joss.03262
 characterized_by:
   # DataLad software
   - object: https://www.scicrunch.org/resolver/SCR_003931
-    predicate: dcterms:subject
+    predicate: ex:subject

--- a/src/things/v1/examples/Thing-04-relations.json
+++ b/src/things/v1/examples/Thing-04-relations.json
@@ -5,7 +5,7 @@
       "id": "https://portal.issn.org/resource/issn/2475-9066",
       "attributes": [
         {
-          "predicate": "dcterms:title",
+          "predicate": "ex:title",
           "type": "dlthings:AttributeSpecification",
           "value": "Journal of Open Source Software"
         }

--- a/src/things/v1/examples/Thing-04-relations.yaml
+++ b/src/things/v1/examples/Thing-04-relations.yaml
@@ -7,7 +7,7 @@ relations:
   https://portal.issn.org/resource/issn/2475-9066:
     # inlined information
     attributes:
-      - predicate: dcterms:title
+      - predicate: ex:title
         value: "Journal of Open Source Software"
   # the datalad software (no information beyond the `id` is inlined)
   https://www.scicrunch.org/resolver/SCR_003931:

--- a/src/things/v1/examples/Thing-05-publication.json
+++ b/src/things/v1/examples/Thing-05-publication.json
@@ -8,7 +8,7 @@
       ],
       "attributes": [
         {
-          "predicate": "dcterms:title",
+          "predicate": "ex:title",
           "type": "dlthings:AttributeSpecification",
           "value": "Scientific Data"
         }
@@ -21,17 +21,17 @@
   ],
   "attributes": [
     {
-      "predicate": "dcterms:title",
+      "predicate": "ex:title",
       "type": "dlthings:AttributeSpecification",
       "value": "FAIRly big: A framework for computationally reproducible processing of large-scale data"
     },
     {
-      "predicate": "dcterms:description",
+      "predicate": "ex:description",
       "type": "dlthings:AttributeSpecification",
       "value": "Large-scale datasets present unique opportunities to perform scientific investigations with unprecedented breadth. However, they also pose considerable challenges for the findability, accessibility, interoperability, and reusability (FAIR) of research outcomes due to infrastructure limitations, data usage constraints, or software license restrictions. Here we introduce a DataLad-based, domain-agnostic framework suitable for reproducible data processing in compliance with open science mandates. The framework attempts to minimize platform idiosyncrasies and performance-related complexities. It affords the capture of machine-actionable computational provenance records that can be used to retrace and verify the origins of research outcomes, as well as be re-executed independent of the original computing infrastructure. We demonstrate the framework’s performance using two showcases: one highlighting data sharing and transparency (using the studyforrest.org dataset) and another highlighting scalability (using the largest public brain imaging dataset available: the UK Biobank dataset)."
     },
     {
-      "predicate": "dcterms:identifier",
+      "predicate": "ex:identifier",
       "exact_mappings": [
         "ADMS:Identifier"
       ],
@@ -50,7 +50,7 @@
       "type": "dlthings:AttributeSpecification"
     },
     {
-      "predicate": "dcterms:bibliographicCitation",
+      "predicate": "ex:bibliographicCitation",
       "type": "dlthings:AttributeSpecification",
       "value": "Wagner, A.S., Waite, L.K., Wierzba, M. et al. FAIRly big: A framework for computationally reproducible processing of large-scale data. Sci Data 9, 80 (2022)."
     },
@@ -58,7 +58,7 @@
       "predicate": "bibo:doi",
       "attributes": [
         {
-          "predicate": "dcterms:title",
+          "predicate": "ex:title",
           "type": "dlthings:AttributeSpecification",
           "value": "DOI"
         }
@@ -70,7 +70,7 @@
       "predicate": "bibo:volume",
       "attributes": [
         {
-          "predicate": "dcterms:title",
+          "predicate": "ex:title",
           "type": "dlthings:AttributeSpecification",
           "value": "Volume"
         }
@@ -82,7 +82,7 @@
       "predicate": "bibo:number",
       "attributes": [
         {
-          "predicate": "dcterms:title",
+          "predicate": "ex:title",
           "type": "dlthings:AttributeSpecification",
           "value": "Document number"
         }
@@ -94,7 +94,7 @@
       "predicate": "bibo:numPages",
       "attributes": [
         {
-          "predicate": "dcterms:title",
+          "predicate": "ex:title",
           "type": "dlthings:AttributeSpecification",
           "value": "Number of pages"
         }
@@ -104,13 +104,13 @@
       "value": "17"
     },
     {
-      "predicate": "dcterms:modified",
+      "predicate": "ex:modified",
       "type": "dlthings:AttributeSpecification",
       "range": "xsd:date",
       "value": "2022-02-11"
     },
     {
-      "predicate": "dcterms:date",
+      "predicate": "ex:date",
       "type": "dlthings:AttributeSpecification",
       "range": "xsd:date",
       "value": "2022-03-11"
@@ -119,19 +119,19 @@
   "characterized_by": [
     {
       "object": "https://portal.issn.org/resource/issn/2052-4463",
-      "predicate": "dcterms:isPartOf"
+      "predicate": "ex:isPartOf"
     },
     {
       "object": "https://www.nature.com/subjects/data-processing",
-      "predicate": "dcterms:subject"
+      "predicate": "ex:subject"
     },
     {
       "object": "https://www.nature.com/subjects/data-publication-and-archiving",
-      "predicate": "dcterms:subject"
+      "predicate": "ex:subject"
     },
     {
       "object": "https://www.nature.com/subjects/software",
-      "predicate": "dcterms:subject"
+      "predicate": "ex:subject"
     },
     {
       "object": "https://www.nature.com/articles/s41597-022-01163-2",
@@ -139,7 +139,7 @@
     },
     {
       "object": "https://spdx.org/licenses/CC-BY-4.0",
-      "predicate": "dcterms:license"
+      "predicate": "ex:license"
     }
   ],
   "type": "dlthings:Thing",

--- a/src/things/v1/examples/Thing-05-publication.yaml
+++ b/src/things/v1/examples/Thing-05-publication.yaml
@@ -11,15 +11,15 @@ relations:
     exact_mappings:
       - bibo:Journal
     attributes:
-      - predicate: dcterms:title
+      - predicate: ex:title
         value: "Scientific Data"
 attributes:
-  - predicate: dcterms:title
+  - predicate: ex:title
     value: "FAIRly big: A framework for computationally reproducible processing of large-scale data"
-  - predicate: dcterms:description
+  - predicate: ex:description
     value: "Large-scale datasets present unique opportunities to perform scientific investigations with unprecedented breadth. However, they also pose considerable challenges for the findability, accessibility, interoperability, and reusability (FAIR) of research outcomes due to infrastructure limitations, data usage constraints, or software license restrictions. Here we introduce a DataLad-based, domain-agnostic framework suitable for reproducible data processing in compliance with open science mandates. The framework attempts to minimize platform idiosyncrasies and performance-related complexities. It affords the capture of machine-actionable computational provenance records that can be used to retrace and verify the origins of research outcomes, as well as be re-executed independent of the original computing infrastructure. We demonstrate the framework’s performance using two showcases: one highlighting data sharing and transparency (using the studyforrest.org dataset) and another highlighting scalability (using the largest public brain imaging dataset available: the UK Biobank dataset)."
   # DOI
-  - predicate: dcterms:identifier
+  - predicate: ex:identifier
     exact_mappings:
       - ADMS:Identifier
     attributes:
@@ -28,48 +28,48 @@ attributes:
       - predicate: ADMS:schemaAgency
         value: https://doi.org
   # bibliographic information
-  - predicate: dcterms:bibliographicCitation
+  - predicate: ex:bibliographicCitation
     value: "Wagner, A.S., Waite, L.K., Wierzba, M. et al. FAIRly big: A framework for computationally reproducible processing of large-scale data. Sci Data 9, 80 (2022)."
   - predicate: bibo:doi
     attributes:
-      - predicate: dcterms:title
+      - predicate: ex:title
         value: DOI
     value: https://doi.org/10.1038/s41597-022-01163-2
   - predicate: bibo:volume
     attributes:
-      - predicate: dcterms:title
+      - predicate: ex:title
         value: Volume
     value: "9"
   - predicate: bibo:number
     attributes:
-      - predicate: dcterms:title
+      - predicate: ex:title
         value: Document number
     value: "80"
   - predicate: bibo:numPages
     attributes:
-      - predicate: dcterms:title
+      - predicate: ex:title
         value: Number of pages
     value: "17"
     range: xsd:nonNegativeInteger
-  - predicate: dcterms:modified
+  - predicate: ex:modified
     range: xsd:date
     value: "2022-02-11"
-  - predicate: dcterms:date
+  - predicate: ex:date
     range: xsd:date
     value: "2022-03-11"
 characterized_by:
   # containing journal
-  - predicate: dcterms:isPartOf
+  - predicate: ex:isPartOf
     object: https://portal.issn.org/resource/issn/2052-4463
   # related topics
-  - predicate: dcterms:subject
+  - predicate: ex:subject
     object: https://www.nature.com/subjects/data-processing
-  - predicate: dcterms:subject
+  - predicate: ex:subject
     object: https://www.nature.com/subjects/data-publication-and-archiving
-  - predicate: dcterms:subject
+  - predicate: ex:subject
     object: https://www.nature.com/subjects/software
   # publisher landing page
   - predicate: owl:sameAs
     object: https://www.nature.com/articles/s41597-022-01163-2
-  - predicate: dcterms:license
+  - predicate: ex:license
     object: https://spdx.org/licenses/CC-BY-4.0

--- a/src/things/v1/examples/ValueSpecification-02-quantitative-measurement.json
+++ b/src/things/v1/examples/ValueSpecification-02-quantitative-measurement.json
@@ -2,7 +2,7 @@
   "id": "exthisns:measurement853",
   "attributes": [
     {
-      "predicate": "dcterms:title",
+      "predicate": "ex:title",
       "type": "dlthings:AttributeSpecification",
       "value": "measured mass (kg)"
     }
@@ -10,11 +10,11 @@
   "characterized_by": [
     {
       "object": "obo:IAO_0000109",
-      "predicate": "dcterms:subject"
+      "predicate": "ex:subject"
     },
     {
       "object": "obo:PATO_0000125",
-      "predicate": "dcterms:subject"
+      "predicate": "ex:subject"
     },
     {
       "object": "obo:UO_0000009",

--- a/src/things/v1/examples/ValueSpecification-02-quantitative-measurement.yaml
+++ b/src/things/v1/examples/ValueSpecification-02-quantitative-measurement.yaml
@@ -1,13 +1,13 @@
 id: exthisns:measurement853
 attributes:
-  - predicate: dcterms:title
+  - predicate: ex:title
     value: "measured mass (kg)"
 characterized_by:
   # measurement datum
-  - predicate: dcterms:subject
+  - predicate: ex:subject
     object: obo:IAO_0000109
   # mass
-  - predicate: dcterms:subject
+  - predicate: ex:subject
     object: obo:PATO_0000125
   # unit: kilogram
   - predicate: obo:UO_0000000


### PR DESCRIPTION
Although `dcterms` is foundational, it is not structurally relevant for the schemas. Hence it is not guaranteed to be defined in all schemas.

For the purpose of demo'ing any prefix should be good enough.

Closes: https://github.com/psychoinformatics-de/datalad-concepts/issues/250