### PR TITLE
Add patch to use `&` to separated implemented interfaces in graphql-schema definitions

### DIFF
--- a/patches/graphqlgen_interface_list.diff
+++ b/patches/graphqlgen_interface_list.diff
@@ -1,0 +1,13 @@
+diff --git a/linkml/generators/graphqlgen.py b/linkml/generators/graphqlgen.py
+index 72da3770..bce294a5 100644
+--- a/linkml/generators/graphqlgen.py
++++ b/linkml/generators/graphqlgen.py
+@@ -40,7 +40,7 @@ class GraphqlGenerator(Generator):
+
+     def visit_class(self, cls: ClassDefinition) -> str:
+         etype = "interface" if (cls.abstract or cls.mixin) and not cls.mixins else "type"
+-        mixins = ", ".join([camelcase(mixin) for mixin in cls.mixins])
++        mixins = " & ".join([camelcase(mixin) for mixin in cls.mixins])
+         out = f"{etype} {camelcase(cls.name)}" + (f" implements {mixins}" if mixins else "")
+         out = "\n".join([out, "  {"])
+         return out

--- a/tools/patch_linkml
+++ b/tools/patch_linkml
@@ -16,3 +16,5 @@ patch -d $(python -c 'import os; import linkml.generators.shacl.shacl_ifabsent_p
 patch -d $(python -c 'import os; import linkml_runtime.loaders as m; print(os.path.dirname(m.__file__))') < patches/rdflib_loader_typedesignator.diff
 # Use correct constructor arguments when normalizing inlined objects
 patch -d $(python -c 'import os; import linkml_runtime.utils.yamlutils as m; print(os.path.dirname(m.__file__))') < patches/linkml_runtime_utils_yamlutils.diff
+# Use `&` to separate multiple interfaces in graphql schemas
+patch -d $(python -c 'import os; import linkml.generators.graphqlgen as m; print(os.path.dirname(m.__file__))') < patches/graphqlgen_interface_list.diff


### PR DESCRIPTION
This PR adds a patch that modifies linkml's graphql-generator to use '&' instead of `,` to separate interfaces in the generated GraphQL schema.
