### PR TITLE
Add panzoom plugin to allow zoom in and pan/drag the mermaid drawing

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,8 @@ nav:
   - Dump-Things: dump-things.md
 plugins:
   - mermaid2
+  - panzoom:
+      full_screen: True # default False
   - redirects:
       redirect_maps:
           # map unversioned URLs to the latest version

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 linkml
 mkdocs
 mkdocs-mermaid2-plugin
+mkdocs-panzoom-plugin
 mkdocs-redirects


### PR DESCRIPTION
Otherwise drawing on e.g. https://concepts.datalad.org/s/temporal/unreleased/ is not useful really -- too small/detailed. With full screen and zoom it becomes much more usable.  Here is a preview

![image](https://github.com/user-attachments/assets/1d032fe6-d9c8-4628-a862-07ff6d9dffe7)

To zoom in, press Alt/Option and if then you would want to drag / pan around -- left click mouse (after having pressed Alt/Option) and drag with the mouse.