### PR TITLE
Present `description` as a multi-line field by default

### DIFF
--- a/src/things/unreleased.yaml
+++ b/src/things/unreleased.yaml
@@ -51,6 +51,8 @@ license: MIT
 prefixes:
   # here for alignment of `pid`
   ADMS: http://www.w3.org/ns/adms#
+  # SHACL annotations
+  dash: http://datashapes.org/dash#
   # primarily for the examples, but also a foundational vocab
   bibo: http://purl.org/ontology/bibo/
   # here for alignment of `relations`
@@ -134,6 +136,8 @@ slots:
       - rdfs:comment
     broad_mappings:
       - obo:IAO_0000300
+    annotations:
+      dash:singleLine: false
 
   exact_mappings:
     slot_uri: skos:exactMatch

--- a/src/things/v1.yaml
+++ b/src/things/v1.yaml
@@ -54,6 +54,8 @@ license: MIT
 prefixes:
   # here for alignment of `pid`
   ADMS: http://www.w3.org/ns/adms#
+  # SHACL annotations
+  dash: http://datashapes.org/dash#
   # primarily for the examples, but also a foundational vocab
   bibo: http://purl.org/ontology/bibo/
   # here for alignment of `relations`
@@ -137,6 +139,8 @@ slots:
       - rdfs:comment
     broad_mappings:
       - obo:IAO_0000300
+    annotations:
+      dash:singleLine: false
 
   exact_mappings:
     slot_uri: skos:exactMatch


### PR DESCRIPTION
This could be overwritten in any class. But I do think it makes sense as a default.