### PR TITLE
Add patch to fix `_normalize_inlined()`

### DIFF
--- a/patches/linkml_runtime_utils_yamlutils.diff
+++ b/patches/linkml_runtime_utils_yamlutils.diff
@@ -1,0 +1,29 @@
+This patch has been proposed for inclusion in linkml-runtime
+in https://github.com/linkml/linkml-runtime/pull/392
+
+
+fix type instantiation in _normalize_inlined
+    
+This commit fixes a problem that was discovered while
+converting between TTL and JSON using the schema
+https://concepts.inm7.de/s/simpleinput/unreleased.yaml
+    
+The original code used a dictionary as argument to
+the constructor of a pydantic-class, when it should
+have used the **-operator to cnvert the dictionary
+into keyword arguments.
+
+diff --git a/linkml_runtime/utils/yamlutils.py b/linkml_runtime/utils/yamlutils.py
+index 8ca8b30..d309091 100644
+--- a/linkml_runtime/utils/yamlutils.py
++++ b/linkml_runtime/utils/yamlutils.py
+@@ -169,7 +169,7 @@ class YAMLRoot(JsonObj):
+                         for lek, lev in items(list_entry):
+                             if lek == key_name and not isinstance(lev, (list, dict, JsonObj)):
+                                 # key_name:value
+-                                order_up(list_entry[lek], slot_type(list_entry))
++                                order_up(list_entry[lek], slot_type(**list_entry))
+                                 break   # Not strictly necessary, but
+                             elif not isinstance(lev, (list, dict, JsonObj)):
+                                 # key: value --> slot_type(key, value)
+

--- a/tools/patch_linkml
+++ b/tools/patch_linkml
@@ -14,3 +14,5 @@ patch -d $(python -c 'import os; import linkml.generators.shaclgen as m; print(o
 patch -d $(python -c 'import os; import linkml.generators.shacl.shacl_ifabsent_processor as m; print(os.path.dirname(m.__file__))') < patches/shacl_ifabsent.diff
 # Honor type-designator slots when loading graphs
 patch -d $(python -c 'import os; import linkml_runtime.loaders as m; print(os.path.dirname(m.__file__))') < patches/rdflib_loader_typedesignator.diff
+# Use correct constructor arguments when normalizing inlined objects
+patch -d $(python -c 'import os; import linkml_runtime.utils.yamlutils as m; print(os.path.dirname(m.__file__))') < patches/linkml_runtime_utils_yamlutils.diff


### PR DESCRIPTION
This PR adds a patch that fixes a problem that was discovered while converting between JSON non-empty `relations` to TTL using the schema <https://concepts.inm7.de/s/simpleinput/unreleased.yaml>.

The original code used a dictionary as the argument to the constructor of a Pydantic class, when it should have used the **-operator to convert the dictionary into keyword arguments.

This patch has been proposed for inclusion in linkml-runtime
in <https://github.com/linkml/linkml-runtime/pull/392>.