### PR TITLE
Replace `subject_type` with a generic `is_a` relationship property

### DIFF
--- a/src/flat-study/unreleased.yaml
+++ b/src/flat-study/unreleased.yaml
@@ -158,10 +158,10 @@ classes:
       contextual entity. One and the same entity can be different
       subjects in two different studies.
     slots:
+      - derived_from
+      - is_a
       - name
       - study
-      - subject_type
-      - derived_from
     slot_usage:
       study:
         required: true
@@ -172,9 +172,14 @@ classes:
         recommended: true
         annotations:
           sh:order: 2
-      subject_type:
+      is_a:
+        title: Type
+        description: >-
+          A classifier that identifies the nature/type of a subject.
+          For specimen (a subject derived/taken from another subject),
+          this classifier should be more precise than the classifier
+          of the source subject.
         recommended: true
-        range: SubjectType
         annotations:
           sh:order: 3
       description:
@@ -185,19 +190,3 @@ classes:
         range: Subject
         annotations:
           sh:order: 5
-
-  SubjectType:
-    is_a: FlatThing
-    description: >-
-      Classifier for the nature of a subject.
-    slots:
-      - name
-    slot_usage:
-      name:
-        recommended: true
-        annotations:
-          sh:order: 1
-      description:
-        annotations:
-          sh:order: 2
-          dash:singleLine: false

--- a/src/flat-study/unreleased/examples/Subject-1.json
+++ b/src/flat-study/unreleased/examples/Subject-1.json
@@ -2,8 +2,8 @@
   "pid": "https://6af3ce47-0c7a-479f-bd60-b960713b50be",
   "schema_type": "dlflatstudy:Subject",
   "study": "https://doi.org/1234/demo",
-  "name": "blood-from-sub-001",
-  "subject_type": "http://purl.obolibrary.org/obo/NCIT_C17610",
   "derived_from": "https://orcid.org/0000-0001-6398-6370",
+  "is_a": "http://purl.obolibrary.org/obo/NCIT_C17610",
+  "name": "blood-from-sub-001",
   "@type": "Subject"
 }

--- a/src/flat-study/unreleased/examples/Subject-1.yaml
+++ b/src/flat-study/unreleased/examples/Subject-1.yaml
@@ -1,5 +1,5 @@
 pid: https://6af3ce47-0c7a-479f-bd60-b960713b50be
 name: blood-from-sub-001
 study: https://doi.org/1234/demo
-subject_type: http://purl.obolibrary.org/obo/NCIT_C17610
+is_a: http://purl.obolibrary.org/obo/NCIT_C17610
 derived_from: https://orcid.org/0000-0001-6398-6370

--- a/src/relations-mixin/unreleased.yaml
+++ b/src/relations-mixin/unreleased.yaml
@@ -74,6 +74,13 @@ slots:
     exact_mappings:
       - dcterms:conformsTo
 
+  is_a:
+    description: >-
+      The nature of the subject.
+    range: Thing
+    exact_mappings:
+      - dcterms:type
+
   part_of:
     description: >-
       The entity that the subject is a part of. A core relation that

--- a/src/study-mixin/unreleased.yaml
+++ b/src/study-mixin/unreleased.yaml
@@ -69,11 +69,3 @@ slots:
     title: Study context
     description: >-
       The study in which the subject took place or existed.
-
-  subject_type:
-    title: Type
-    description: >-
-      A classifier that identifies the nature/type of a subject.
-      For specimen (a subject derived/taken from another subject),
-      this classifier should be more precise than the classifier
-      of the source subject.


### PR DESCRIPTION
This is defined as `dcterms:type`. However, `type` is not used as the property name to avoid confusion with `rdf:type`, which this is not. `is_a` is intended to be a non-schema, but semantic classifier.