### PR TITLE
Adjust location and naming of JSON-LD context files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ build/linkml-docs/s/%: src/%.yaml src/%/extra-docs
 	# jsonld context
 	gen-jsonld-context \
 		--mergeimports \
-		$< > $@.jsonld
+		$< > $@.context.jsonld
 	# SHACL with annotation needed to build UI specs
 	gen-shacl \
 		--include-annotations \

--- a/src/distribution/unreleased.yaml
+++ b/src/distribution/unreleased.yaml
@@ -40,7 +40,7 @@ description: |
 
   The schema is available as
 
-  - [JSON-LD context](../unreleased.jsonld)
+  - [JSON-LD context](../unreleased.context.jsonld)
   - [LinkML YAML](../unreleased.yaml)
   - [OWL TTL](../unreleased.owl.ttl)
   - [SHACL TTL](../unreleased.shacl.ttl)

--- a/src/identifiers/unreleased.yaml
+++ b/src/identifiers/unreleased.yaml
@@ -20,7 +20,7 @@ description: |
 
   The schema definition is available as
 
-  - [JSON-LD context](../unreleased.jsonld)
+  - [JSON-LD context](../unreleased.context.jsonld)
   - [LinkML YAML](../unreleased.yaml)
   - [OWL TTL](../unreleased.owl.ttl)
   - [SHACL TTL](../unreleased.shacl.ttl)

--- a/src/properties/unreleased.yaml
+++ b/src/properties/unreleased.yaml
@@ -21,7 +21,7 @@ description: |
 
   The schema definition is available as
 
-  - [JSON-LD context](../unreleased.jsonld)
+  - [JSON-LD context](../unreleased.context.jsonld)
   - [LinkML YAML](../unreleased.yaml)
   - [OWL TTL](../unreleased.owl.ttl)
   - [SHACL TTL](../unreleased.shacl.ttl)

--- a/src/prov/unreleased.yaml
+++ b/src/prov/unreleased.yaml
@@ -44,7 +44,7 @@ description: |
 
   The schema definition is available as
 
-  - [JSON-LD context](../unreleased.jsonld)
+  - [JSON-LD context](../unreleased.context.jsonld)
   - [LinkML YAML](../unreleased.yaml)
   - [OWL TTL](../unreleased.owl.ttl)
   - [SHACL TTL](../unreleased.shacl.ttl)

--- a/src/publications/unreleased.yaml
+++ b/src/publications/unreleased.yaml
@@ -14,7 +14,7 @@ description: |
 
   The schema is available as
 
-  - [JSON-LD context](../unreleased.jsonld)
+  - [JSON-LD context](../unreleased.context.jsonld)
   - [LinkML YAML](../unreleased.yaml)
   - [OWL TTL](../unreleased.owl.ttl)
   - [SHACL TTL](../unreleased.shacl.ttl)

--- a/src/resources/unreleased.yaml
+++ b/src/resources/unreleased.yaml
@@ -11,7 +11,7 @@ description: |
 
   The schema is available as
 
-  - [JSON-LD context](../unreleased.jsonld)
+  - [JSON-LD context](../unreleased.context.jsonld)
   - [LinkML YAML](../unreleased.yaml)
   - [OWL TTL](../unreleased.owl.ttl)
   - [SHACL TTL](../unreleased.shacl.ttl)

--- a/src/roles/unreleased.yaml
+++ b/src/roles/unreleased.yaml
@@ -24,7 +24,7 @@ description: |
 
   The schema definition is available as
 
-  - [JSON-LD context](../unreleased.jsonld)
+  - [JSON-LD context](../unreleased.context.jsonld)
   - [LinkML YAML](../unreleased.yaml)
   - [OWL TTL](../unreleased.owl.ttl)
   - [SHACL TTL](../unreleased.shacl.ttl)

--- a/src/social/unreleased.yaml
+++ b/src/social/unreleased.yaml
@@ -22,7 +22,7 @@ description: |
 
   The schema definition is available as
 
-  - [JSON-LD context](../unreleased.jsonld)
+  - [JSON-LD context](../unreleased.context.jsonld)
   - [LinkML YAML](../unreleased.yaml)
   - [OWL TTL](../unreleased.owl.ttl)
   - [SHACL TTL](../unreleased.shacl.ttl)

--- a/src/spatial/unreleased.yaml
+++ b/src/spatial/unreleased.yaml
@@ -13,7 +13,7 @@ description: |
 
   The schema definition is available as
 
-  - [JSON-LD context](../unreleased.jsonld)
+  - [JSON-LD context](../unreleased.context.jsonld)
   - [LinkML YAML](../unreleased.yaml)
   - [OWL TTL](../unreleased.owl.ttl)
   - [SHACL TTL](../unreleased.shacl.ttl)

--- a/src/temporal/unreleased.yaml
+++ b/src/temporal/unreleased.yaml
@@ -13,7 +13,7 @@ description: |
 
   The schema definition is available as
 
-  - [JSON-LD context](../unreleased.jsonld)
+  - [JSON-LD context](../unreleased.context.jsonld)
   - [LinkML YAML](../unreleased.yaml)
   - [OWL TTL](../unreleased.owl.ttl)
   - [SHACL TTL](../unreleased.shacl.ttl)

--- a/src/things/unreleased.yaml
+++ b/src/things/unreleased.yaml
@@ -41,7 +41,7 @@ description: |
 
   The schema definition is available as
 
-  - [JSON-LD context](../unreleased.jsonld)
+  - [JSON-LD context](../unreleased.context.jsonld)
   - [LinkML YAML](../unreleased.yaml)
   - [OWL TTL](../unreleased.owl.ttl)
   - [SHACL TTL](../unreleased.shacl.ttl)

--- a/src/things/v1.yaml
+++ b/src/things/v1.yaml
@@ -41,7 +41,7 @@ description: |
 
   The schema definition is available as
 
-  - [JSON-LD context](../v1.jsonld)
+  - [JSON-LD context](../v1.context.jsonld)
   - [LinkML YAML](../v1.yaml)
   - [OWL TTL](../v1.owl.ttl)
   - [SHACL TTL](../v1.shacl.ttl)

--- a/src/types/unreleased.yaml
+++ b/src/types/unreleased.yaml
@@ -19,7 +19,7 @@ description: |
 
   The schema definition is available as
 
-  - [JSON-LD context](../unreleased.jsonld)
+  - [JSON-LD context](../unreleased.context.jsonld)
   - [LinkML YAML](../unreleased.yaml)
   - [OWL TTL](../unreleased.owl.ttl)
   - [SHACL TTL](../unreleased.shacl.ttl)


### PR DESCRIPTION
I observed HTTP404 errors triggered by `linkml-convert`. I assume this is the convention that it uses for loading imported schemas when converting to TTL