### PR TITLE
Introduce `Organization` in flat-social

### DIFF
--- a/src/flat-social/unreleased.yaml
+++ b/src/flat-social/unreleased.yaml
@@ -63,8 +63,34 @@ emit_prefixes:
 imports:
   - dlschemas:flat/unreleased
   - dlschemas:social-mixin/unreleased
+  - dlschemas:spatial-mixin/unreleased
 
 classes:
+  Organization:
+    is_a: FlatThing
+    description: >-
+      A social or legal institution such as a company, a society, or a university.
+    slots:
+      - name
+      - short_name
+      - at_location
+    slot_usage:
+      name:
+        annotations:
+          sh:order: 1
+      short_name:
+        annotations:
+          sh:order: 2
+      at_location:
+        range: Thing
+        comments:
+          - Derived classes can spezialize the range to the desired type.
+        annotations:
+          sh:order: 3
+    exact_mappings:
+      - prov:Organization
+
+
   Person:
     is_a: FlatThing
     description: >-

--- a/src/flat-social/unreleased/examples/Organization-02-attributes.json
+++ b/src/flat-social/unreleased/examples/Organization-02-attributes.json
@@ -1,0 +1,8 @@
+{
+  "pid": "https://ror.org/02nv7yv05",
+  "schema_type": "dlflatsocial:Organization",
+  "name": "Forschungszentrum Jülich",
+  "short_name": "FZJ",
+  "at_location": "https://sws.geonames.org/6557321",
+  "@type": "Organization"
+}

--- a/src/flat-social/unreleased/examples/Organization-02-attributes.yaml
+++ b/src/flat-social/unreleased/examples/Organization-02-attributes.yaml
@@ -1,0 +1,4 @@
+pid: https://ror.org/02nv7yv05
+name: Forschungszentrum Jülich
+short_name: FZJ
+at_location: https://sws.geonames.org/6557321

--- a/src/flat-social/unreleased/examples/Person-01-minimal.json
+++ b/src/flat-social/unreleased/examples/Person-01-minimal.json
@@ -1,0 +1,5 @@
+{
+  "pid": "http://orcid.org/0000-0001-7628-0801",
+  "schema_type": "dlflatsocial:Person",
+  "@type": "Person"
+}

--- a/src/flat-social/unreleased/examples/Person-02-attributes.json
+++ b/src/flat-social/unreleased/examples/Person-02-attributes.json
@@ -1,0 +1,7 @@
+{
+  "pid": "https://orcid.org/0000-0001-6398-6370",
+  "schema_type": "dlflatsocial:Person",
+  "family_name": "Hanke",
+  "given_name": "Michael",
+  "@type": "Person"
+}

--- a/src/flat-social/unreleased/validation/Organization.valid.cfg.yaml
+++ b/src/flat-social/unreleased/validation/Organization.valid.cfg.yaml
@@ -1,0 +1,9 @@
+schema: src/flat-social/unreleased.yaml
+target_class: Organization
+data_sources:
+  - src/flat-social/unreleased/examples/Organization-02-attributes.yaml
+plugins:
+  JsonschemaValidationPlugin:
+    closed: true
+    include_range_class_descendants: false
+  RecommendedSlotsPlugin:


### PR DESCRIPTION
This is the first example of an attempt to maximize orthogonality of the flat schemas. Only the plain slot `at_location` is taken from `spatial-mixin`. No range for it is defined there. This is only done in `flat-social`. But here again, no real "spatial" range is declared. Instead only `Thing` is used.

The idea is that consuming application schemas will want to flexibly use specific types (say `City`). Trying to define all possible type of this kind would blow things up needlessly. `Thing` works, because everything is a `Thing` in the end, and a GEO URL (`geo:...`) is a sufficient PID for a `Thing` also.