### PR TITLE
Draft of a schema for NeuroBagel's graph data format

### DIFF
--- a/src/neurobagel/unreleased.yaml
+++ b/src/neurobagel/unreleased.yaml
@@ -1,0 +1,275 @@
+id: https://concepts.datalad.org/s/neurobagel/unreleased
+name: neurobagel-schema
+version: UNRELEASED
+status: eunal:concept-status/DRAFT
+title: Implementation of the NeuroBagel graph data schema
+description: |
+  The schema definition is available as
+
+  - [JSON-LD context](../unreleased.jsonld)
+  - [LinkML YAML](../unreleased.yaml)
+  - [OWL TTL](../unreleased.owl.ttl)
+  - [SHACL TTL](../unreleased.shacl.ttl)
+
+comments:
+  - ALL CONTENT HERE IS UNRELEASED AND MAY CHANGE ANY TIME
+
+license: MIT
+
+prefixes:
+  dcterms: http://purl.org/dc/terms/
+  dlschemas: https://concepts.datalad.org/s/
+  dltypes: https://concepts.datalad.org/s/types/unreleased/
+  eunal: http://publications.europa.eu/resource/authority/
+  ex: http://example.org/
+  linkml: https://w3id.org/linkml/
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
+  rdfs: http://www.w3.org/2000/01/rdf-schema#
+  # from neurobagel
+  cogatlas: https://www.cognitiveatlas.org/task/id/
+  nb: http://neurobagel.org/vocab/
+  ncit: http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#
+  nidm: http://purl.org/nidash/nidm#
+  snomed: http://purl.bioontology.org/ontology/SNOMEDCT/
+  np: https://github.com/nipoppy/pipeline-catalog/tree/main/processing/
+
+
+default_prefix: nb
+
+imports:
+  - linkml:types
+
+types:
+
+
+slots:
+  identifier:
+    description: >-
+      TODO
+    range: uriorcurie
+    identifier: true
+
+  schemaKey: 
+    description: >-
+      TODO
+    designates_type: true
+    range: string
+
+  hasContrastType:
+    description: >-
+      TODO
+    range: Image
+    inlined: true
+
+  hasPipelineVersion:
+    description: >-
+      TODO
+    range: string
+
+  hasPipelineName:
+    description: >-
+      TODO
+    range: Pipeline
+    inlined: true
+
+  hasLabel:
+    description: >-
+      TODO
+    range: string
+
+  hasAge:
+    description: >-
+      TODO
+    range: float
+
+  hasSex:
+    description: >-
+      TODO
+    range: Sex
+    inlined: true
+
+  isSubjectGroup:
+    description: >-
+      TODO
+    range: SubjectGroup
+    inlined: true
+
+  hasDiagnosis:
+    description: >-
+      TODO
+    range: Diagnosis
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+
+  hasAssessment:
+    description: >-
+      TODO
+    range: Assessment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+
+  hasFilePath:
+    description: >-
+      TODO
+    range: string
+
+  hasAcquisition:
+    description: >-
+      TODO
+    range: Acquisition
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+
+  hasCompletedPipeline:
+    description: >-
+      TODO
+    range: CompletedPipeline
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+
+  hasSession:
+    description: >-
+      TODO
+    range: Session
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+
+  hasPortalURI:
+    description: >-
+      TODO
+    range: uri
+
+  hasSamples:
+    description: >-
+      TODO
+    range: Subject
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+
+
+classes:
+  Bagel:
+    description: >-
+      TODO
+    slots:
+      - identifier
+      - schemaKey
+
+  ControlledTerm:
+    is_a: Bagel
+    description: >-
+      TODO
+
+  Sex:
+    is_a: ControlledTerm
+    description: >-
+      TODO
+
+  Diagnosis:
+    is_a: ControlledTerm
+    description: >-
+      TODO
+
+  SubjectGroup:
+    is_a: ControlledTerm
+    description: >-
+      TODO
+
+  Assessment:
+    is_a: ControlledTerm
+    description: >-
+      TODO
+
+  Image:
+    is_a: ControlledTerm
+    description: >-
+      TODO
+
+  Acquisition:
+    is_a: Bagel
+    description: >-
+      TODO
+    slots:
+      - hasContrastType
+    slot_usage:
+      hasContrastType:
+        required: true
+
+  Pipeline:
+    is_a: ControlledTerm
+    description: >-
+      TODO
+
+  CompletedPipeline:
+    is_a: Bagel
+    description: >-
+      TODO
+    slots:
+      - hasPipelineVersion
+      - hasPipelineName
+    slot_usage:
+      hasPipelineVersion:
+        required: true
+      hasPipelineName:
+        required: true
+
+  Session:
+    is_a: Bagel
+    description: >-
+      TODO
+    slots:
+      - hasLabel
+    slot_usage:
+      hasLabel:
+        required: true
+
+  PhenotypicSession:
+    is_a: Session
+    description: >-
+      TODO
+    slots:
+      - hasAge
+      - hasSex
+      - isSubjectGroup
+      - hasDiagnosis
+      - hasAssessment
+
+  ImagingSession:
+    is_a: Session
+    description: >-
+      TODO
+    slots:
+      - hasFilePath
+      - hasAcquisition
+      - hasCompletedPipeline
+
+  Subject:
+    is_a: Bagel
+    description: >-
+      TODO
+    slots:
+      - hasLabel
+      - hasSession
+    slot_usage:
+      hasLabel:
+        required: true
+
+  Dataset:
+    is_a: Bagel
+    description: >-
+      TODO
+    slots:
+      - hasLabel
+      - hasPortalURI
+      - hasSamples
+    slot_usage:
+      hasLabel:
+        required: true
+      hasSamples:
+        required: true


### PR DESCRIPTION
With this schema, I can convert the demo data shipped with NeuroBagel into YAML and back. I can do validation and all the other linkml goodness.

This is posted here, in order to fuel a data transformation pipeline from "our" schemas to NeuroBagel's in order to feed an instance with dataset information.

This schema draft is currently not rendered or hooked up to the validation and linting, because it does not meet our conventions (and will never). I need to allow for a schema-specific linter config first.

```
  warning  Slot has name 'schemaKey'  (standard_naming)
  warning  Slot has name 'hasContrastType'  (standard_naming)
  warning  Slot has name 'hasPipelineVersion'  (standard_naming)
  warning  Slot has name 'hasPipelineName'  (standard_naming)
  warning  Slot has name 'hasLabel'  (standard_naming)
  warning  Slot has name 'hasAge'  (standard_naming)
  warning  Slot has name 'hasSex'  (standard_naming)
  warning  Slot has name 'isSubjectGroup'  (standard_naming)
  warning  Slot has name 'hasDiagnosis'  (standard_naming)
  warning  Slot has name 'hasAssessment'  (standard_naming)
  warning  Slot has name 'hasFilePath'  (standard_naming)
  warning  Slot has name 'hasAcquisition'  (standard_naming)
  warning  Slot has name 'hasCompletedPipeline'  (standard_naming)
  warning  Slot has name 'hasSession'  (standard_naming)
  warning  Slot has name 'hasPortalURI'  (standard_naming)
  warning  Slot has name 'hasSamples'  (standard_naming)
  warning  Schema maps prefix 'ncit' to namespace 'http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#' instead of using prefix 'NCIThesaurus'  (canonical_prefixes)
  warning  Schema maps prefix 'nidm' to namespace 'http://purl.org/nidash/nidm#' instead of namespace 'http://nidm.nidash.org/'  (canonical_prefixes)
  warning  Schema maps prefix 'np' to namespace 'https://github.com/nipoppy/pipeline-catalog/tree/main/processing/' instead of namespace 'http://www.nanopub.org/nschema#'  (canonical_prefixes)
```