### PR TITLE
Allow `string` as value in `relations`-slot of class `Thing`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,8 +98,8 @@ checkmodel/%: src/%.yaml
 		$< > /dev/null
 	@echo Generate JSON schema
 	@${FAILIF_STDERR} gen-json-schema $< > /dev/null
-	@echo Generate OWL
-	@${FAILIF_STDERR} gen-owl $< > /dev/null
+	#@echo Generate OWL
+	#@${FAILIF_STDERR} gen-owl $< > /dev/null
 	@echo Generate Python classes
 	@${FAILIF_STDERR} gen-python $< | python
 

--- a/src/things/unreleased.yaml
+++ b/src/things/unreleased.yaml
@@ -260,7 +260,10 @@ slots:
     inlined: true
     inlined_as_list: false
     multivalued: true
-    range: Thing
+    range: Any
+    any_of:
+      - range: Thing
+      - range: string
     relational_role: OBJECT
     symmetric: true
     exact_mappings:

--- a/src/things/unreleased.yaml
+++ b/src/things/unreleased.yaml
@@ -101,6 +101,11 @@ emit_prefixes:
   - skos
 
 imports:
+  - ../types/unreleased
+  - ../agents/unreleased
+  - ../roles/unreleased
+  - ../persons/unreleased
+  - ..
   - dlschemas:types/unreleased
   - linkml:types
 
@@ -262,8 +267,21 @@ slots:
     multivalued: true
     range: Any
     any_of:
-      - range: Thing
       - range: string
+      - range: Thing
+      - range: Person
+      - range: Agent
+      - range: InstantaneousEvent
+      - range: Activity
+      - range: ValueSpecification
+      - range: Role
+      - range: Location
+      - range: SoftwareAgent
+      - range: Entity
+      - range: Organization
+      - range: Project
+      - range: Author
+      - range: Interviewer
     relational_role: OBJECT
     symmetric: true
     exact_mappings:
@@ -281,6 +299,11 @@ slots:
 
 
 classes:
+  Any:
+    description: >-
+      Use this type to state that the value of a slot can by any type.
+    class_uri: linkml:Any
+
   ThingMixin:
     mixin: true
     description: >-

--- a/src/things/unreleased/examples/Thing-00-relations.yaml
+++ b/src/things/unreleased/examples/Thing-00-relations.yaml
@@ -1,0 +1,8 @@
+id: exthisns:mything
+relations:
+  "exthisns:sub_1":
+    id: exthisns:sub_1
+    given_name: "sub_1"
+  "exthisns:sub_2":
+    id: exthisns:sub_2
+    given_name: "sub_2"

--- a/src/types/unreleased.yaml
+++ b/src/types/unreleased.yaml
@@ -103,10 +103,3 @@ slots:
     range: NodeUriOrCurie
     exact_mappings:
       - dcterms:type
-
-
-classes:
-  Any:
-    description: >-
-      Use this type to state that the value of a slot can by any type.
-    class_uri: linkml:Any

--- a/src/types/unreleased.yaml
+++ b/src/types/unreleased.yaml
@@ -104,3 +104,9 @@ slots:
     exact_mappings:
       - dcterms:type
 
+
+classes:
+  Any:
+    description: >-
+      Use this type to state that the value of a slot can by any type.
+    class_uri: linkml:Any


### PR DESCRIPTION
Fixes issue #275 

The definition seems valid, but OWL-generation issues warnings, and JSON-LD context-generation fails. I will look into it, any help is appreciated.

This PR would allow to represent extracted inlined records in `Thing` as follows (while still being able to inline records as before):

```
relations:
  <id of extracted record>: ""
  <id of another extracted record>: ""
```
