### PR TITLE
Introduce `Instrument` as another basic `Resource` category

### DIFF
--- a/src/publications/unreleased.yaml
+++ b/src/publications/unreleased.yaml
@@ -26,6 +26,7 @@ license: MIT
 
 prefixes:
   dlidentifiers: https://concepts.datalad.org/s/identifiers/unreleased/
+  dlprops: https://concepts.datalad.org/s/properties/unreleased/
   dlprov: https://concepts.datalad.org/s/prov/unreleased/
   dlpubs: https://concepts.datalad.org/s/publications/unreleased/
   dlroles: https://concepts.datalad.org/s/roles/unreleased/
@@ -51,6 +52,7 @@ default_prefix: dlpubs
 
 emit_prefixes:
   - dlidentifiers
+  - dlprops
   - dlprov
   - dlpubs
   - dlres
@@ -68,7 +70,6 @@ emit_prefixes:
   - xsd
 
 imports:
-  - dlschemas:properties/unreleased
   - dlschemas:temporal/unreleased
   - dlschemas:resources/unreleased
 
@@ -88,6 +89,3 @@ classes:
     slots:
       - date_modified
       - date_published
-      - about
-      - same_as
-      - title

--- a/src/publications/unreleased/examples/Publication-03-attributes.json
+++ b/src/publications/unreleased/examples/Publication-03-attributes.json
@@ -2,13 +2,13 @@
   "id": "https://doi.org/10.1038/s41597-022-01163-2",
   "description": "Large-scale datasets present unique opportunities to perform scientific investigations with unprecedented breadth. However, they also pose considerable challenges for the findability, accessibility, interoperability, and reusability (FAIR) of research outcomes due to infrastructure limitations, data usage constraints, or software license restrictions. Here we introduce a DataLad-based, domain-agnostic framework suitable for reproducible data processing in compliance with open science mandates. The framework attempts to minimize platform idiosyncrasies and performance-related complexities. It affords the capture of machine-actionable computational provenance records that can be used to retrace and verify the origins of research outcomes, as well as be re-executed independent of the original computing infrastructure. We demonstrate the framework’s performance using two showcases: one highlighting data sharing and transparency (using the studyforrest.org dataset) and another highlighting scalability (using the largest public brain imaging dataset available: the UK Biobank dataset).",
   "schema_type": "dlpubs:Publication",
-  "date_modified": "2022-02-11",
-  "date_published": "2022-03-11",
   "about": [
     "https://www.nature.com/subjects/data-processing",
     "https://www.nature.com/subjects/data-publication-and-archiving",
     "https://www.nature.com/subjects/software"
   ],
   "title": "FAIRly big: A framework for computationally reproducible processing of large-scale data",
+  "date_modified": "2022-02-11",
+  "date_published": "2022-03-11",
   "@type": "Publication"
 }

--- a/src/resources/unreleased.yaml
+++ b/src/resources/unreleased.yaml
@@ -38,6 +38,7 @@ prefixes:
   ex: http://example.org/
   linkml: https://w3id.org/linkml/
   marcrel: http://id.loc.gov/vocabulary/relators/
+  obo: http://purl.obolibrary.org/obo/
   rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   rdfs: http://www.w3.org/2000/01/rdf-schema#
   skos: http://www.w3.org/2004/02/skos/core#
@@ -48,6 +49,7 @@ default_prefix: dlres
 
 emit_prefixes:
   - dlidentifiers
+  - dlprops
   - dlprov
   - dlres
   - dlroles
@@ -64,6 +66,7 @@ emit_prefixes:
   - xsd
 
 imports:
+  - dlschemas:properties/unreleased
   - dlschemas:prov/unreleased
 
 slots:
@@ -128,9 +131,14 @@ classes:
       A consumable, often quantifiable entity, typically made available by a
       single agent.
     slots:
+      - about
       - indexed_parts
       - indexed_part_of
-    #  - contact_point
+      - same_as
+      - short_name
+      - title
+      # TODO add example on how to annotate the relation to a contact point
+      # - contact_point
     narrow_mappings:
       - dcat:Resource
 
@@ -141,6 +149,9 @@ classes:
       A grant, typically financial or otherwise quantifiable, of resources.
     slots:
       - sponsor
+    disjoint_with:
+      - Dataset
+      - Grant
     exact_mappings:
       - schema:Grant
 
@@ -151,6 +162,9 @@ classes:
       A collection of data, published or curated by a single agent. This is a
       conceptual entity. A single dataset might be available in more than
       one representation, with differing schematic layouts, formats, and serializations.
+    disjoint_with:
+      - Grant
+      - Instrument
     exact_mappings:
       - dcat:Dataset
     #slots:
@@ -181,3 +195,19 @@ classes:
     description: >-
       An association class for attaching an index `locator` as additional information to a
       `isPartOf` relationship.
+
+  Instrument:
+    class_uri: dlres:Instrument
+    is_a: Resource
+    description: >-
+      A thing that enables an agent to perform an action. This is typically a device
+      (e.g., a machine to perform a particular type of measurement), but it can also be
+      a questionnaire that is used to perform a particular kind of assessment.
+      An instrument is typically not a "reagent".
+    disjoint_with:
+      - Dataset
+      - Grant
+    related_mappings:
+      - schema:instrument
+    narrow_mappings:
+      - obo:NCIT_C62103

--- a/src/resources/unreleased/examples/Instrument-03-rich.json
+++ b/src/resources/unreleased/examples/Instrument-03-rich.json
@@ -1,0 +1,18 @@
+{
+  "id": "https://www.cognitiveatlas.org/task/id/trm_55a6a8e81b7f4",
+  "description": "A widely used measure of impulsiveness. It includes 30 items that are scored to yield six first-order factors (attention, motor, self-control, cognitive complexity, perseverance, and cognitive instability impulsiveness) and three second-order factors (attentional, motor, and non-planning impulsiveness).",
+  "characterized_by": [
+    {
+      "object": "https://doi.org/10.1016/j.paid.2009.04.008",
+      "predicate": "http://purl.org/spar/cito/citesAsAuthority"
+    }
+  ],
+  "schema_type": "dlres:Instrument",
+  "about": [
+    "https://en.wikipedia.org/wiki/Impulsivity"
+  ],
+  "same_as": "https://en.wikipedia.org/wiki/Barratt_Impulsiveness_Scale",
+  "short_name": "BIS",
+  "title": "Barratt Impulsiveness Scale",
+  "@type": "Instrument"
+}

--- a/src/resources/unreleased/examples/Instrument-03-rich.yaml
+++ b/src/resources/unreleased/examples/Instrument-03-rich.yaml
@@ -1,0 +1,15 @@
+id: https://www.cognitiveatlas.org/task/id/trm_55a6a8e81b7f4
+same_as: https://en.wikipedia.org/wiki/Barratt_Impulsiveness_Scale
+short_name: BIS
+title: Barratt Impulsiveness Scale
+description: >-
+  A widely used measure of impulsiveness. It includes 30 items that are scored
+  to yield six first-order factors (attention, motor, self-control,
+  cognitive complexity, perseverance, and cognitive instability impulsiveness)
+  and three second-order factors (attentional, motor, and non-planning
+  impulsiveness).
+about:
+  - https://en.wikipedia.org/wiki/Impulsivity
+characterized_by:
+  - predicate: http://purl.org/spar/cito/citesAsAuthority
+    object: https://doi.org/10.1016/j.paid.2009.04.008

--- a/src/resources/unreleased/validation/Instrument.valid.cfg.yaml
+++ b/src/resources/unreleased/validation/Instrument.valid.cfg.yaml
@@ -1,0 +1,11 @@
+schema: src/resources/unreleased.yaml
+target_class: Instrument
+data_sources:
+  #- src/resources/unreleased/examples/Instrument-01-minimal.yaml
+  #- src/resources/unreleased/examples/Instrument-02-.yaml
+  - src/resources/unreleased/examples/Instrument-03-rich.yaml
+plugins:
+  JsonschemaValidationPlugin:
+    closed: true
+    include_range_class_descendants: false
+  RecommendedSlotsPlugin:


### PR DESCRIPTION
This make the full list be

- `Dataset`
- `Grant`
- `Instrument`
- `Publication` (in another schema)

This change includeis the move of the following basic slots from `Publication` to `Resource:

- `about`
- `same_as`
- `short_name`
- `title`

There appears to be sufficient evidence for their general applicability to any resource.

The included example is, on purpose, an atypical `Instrument`: a questionaire used to perform cognitive assessments.