### PR TITLE
Switch to material theme

### DIFF
--- a/.github/workflows/model-checks.yml
+++ b/.github/workflows/model-checks.yml
@@ -18,16 +18,9 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Install dependencies
-        run: |
-          pip install -r requirements.txt
-
-      - name: Patch linkml
-        run: |
-          tools/patch_linkml
+      - name: Install hatch
+        run: python -m pip install hatch
 
       - name: Run checks
         run: |
-          # make the checks self-contained re what is in the repo now
-          make imports-local
-          make check-models
+          hatch run check:models

--- a/.github/workflows/validate-examples.yaml
+++ b/.github/workflows/validate-examples.yaml
@@ -18,16 +18,9 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Install dependencies
-        run: |
-          pip install -r requirements.txt
-
-      - name: Patch linkml
-        run: |
-          tools/patch_linkml
+      - name: Install hatch
+        run: python -m pip install hatch
 
       - name: Validate
         run: |
-          # make the checks self-contained re what is in the repo now
-          make imports-local
-          make check-validation
+          hatch run check:examples

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,5 +45,5 @@ site_url: !ENV [SITEURL, 'https://concepts.datalad.org']
 # false, because we have many doc files that are not mentioned in "nav"
 strict: false
 theme:
-  name: mkdocs
+  name: material
   locale: en

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,11 +52,20 @@ post-install-commands = [
   "{root}/tools/patch_linkml",
 ]
 
+[tool.hatch.envs.check]
+description = "test models and examples"
+
+[tool.hatch.envs.check.scripts]
+models = "make imports-local && make check-models"
+examples = "make imports-local && make check-validation"
+
 [tool.hatch.envs.docs]
 description = "build mkdocs-based documentation and website"
 extra-dependencies = [
   "mkdocs",
+  "mkdocs-material",
   "mkdocs-mermaid2-plugin",
+  "mkdocs-panzoom-plugin",
   "mkdocs-redirects",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-linkml
-mkdocs
-mkdocs-mermaid2-plugin
-mkdocs-panzoom-plugin
-mkdocs-redirects


### PR DESCRIPTION
This is a precondition for the panzoom plugin. At least when trying to avoid more fiddling. The theme choice was arbitrary so far. The material theme looks good. Switching...

This change also removed the `requirements.txt`. Information was duplicated and outdated with respect to the cannonical pyproject.toml

Closes: https://github.com/psychoinformatics-de/datalad-concepts/issues/278