### PR TITLE
Add `annotations` slot to any `Thing`

### DIFF
--- a/src/roles/unreleased/examples/Role-02-explained.json
+++ b/src/roles/unreleased/examples/Role-02-explained.json
@@ -1,0 +1,12 @@
+{
+  "id": "marcrel:pdr",
+  "annotations": {
+    "skos:prefLabel": {
+      "annotation_tag": "skos:prefLabel",
+      "annotation_value": "Project director"
+    }
+  },
+  "description": "A person or organization with primary responsibility for all essential aspects of a project, has overall responsibility for managing projects, or provides overall direction to a project manager",
+  "schema_type": "dlroles:Role",
+  "@type": "Role"
+}

--- a/src/roles/unreleased/examples/Role-02-explained.yaml
+++ b/src/roles/unreleased/examples/Role-02-explained.yaml
@@ -1,0 +1,6 @@
+id: marcrel:pdr
+description: A person or organization with primary responsibility for all essential
+  aspects of a project, has overall responsibility for managing projects, or provides
+  overall direction to a project manager
+annotations:
+  skos:prefLabel: Project director

--- a/src/roles/unreleased/validation/Role.valid.cfg.yaml
+++ b/src/roles/unreleased/validation/Role.valid.cfg.yaml
@@ -2,6 +2,7 @@ schema: src/roles/unreleased.yaml
 target_class: Role
 data_sources:
   - src/roles/unreleased/examples/Role-01-minimal.yaml
+  - src/roles/unreleased/examples/Role-02-explained.yaml
 plugins:
   JsonschemaValidationPlugin:
     closed: true

--- a/src/things/v1.yaml
+++ b/src/things/v1.yaml
@@ -217,6 +217,25 @@ slots:
     range: uriorcurie
     multivalued: true
 
+  annotations:
+    slot_uri: dlthings:annotations
+    description: >-
+      A record of properties of the metadata record on a subject, a collection
+      of tag/text tuples with the semantics of OWL Annotation.
+    range: Annotation
+    inlined: true
+    multivalued: true
+    annotations:
+      sh:name: Annotations
+
+  annotation_tag:
+    description: A tag identifying an annotation.
+    range: uriorcurie
+
+  annotation_value:
+    description: The actual annotation.
+    range: string
+
   narrow_mappings:
     slot_uri: skos:narrowMatch
     is_a: mappings
@@ -308,6 +327,7 @@ classes:
       A set of `mappings` slots enables the alignment for arbitrary external
       schemas and terminologies.
     slots:
+      - annotations
       - broad_mappings
       - close_mappings
       - description
@@ -416,3 +436,16 @@ classes:
             an error.
     exact_mappings:
       - obo:OBI_0001933
+
+  Annotation:
+    description: >-
+      A tag/value pair with the semantics of OWL Annotation.
+    slots:
+      - annotation_tag
+      - annotation_value
+    slot_usage:
+      annotation_tag:
+        key: true
+        required: true
+      annotation_value:
+        required: true


### PR DESCRIPTION
There is a need to express metadata on a metadata record. For example, how a metadata record is best presented.

This serves the same purpose as linkml's `annotations` slot, and the use of the shacl `sh:name` annotation for a class/slot name. However, this approach also extends into the realm of individual instances.

Use case: Role instances need to be presented in a meaningfully compact way (also Instruments, etc). `skos:prefLabel` for
https://id.loc.gov/vocabulary/relators/spn.html could simply be set to `Sponsor` and would offer the information to do this.

LinkML's `annotation_value` slot allows for `linkml:Any` values. However, this is giving me pain. I decided to not investigate this now (more important things to do), and leave it at `string` for now. It should be non-invasive to relax this later on.

An example for a `Role` annotation is included.