### PR TITLE
More flexible means to express `Thing` relationships

### DIFF
--- a/src/edistributions/unreleased/examples/ElectronicDistribution-03-parts.json
+++ b/src/edistributions/unreleased/examples/ElectronicDistribution-03-parts.json
@@ -4,20 +4,22 @@
     "https://example.org/133a6ad2ca7ba8adb54b95ba204f20cfabfcba98": {
       "pid": "https://example.org/133a6ad2ca7ba8adb54b95ba204f20cfabfcba98",
       "schema_type": "dledist:ElectronicDistribution",
-      "indexed_parts": {
-        "README.md": {
-          "locator": "README.md",
-          "resource": "https://example.org/b339e2493957d7c15add64243572205185c951fb"
+      "qualified_relations": [
+        {
+          "object": "https://example.org/b339e2493957d7c15add64243572205185c951fb",
+          "schema_type": "dlres:IndexedResourcePart",
+          "locator": "README.md"
         }
-      }
+      ]
     }
   },
   "schema_type": "dledist:ElectronicDistribution",
-  "indexed_parts": {
-    "code": {
-      "locator": "code",
-      "resource": "https://example.org/133a6ad2ca7ba8adb54b95ba204f20cfabfcba98"
+  "qualified_relations": [
+    {
+      "object": "https://example.org/133a6ad2ca7ba8adb54b95ba204f20cfabfcba98",
+      "schema_type": "dlres:IndexedResourcePart",
+      "locator": "code"
     }
-  },
+  ],
   "@type": "ElectronicDistribution"
 }

--- a/src/edistributions/unreleased/examples/ElectronicDistribution-03-parts.yaml
+++ b/src/edistributions/unreleased/examples/ElectronicDistribution-03-parts.yaml
@@ -4,12 +4,16 @@
 # is only locally unique, within the scope of the parts of a
 # particular distribution object.
 pid: https://example.org/20b330286682a772021c75f59fdbde07155773bb
-indexed_parts:
+qualified_relations:
   # a directory
-  code: https://example.org/133a6ad2ca7ba8adb54b95ba204f20cfabfcba98
+  - schema_type: dlres:IndexedResourcePart
+    locator: code
+    object: https://example.org/133a6ad2ca7ba8adb54b95ba204f20cfabfcba98
 relations:
   https://example.org/133a6ad2ca7ba8adb54b95ba204f20cfabfcba98:
     schema_type: dledist:ElectronicDistribution
-    indexed_parts:
+    qualified_relations:
       # a file
-      README.md: https://example.org/b339e2493957d7c15add64243572205185c951fb
+      - schema_type: dlres:IndexedResourcePart
+        locator: README.md
+        object: https://example.org/b339e2493957d7c15add64243572205185c951fb

--- a/src/edistributions/unreleased/examples/ElectronicDistribution-04-partrole.json
+++ b/src/edistributions/unreleased/examples/ElectronicDistribution-04-partrole.json
@@ -1,18 +1,20 @@
 {
   "pid": "https://example.org/20b330286682a772021c75f59fdbde07155773bb",
   "schema_type": "dledist:ElectronicDistribution",
-  "indexed_parts": {
-    "run-me.sh": {
-      "locator": "run-me.sh",
-      "resource": "https://example.org/133a6ad2ca7ba8adb54b95ba204f20cfabfcba98"
+  "qualified_relations": [
+    {
+      "object": "https://example.org/133a6ad2ca7ba8adb54b95ba204f20cfabfcba98",
+      "schema_type": "dlres:IndexedResourcePart",
+      "locator": "run-me.sh"
     },
-    "run-me": {
-      "locator": "run-me",
-      "resource": "https://example.org/133a6ad2ca7ba8adb54b95ba204f20cfabfcba98",
+    {
+      "object": "https://example.org/133a6ad2ca7ba8adb54b95ba204f20cfabfcba98",
       "roles": [
         "obo:ONTOAVIDA_00000002"
-      ]
+      ],
+      "schema_type": "dlres:IndexedResourcePart",
+      "locator": "run-me"
     }
-  },
+  ],
   "@type": "ElectronicDistribution"
 }

--- a/src/edistributions/unreleased/examples/ElectronicDistribution-04-partrole.yaml
+++ b/src/edistributions/unreleased/examples/ElectronicDistribution-04-partrole.yaml
@@ -4,11 +4,14 @@
 # for two different distribution parts (i.e. files in a directory).
 # One is a plain script, and the other an executable file.
 pid: https://example.org/20b330286682a772021c75f59fdbde07155773bb
-indexed_parts:
+qualified_relations:
   # a directory
-  run-me.sh: https://example.org/133a6ad2ca7ba8adb54b95ba204f20cfabfcba98
-  run-me:
-    resource: https://example.org/133a6ad2ca7ba8adb54b95ba204f20cfabfcba98
+  - schema_type: dlres:IndexedResourcePart
+    locator: run-me.sh
+    object: https://example.org/133a6ad2ca7ba8adb54b95ba204f20cfabfcba98
+  - schema_type: dlres:IndexedResourcePart
+    locator: run-me
+    object: https://example.org/133a6ad2ca7ba8adb54b95ba204f20cfabfcba98
     roles:
       # executable file
       - obo:ONTOAVIDA_00000002

--- a/src/prov/unreleased/examples/Agent-03-relations.json
+++ b/src/prov/unreleased/examples/Agent-03-relations.json
@@ -1,13 +1,14 @@
 {
   "pid": "ex:ns/people/jane",
   "schema_type": "dlprov:Agent",
-  "qualified_relations": {
-    "geo:-19.738897,63.453072?z=19": {
+  "qualified_relations": [
+    {
       "object": "geo:-19.738897,63.453072?z=19",
       "roles": [
         "obo:NCIT_C17556"
-      ]
+      ],
+      "schema_type": "dlroles:Relationship"
     }
-  },
+  ],
   "@type": "Agent"
 }

--- a/src/prov/unreleased/examples/Agent-03-relations.yaml
+++ b/src/prov/unreleased/examples/Agent-03-relations.yaml
@@ -3,7 +3,7 @@
 pid: ex:ns/people/jane
 qualified_relations:
   # using a GEO URI as a location identifier
-  geo:-19.738897,63.453072?z=19:
+  - object: geo:-19.738897,63.453072?z=19
     roles:
       # worksite
       - obo:NCIT_C17556

--- a/src/publications/unreleased/examples/Publication-02-linkage.json
+++ b/src/publications/unreleased/examples/Publication-02-linkage.json
@@ -9,68 +9,75 @@
       "schema_agency": "DOI Foundation"
     }
   ],
-  "qualified_relations": {
-    "https://orcid.org/0000-0003-2917-3450": {
+  "qualified_relations": [
+    {
+      "object": "https://issn.org/resource/issn/2052-4463",
+      "roles": [
+        "marcrel:pup"
+      ],
+      "schema_type": "dlres:IndexedResourcePart",
+      "locator": "9, 80"
+    },
+    {
       "object": "https://orcid.org/0000-0003-2917-3450",
       "roles": [
         "marcrel:aut",
         "obo:NCIT_C25461",
         "obo:MS_1002034"
-      ]
+      ],
+      "schema_type": "dlroles:Relationship"
     },
-    "https://orcid.org/0000-0003-2213-7465": {
+    {
       "object": "https://orcid.org/0000-0003-2213-7465",
       "roles": [
         "marcrel:aut",
         "obo:MS_1002034"
-      ]
+      ],
+      "schema_type": "dlroles:Relationship"
     },
-    "https://orcid.org/0000-0003-0820-2662": {
+    {
       "object": "https://orcid.org/0000-0003-0820-2662",
       "roles": [
         "marcrel:aut",
         "obo:MS_1002034"
-      ]
+      ],
+      "schema_type": "dlroles:Relationship"
     },
-    "https://orcid.org/0000-0001-7163-3110": {
+    {
       "object": "https://orcid.org/0000-0001-7163-3110",
       "roles": [
         "marcrel:aut"
-      ]
+      ],
+      "schema_type": "dlroles:Relationship"
     },
-    "https://orcid.org/0000-0002-8402-6173": {
+    {
       "object": "https://orcid.org/0000-0002-8402-6173",
       "roles": [
         "marcrel:aut"
-      ]
+      ],
+      "schema_type": "dlroles:Relationship"
     },
-    "https://orcid.org/0000-0001-7628-0801": {
+    {
       "object": "https://orcid.org/0000-0001-7628-0801",
       "roles": [
         "marcrel:aut"
-      ]
+      ],
+      "schema_type": "dlroles:Relationship"
     },
-    "https://orcid.org/0000-0001-6363-2759": {
+    {
       "object": "https://orcid.org/0000-0001-6363-2759",
       "roles": [
         "marcrel:aut"
-      ]
+      ],
+      "schema_type": "dlroles:Relationship"
     },
-    "https://orcid.org/0000-0001-6398-6370": {
+    {
       "object": "https://orcid.org/0000-0001-6398-6370",
       "roles": [
         "marcrel:aut",
         "obo:MS_1002035"
-      ]
-    }
-  },
-  "indexed_part_of": [
-    {
-      "locator": "9, 80",
-      "resource": "https://issn.org/resource/issn/2052-4463",
-      "roles": [
-        "marcrel:pup"
-      ]
+      ],
+      "schema_type": "dlroles:Relationship"
     }
   ],
   "@type": "Publication"

--- a/src/publications/unreleased/examples/Publication-02-linkage.yaml
+++ b/src/publications/unreleased/examples/Publication-02-linkage.yaml
@@ -2,17 +2,17 @@ pid: https://doi.org/10.1038/s41597-022-01163-2
 identifiers:
   - schema_type: dlidentifiers:DOI
     notation: 10.1038/s41597-022-01163-2
-indexed_part_of:
+qualified_relations:
   # scientific data
-  - resource: https://issn.org/resource/issn/2052-4463
+  - schema_type: dlres:IndexedResourcePart
+    object: https://issn.org/resource/issn/2052-4463
     locator: "9, 80"
     roles:
       # publication place
       - marcrel:pup
-qualified_relations:
   # agent roles
   # adina
-  https://orcid.org/0000-0003-2917-3450:
+  - object: https://orcid.org/0000-0003-2917-3450
     roles:
       # author
       - marcrel:aut
@@ -21,33 +21,33 @@ qualified_relations:
       # first author
       - obo:MS_1002034
   # laura
-  https://orcid.org/0000-0003-2213-7465:
+  - object: https://orcid.org/0000-0003-2213-7465
     roles:
       - marcrel:aut
       - obo:MS_1002034
   # małgorzata
-  https://orcid.org/0000-0003-0820-2662:
+  - object: https://orcid.org/0000-0003-0820-2662
     roles:
       - marcrel:aut
       - obo:MS_1002034
   # felix
-  https://orcid.org/0000-0001-7163-3110:
+  - object: https://orcid.org/0000-0001-7163-3110
     roles:
       - marcrel:aut
   # alex
-  https://orcid.org/0000-0002-8402-6173:
+  - object: https://orcid.org/0000-0002-8402-6173
     roles:
       - marcrel:aut
   # benjamin
-  https://orcid.org/0000-0001-7628-0801:
+  - object: https://orcid.org/0000-0001-7628-0801
     roles:
       - marcrel:aut
   # simon
-  https://orcid.org/0000-0001-6363-2759:
+  - object: https://orcid.org/0000-0001-6363-2759
     roles:
       - marcrel:aut
   # michael
-  https://orcid.org/0000-0001-6398-6370:
+  - object: https://orcid.org/0000-0001-6398-6370
     roles:
       - marcrel:aut
       # senior author

--- a/src/resources/unreleased.yaml
+++ b/src/resources/unreleased.yaml
@@ -105,31 +105,6 @@ slots:
       - sio:SIO_000426
     inverse: distributions
 
-  indexed_parts:
-    slot_uri: dlres:indexed_parts
-    description: >-
-      A qualified relation that assigns an index `locator` to a resource within the
-      context of a `hasPart` relationship with a subject (the containing
-      resource).
-    range: IndexedResourcePart
-    multivalued: true
-    inlined: true
-    broad_mappings:
-      - dcat:qualifiedRelation
-
-  indexed_part_of:
-    slot_uri: dlres:indexed_part_of
-    description: >-
-      A qualified relation that assigns an index `locator` to a resource within the
-      context of an `isPartOf` relationship with a subject (the contained
-      resource).
-    range: IndexedResourcePartOf
-    multivalued: true
-    inlined: true
-    inlined_as_list: true
-    broad_mappings:
-      - dcat:qualifiedRelation
-
   locator:
     slot_uri: dlres:locator
     description: >-
@@ -147,14 +122,6 @@ slots:
     exact_mappings:
       - dcat:previousVersion
       - pav:previousVersion
-
-  resource:
-    slot_uri: dlres:resource
-    description: >-
-      Property referencing a resource within an indexed-part or indexed-part-of
-      qualified relationship.
-    range: Resource
-    inlined: false
 
   sponsor:
     slot_uri: dlres:sponsor
@@ -198,8 +165,6 @@ classes:
       - conforms_to
       - date_modified
       - date_published
-      - indexed_parts
-      - indexed_part_of
       - keywords
       - previous_version
       - same_as
@@ -300,24 +265,24 @@ classes:
       - schema:Grant
 
   IndexedResourceRelationship:
+    is_a: Relationship
     description: >-
-      An association class for attaching a `name` as additional information to a
+      An association class for attaching a `locator` as additional information to a
       `hasPart` relationship.
     slots:
       - locator
-      - resource
-      - roles
+    slot_usage:
+      locator:
+        key: true
+      object:
+        required: true
+        range: Resource
 
   IndexedResourcePart:
     is_a: IndexedResourceRelationship
     description: >-
       An association class for attaching an index `locator` as additional information to a
       `hasPart` relationship.
-    slot_usage:
-      locator:
-        key: true
-      resource:
-        required: true
 
   IndexedResourcePartOf:
     is_a: IndexedResourceRelationship

--- a/src/resources/unreleased/examples/Dataset-03-license.json
+++ b/src/resources/unreleased/examples/Dataset-03-license.json
@@ -8,13 +8,14 @@
     }
   },
   "schema_type": "dlres:Dataset",
-  "qualified_relations": {
-    "https://spdx.org/licenses/CC-BY-4.0": {
+  "qualified_relations": [
+    {
       "object": "https://spdx.org/licenses/CC-BY-4.0",
       "roles": [
         "dcterms:LicenseDocument"
-      ]
+      ],
+      "schema_type": "dlroles:Relationship"
     }
-  },
+  ],
   "@type": "Dataset"
 }

--- a/src/resources/unreleased/examples/Dataset-03-license.yaml
+++ b/src/resources/unreleased/examples/Dataset-03-license.yaml
@@ -4,6 +4,6 @@ relations:
     schema_type: dlres:Document
     short_name: CC-BY-4.0
 qualified_relations:
-  https://spdx.org/licenses/CC-BY-4.0:
+  - object: https://spdx.org/licenses/CC-BY-4.0
     roles:
       - dcterms:LicenseDocument

--- a/src/resources/unreleased/examples/Resource-02-parts.json
+++ b/src/resources/unreleased/examples/Resource-02-parts.json
@@ -1,15 +1,17 @@
 {
   "pid": "ex:directory1",
   "schema_type": "dlres:Resource",
-  "indexed_parts": {
-    "file1.txt": {
-      "locator": "file1.txt",
-      "resource": "ex:file1"
+  "qualified_relations": [
+    {
+      "object": "ex:file1",
+      "schema_type": "dlres:IndexedResourcePart",
+      "locator": "file1.txt"
     },
-    "subdirectory": {
-      "locator": "subdirectory",
-      "resource": "ex:directory2"
+    {
+      "object": "ex:directory2",
+      "schema_type": "dlres:IndexedResourcePart",
+      "locator": "subdirectory"
     }
-  },
+  ],
   "@type": "Resource"
 }

--- a/src/resources/unreleased/examples/Resource-02-parts.yaml
+++ b/src/resources/unreleased/examples/Resource-02-parts.yaml
@@ -2,6 +2,10 @@
 # that can be used to locate the part within the containing
 # resource
 pid: ex:directory1
-indexed_parts:
-  file1.txt: ex:file1
-  subdirectory: ex:directory2
+qualified_relations:
+  - schema_type: dlres:IndexedResourcePart
+    locator: file1.txt
+    object: ex:file1
+  - schema_type: dlres:IndexedResourcePart
+    locator: subdirectory
+    object: ex:directory2

--- a/src/resources/unreleased/examples/Resource-03-partof.json
+++ b/src/resources/unreleased/examples/Resource-03-partof.json
@@ -1,10 +1,11 @@
 {
   "pid": "https://doi.org/10.21105/joss.03262",
   "schema_type": "dlres:Resource",
-  "indexed_part_of": [
+  "qualified_relations": [
     {
-      "locator": "6(63), 3262",
-      "resource": "https://issn.org/resource/ISSN/2475-9066"
+      "object": "https://issn.org/resource/ISSN/2475-9066",
+      "schema_type": "dlres:IndexedResourcePartOf",
+      "locator": "6(63), 3262"
     }
   ],
   "@type": "Resource"

--- a/src/resources/unreleased/examples/Resource-03-partof.yaml
+++ b/src/resources/unreleased/examples/Resource-03-partof.yaml
@@ -2,6 +2,7 @@
 # including an identifier that enables locating the resource
 # within the containing resource.
 pid: https://doi.org/10.21105/joss.03262
-indexed_part_of:
-  - resource: https://issn.org/resource/ISSN/2475-9066
+qualified_relations:
+  - schema_type: dlres:IndexedResourcePartOf
+    object: https://issn.org/resource/ISSN/2475-9066
     locator: "6(63), 3262"

--- a/src/roles/unreleased.yaml
+++ b/src/roles/unreleased.yaml
@@ -84,6 +84,7 @@ slots:
     domain: Thing
     range: Relationship
     inlined: true
+    inlined_as_list: true
     multivalued: true
     exact_mappings:
       - dcat:qualifiedRelation
@@ -111,13 +112,11 @@ classes:
     slots:
       - object
       - roles
+      - schema_type
     slot_usage:
-      roles:
-        required: true
       object:
         required: true
-        key: true
-        range: uriorcurie
+        range: Thing
     close_mappings:
       - prov:Influence
       - dcat:Relationship

--- a/src/roles/unreleased/examples/Relationship-01-topic.json
+++ b/src/roles/unreleased/examples/Relationship-01-topic.json
@@ -3,5 +3,6 @@
   "roles": [
     "http://purl.obolibrary.org/obo/topic_0003"
   ],
+  "schema_type": "dlroles:Relationship",
   "@type": "Relationship"
 }

--- a/src/roles/unreleased/examples/Relationship-02-author.json
+++ b/src/roles/unreleased/examples/Relationship-02-author.json
@@ -4,5 +4,6 @@
     "marcrel:aut",
     "marcrel:sad"
   ],
+  "schema_type": "dlroles:Relationship",
   "@type": "Relationship"
 }

--- a/src/social/unreleased/examples/Group-03-members.json
+++ b/src/social/unreleased/examples/Group-03-members.json
@@ -1,13 +1,22 @@
 {
   "pid": "https://example.com/vips",
   "schema_type": "dlsocial:Group",
-  "qualified_relations": {
-    "https://orcid.org/0000-0002-9079-593X": {
+  "qualified_relations": [
+    {
       "object": "https://orcid.org/0000-0002-9079-593X",
       "roles": [
         "obo:NCIT_C25368"
-      ]
+      ],
+      "schema_type": "dlroles:Relationship"
+    },
+    {
+      "object": "https://scholar.google.com/citations?user=8qD8mxQAAAAJ",
+      "roles": [
+        "obo:NCIT_C25368"
+      ],
+      "schema_type": "dltemporal:TransientRelationship",
+      "ended_at": "20220414"
     }
-  },
+  ],
   "@type": "Group"
 }

--- a/src/social/unreleased/examples/Group-03-members.yaml
+++ b/src/social/unreleased/examples/Group-03-members.yaml
@@ -1,7 +1,13 @@
 pid: https://example.com/vips
 qualified_relations:
   # Stephen Hawkin
-  https://orcid.org/0000-0002-9079-593X:
+  - object: https://orcid.org/0000-0002-9079-593X
     roles:
       # member
       - obo:NCIT_C25368
+  - schema_type: dltemporal:TransientRelationship
+    object: https://scholar.google.com/citations?user=8qD8mxQAAAAJ
+    roles:
+      # member
+      - obo:NCIT_C25368
+    ended_at: "20220414"

--- a/src/social/unreleased/examples/Organization-03-relations.json
+++ b/src/social/unreleased/examples/Organization-03-relations.json
@@ -1,13 +1,14 @@
 {
   "pid": "https://trr379.de",
   "schema_type": "dlsocial:Organization",
-  "qualified_relations": {
-    "https://ror.org/018mejw64": {
+  "qualified_relations": [
+    {
       "object": "https://ror.org/018mejw64",
       "roles": [
         "marcrel:fnd"
-      ]
+      ],
+      "schema_type": "dlroles:Relationship"
     }
-  },
+  ],
   "@type": "Organization"
 }

--- a/src/social/unreleased/examples/Organization-03-relations.yaml
+++ b/src/social/unreleased/examples/Organization-03-relations.yaml
@@ -1,6 +1,6 @@
 pid: https://trr379.de
 qualified_relations:
   # DFG is a funder
-  https://ror.org/018mejw64:
+  - object: https://ror.org/018mejw64
     roles:
       - marcrel:fnd

--- a/src/social/unreleased/examples/Person-03-relations.json
+++ b/src/social/unreleased/examples/Person-03-relations.json
@@ -1,19 +1,21 @@
 {
   "pid": "ex:ns/people/jane",
   "schema_type": "dlsocial:Person",
-  "qualified_relations": {
-    "email:jane@example.org": {
+  "qualified_relations": [
+    {
       "object": "email:jane@example.org",
       "roles": [
         "http://schema.org/email"
-      ]
+      ],
+      "schema_type": "dlroles:Relationship"
     },
-    "geo:-19.738897,63.453072?z=19": {
+    {
       "object": "geo:-19.738897,63.453072?z=19",
       "roles": [
         "obo:NCIT_C17556"
-      ]
+      ],
+      "schema_type": "dlroles:Relationship"
     }
-  },
+  ],
   "@type": "Person"
 }

--- a/src/social/unreleased/examples/Person-03-relations.yaml
+++ b/src/social/unreleased/examples/Person-03-relations.yaml
@@ -4,11 +4,11 @@
 # use of GEO URIs as identifiers for locations
 pid: ex:ns/people/jane
 qualified_relations:
-  email:jane@example.org:
+  - object: email:jane@example.org
     roles:
       - http://schema.org/email
   # using a GEO URI as a location identifier
-  geo:-19.738897,63.453072?z=19:
+  - object: geo:-19.738897,63.453072?z=19
     roles:
       # worksite
       - obo:NCIT_C17556

--- a/src/social/unreleased/examples/Project-03-relations.json
+++ b/src/social/unreleased/examples/Project-03-relations.json
@@ -7,14 +7,15 @@
     }
   ],
   "schema_type": "dlsocial:Project",
-  "qualified_relations": {
-    "http://orcid.org/0000-0001-6398-6370": {
+  "qualified_relations": [
+    {
       "object": "http://orcid.org/0000-0001-6398-6370",
       "roles": [
         "marcrel:ctb"
-      ]
+      ],
+      "schema_type": "dlroles:Relationship"
     }
-  },
+  ],
   "associated_with": [
     "http://orcid.org/0000-0001-6398-6370"
   ],

--- a/src/social/unreleased/examples/Project-03-relations.yaml
+++ b/src/social/unreleased/examples/Project-03-relations.yaml
@@ -7,7 +7,7 @@ characterized_by:
 associated_with:
   - http://orcid.org/0000-0001-6398-6370
 qualified_relations:
-  http://orcid.org/0000-0001-6398-6370:
+  - object: http://orcid.org/0000-0001-6398-6370
     roles:
       # contributor
       - marcrel:ctb

--- a/src/temporal/unreleased.yaml
+++ b/src/temporal/unreleased.yaml
@@ -136,6 +136,7 @@ slots:
 
 classes:
   InstantaneousEvent:
+    class_uri: dltemporal:InstantaneousEvent
     is_a: Thing
     description: >-
       A moment of a transition from one particular state of the world to another.
@@ -145,3 +146,12 @@ classes:
       - qualified_relations
     exact_mappings:
       - prov:InstantaneousEvent
+
+  TransientRelationship:
+    class_uri: dltemporal:TransientRelationship
+    is_a: Relationship
+    description: >-
+      A relationship that is valid or remains in place for a limited time.
+    slots:
+      - started_at
+      - ended_at

--- a/src/things/unreleased.yaml
+++ b/src/things/unreleased.yaml
@@ -128,10 +128,12 @@ slots:
   description:
     slot_uri: dlthings:description
     description: A free-text account of the subject.
+    range: string
     exact_mappings:
       - dcterms:description
       - rdfs:comment
-    range: string
+    broad_mappings:
+      - obo:IAO_0000300
 
   exact_mappings:
     slot_uri: skos:exactMatch
@@ -206,10 +208,13 @@ slots:
     range: Annotation
     inlined: true
     multivalued: true
+    exact_mappings:
+      - obo:NCIT_C44272
+
 
   annotation_tag:
     description: A tag identifying an annotation.
-    range: uriorcurie
+    range: Thing
 
   annotation_value:
     description: The actual annotation.
@@ -228,16 +233,15 @@ slots:
     slot_uri: rdf:object
     description: >-
       Reference to a `Thing` within a `Statement`.
-    range: uriorcurie
     inlined: false
     multivalued: false
     relational_role: OBJECT
     exact_mappings:
       - rdf:object
     notes:
-      - The `range` is `uriorcurie` here (and not `Thing`), because
-        we have an undetermined issue with linkml not accepting such
-        a range.
+      - We do not declare a range here to be able to tighten the range in
+        subclasses of class that need a particular range. This appears to
+        be working around a linkml limitation.
 
   predicate:
     slot_uri: rdf:predicate
@@ -372,6 +376,7 @@ classes:
     slot_usage:
       object:
         required: true
+        range: Thing
       predicate:
         required: true
     exact_mappings:

--- a/src/things/v1.yaml
+++ b/src/things/v1.yaml
@@ -236,16 +236,15 @@ slots:
     slot_uri: rdf:object
     description: >-
       Reference to a `Thing` within a `Statement`.
-    range: uriorcurie
     inlined: false
     multivalued: false
     relational_role: OBJECT
     exact_mappings:
       - rdf:object
     notes:
-      - The `range` is `uriorcurie` here (and not `Thing`), because
-        we have an undetermined issue with linkml not accepting such
-        a range.
+      - We do not declare a range here to be able to tighten the range in
+        subclasses of class that need a particular range. This appears to
+        be working around a linkml limitation.
 
   predicate:
     slot_uri: rdf:predicate
@@ -380,6 +379,7 @@ classes:
     slot_usage:
       object:
         required: true
+        range: Thing
       predicate:
         required: true
     exact_mappings:


### PR DESCRIPTION
The most important change here is that `Relationship` now supports the `schema_type` type designator slot. This enables declaring particular and different relationship types via `qualified_relations`.

This made it necessary to switch `qualified_relations` from a key-based inlining setup to inlining as a list, because now multiple different relationship types could be possible between the same two `Thing` instances.

As part of this effort, the range of the `Relationship` (and `Statement`) slot `object` has been change to `Thing` (from `uriorcurie`). This involved no declaring a range in the actual `slot` definition -- seemingly working around a linkml limitation.

The possibility to express different relationship types via `qualified_relations` made it possible to remove the slots `indexed_parts` and `indexed_part_of` from `Resource`, by making `IndexedResourcePart` and `IndexedResourcePartOf` proper subclasses of `Relationship`. The, now redundant, `resource` slot was removed, and the range of `object` adjusted to be `Resource` in these subclasses to maintain the specificity of validation.

A `TransientRelationship` class was added to the `temporal` schema component. This can be used to express temporary or time limited relationship, such as a group membership for a particular time window.

This appears to be a more broadly applicable approach than defining individual concepts (e.g., `Membership`) that are themselves modeled to be temporally constrained.

Multiplexing all these semantics onto `qualified_relations` makes the respective expressions a bit more verbose (in comparison to the very compact key-value expression that was possible with `indexed_parts`. But the counter-force to further proliferation of means of expressing the same things appears to be overall positive.

Closes: https://github.com/psychoinformatics-de/datalad-concepts/issues/288