### PR TITLE
Add slot for `skos:prefLabel` -> `preferred_label`

### DIFF
--- a/src/roles/unreleased/examples/Role-02-explained.json
+++ b/src/roles/unreleased/examples/Role-02-explained.json
@@ -1,0 +1,7 @@
+{
+  "id": "marcrel:pdr",
+  "description": "A person or organization with primary responsibility for all essential aspects of a project, has overall responsibility for managing projects, or provides overall direction to a project manager",
+  "preferred_label": "Project director",
+  "schema_type": "dlroles:Role",
+  "@type": "Role"
+}

--- a/src/roles/unreleased/examples/Role-02-explained.yaml
+++ b/src/roles/unreleased/examples/Role-02-explained.yaml
@@ -1,0 +1,5 @@
+id: marcrel:pdr
+description: A person or organization with primary responsibility for all essential
+  aspects of a project, has overall responsibility for managing projects, or provides
+  overall direction to a project manager
+preferred_label: Project director

--- a/src/things/v1.yaml
+++ b/src/things/v1.yaml
@@ -248,6 +248,16 @@ slots:
     exact_mappings:
       - rdf:predicate
 
+  preferred_label:
+    slot_uri: skos:prefLabel
+    description: >-
+      The preferred label for a subject. This information is specifically
+      about the presentation of a `Thing` instance. For general naming
+      purposes, a class should provides slots like `name`, `title`, or
+      similar.
+    range: string
+    multivalued: false
+
   range:
     slot_uri: rdfs:range
     description: >-
@@ -316,6 +326,7 @@ classes:
       - characterized_by
       - narrow_mappings
       - related_mappings
+      - preferred_label
       - schema_type
 
   ValueSpecificationMixin:


### PR DESCRIPTION
This serves the same purpose as the shacl `sh:name` annotation for a class/slot name. However, this approach also extends into the realm of individual instances.

Use case: Role instances need to be presented in a meaningfully compact way (also Instruments, etc). `skos:prefLabel` for
https://id.loc.gov/vocabulary/relators/spn.html could simply be set to `Sponsor` and would offer the information to do this.

This is defined as something separate from `name`, `title` etc, to discourage abusing one purpose for the respective other.