### PR TITLE
ci: avoid calling linkml validate with absent config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,14 +147,14 @@ check-validation: \
 	convertexamples/edistributions/unreleased \
 	checkvalidation/edistributions/unreleased
 checkvalidation/%:
-	$(MAKE) checkvalid/$* #checkinvalid/$*
+	$(MAKE) checkvalid/$* checkinvalid/$*
 checkvalid/%: src/%/validation src/%.yaml
-	@for ex in $</*.valid.cfg.yaml; do \
+	@for ex in $(wildcard $</*.valid.cfg.yaml); do \
 		echo "Validate $$ex" ; \
 		linkml-validate --config "$$ex" || exit 5 ; \
 	done
 checkinvalid/%: src/%/validation src/%.yaml
-	@for ex in $</*.invalid.cfg.yaml; do \
+	@for ex in $(wildcard $</*.invalid.cfg.yaml); do \
 		echo "(In)validate $$ex" ; \
 		linkml-validate --config "$$ex" && exit 5 || true; \
 	done


### PR DESCRIPTION
The (checkvalid / checkinvalid) targets in the makefile, which glob for `*(in)valid.cfg.yaml` files, should now act selectively and no longer try to call `linkml validate` when no config files match the pattern. This means both can be included in the checkvalidation target again, after checkinvalid was excluded in 8e50084 to reduce clutter caused by errors.

Previously, if there were no *.invalid.cfg.yaml files, we still made it into the `@for ex in $</*invalid.cfg.yaml` loop -- but with the wildcard *expression* verbatim (same would happen for `*valid`, but we usually have those). This caused errors like:

"Invalid value for '--config': File 'src/flat-data/unreleased/validation/*.invalid.cfg.yaml' does not exist."

It seems that make's wildcard *function* avoids the pitfall, while correctly expanding the globs when files are present.

https://www.gnu.org/software/make/manual/html_node/Wildcard-Function.html https://www.gnu.org/software/make/manual/html_node/Wildcard-Pitfall.html