### PR TITLE
ci: don't check invalid examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ check-validation: \
 	convertexamples/edistributions/unreleased \
 	checkvalidation/edistributions/unreleased
 checkvalidation/%:
-	$(MAKE) checkvalid/$* checkinvalid/$*
+	$(MAKE) checkvalid/$* #checkinvalid/$*
 checkvalid/%: src/%/validation src/%.yaml
 	@for ex in $</*.valid.cfg.yaml; do \
 		echo "Validate $$ex" ; \


### PR DESCRIPTION
there are no configurations for invalid examples and this - so far - only causes clutter. It can be commented back in when there are invalid configurations in place.