### PR TITLE
Update patch to fix faulty shaclgen export of `sh:order`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,10 @@ build/linkml-docs/s/%: src/%.yaml src/%/extra-docs
 		--mergeimports \
 		$< > $@.context.jsonld
 	# SHACL with annotation needed to build UI specs
+	# and excluding automatic addition of sh:order
 	gen-shacl \
 		--include-annotations \
+		--exclude-order \
 		$< > $@.shacl.ttl
 
 build/mkdocs-site: build/linkml-docs extra-docs/*.md

--- a/patches/shaclgen_annotations.diff
+++ b/patches/shaclgen_annotations.diff
@@ -1,36 +1,63 @@
-This patches shaclgen.py to allow improved handling of slot annotations.
-Firstly, it prevents creation of faulty sh:order lists by prioritizing sh:order provided
-via annotation, since sh:order should just be a single numerical value.
-See for context: https://github.com/linkml/linkml/pull/2111#issuecomment-2116208229
-Secondly, and for a similar reason, it only sets sh:path automatically if the
+This patches shaclgen.py to allow improved handling of slot annotations and sh:order.
+Firstly, it introduces the --exclude-order flag that allows to completely disable the
+automatic assignment of the sh:order field to exported property shapes. See:
+https://github.com/psychoinformatics-de/shacl-vue/issues/107#issuecomment-2866073117
+Secondly, if the --exclude-order flag is not used, the patch prevents creation of faulty
+sh:order lists by prioritizing sh:order provided via annotation, since sh:order should
+just be a single numerical value. See for context:
+https://github.com/linkml/linkml/pull/2111#issuecomment-2116208229
+Lastlt, and for a similar reason as before, it only sets sh:path automatically if the
 value has not already been set via annotation.
 --- shaclgen.py
 +++ shaclgen.py
-@@ -111,9 +111,7 @@ class ShaclGenerator(Generator):
-                     if v is not None:
+@@ -30,6 +30,8 @@ class ShaclGenerator(Generator):
+     """parameterized suffix to be appended. No suffix per default."""
+     include_annotations: bool = False
+     """True means include all class / slot / type annotations in generated Node or Property shapes"""
++    exclude_order: bool = False
++    """True means exclude the automatic addition of sh:order to Property shapes"""
+     exclude_imports: bool = False
+     """If True, elements from imported ontologies won't be included in the generator's output"""
+     generatorname = os.path.basename(__file__)
+@@ -114,8 +116,6 @@ class ShaclGenerator(Generator):
                          g.add((pnode, p, Literal(v)))
-
--                prop_pv(SH.path, slot_uri)
+ 
+                 prop_pv(SH.path, slot_uri)
 -                prop_pv_literal(SH.order, order)
 -                order += 1
-+                # prop_pv(SH.path, slot_uri)
                  prop_pv_literal(SH.name, s.title)
                  prop_pv_literal(SH.description, s.description)
                  # minCount
-@@ -221,6 +219,16 @@ class ShaclGenerator(Generator):
+@@ -223,6 +223,18 @@ class ShaclGenerator(Generator):
                  default_value = ifabsent_processor.process_slot(s, c)
                  if default_value:
                      prop_pv(SH.defaultValue, default_value)
-+
-+                # sh:order may already have been added to the graph via annotations
-+                if not (pnode, SH.order, None) in g:
-+                    prop_pv_literal(SH.order, order)
-+                    order += 1
-+
++                
++                # Add the order automatically unless the --exclude-order flag was supplied
++                if not self.exclude_order:
++                    # sh:order may already have been added to the graph via annotations
++                    if not (pnode, SH.order, None) in g:
++                        prop_pv_literal(SH.order, order)
++                        order += 1
++                
 +                # sh:path may already have been added to the graph via annotations
 +                if not (pnode, SH.path, None) in g:
 +                    prop_pv(SH.path, slot_uri)
-+
-
++                
+ 
          return g
  
+@@ -366,6 +378,13 @@ def add_simple_data_type(func: Callable, r: ElementName) -> None:
+     show_default=True,
+     help="Use --include-annotations to include annotations of slots, types, and classes in the generated SHACL shapes.",
+ )
++@click.option(
++    "--exclude-order/--include-order",
++    default=False,
++    show_default=True,
++    help="Use --exclude-order to exclude sh:order from being added automatically to generated SHACL property shapes. "
++    "Default behavior adds order. This flag has no influence on sh:order being added via annotations.",
++)
+ @click.option(
+     "--exclude-imports/--include-imports",
+     default=False,


### PR DESCRIPTION
See https://github.com/psychoinformatics-de/shacl-vue/issues/107.

The updated patch allows switching off the automatic generation of the sh:order field for a property shape, by using the new `--exclude-order` flag.