### PR TITLE
Adds missing dlfilesmx prefix to demo-research-assets schema

### DIFF
--- a/.github/workflows/model-checks.yml
+++ b/.github/workflows/model-checks.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.13'
 
       - name: Install hatch
         run: python -m pip install hatch

--- a/.github/workflows/sitebuild.yml
+++ b/.github/workflows/sitebuild.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.13'
 
       - name: Install hatch
         run: python -m pip install hatch

--- a/.github/workflows/validate-examples.yaml
+++ b/.github/workflows/validate-examples.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.13'
 
       - name: Install hatch
         run: python -m pip install hatch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]

--- a/src/demo-research-assets/unreleased.yaml
+++ b/src/demo-research-assets/unreleased.yaml
@@ -33,6 +33,7 @@ prefixes:
   dash: http://datashapes.org/dash#
   dcterms: http://purl.org/dc/terms/
   dlcommonmx: https://concepts.datalad.org/s/common-mixin/unreleased/
+  dlfilesmx: https://concepts.datalad.org/s/files-mixin/unreleased/
   dlflat: https://concepts.datalad.org/s/flat/unreleased/
   dlflatfiles: https://concepts.datalad.org/s/flat-files/unreleased/
   dlflatprov: https://concepts.datalad.org/s/flat-prov/unreleased/
@@ -75,6 +76,7 @@ default_prefix: xyzra
 
 emit_prefixes:
   - dlcommonmx
+  - dlfilesmx
   - dlflat
   - dlflatfiles
   - dlflatres


### PR DESCRIPTION
@mih The missing prefix strikes again.

I was thinking about what the best way could be to catch this early, ideally during the schema build process of this repo. The way I usually catch it, after it surfacing as some random error in `shacl-vue`, is to look at the exported SHACL and see if any of the `sh:PropertyShape`s have an `sh:path` (or `sh:class` or `sh:datatype`) that is displayed in full named node syntax `<https://concepts.datalad.org/s/files-mixin/unreleased/distribution_of>` as opposed to a CURIE `dlfilesmx:distribution_of`. This would mean that said prefix is not included in the SHACL list of prefixes and hence not in the schema.

I don't think it will work to run through and compare all the emitted prefixes of the schemas that are imported by the current schema, since not all of those prefixes are necessarily needed in the end schema that is exported to SHACL.

WDYT?

Also, no idea (yet) what is giving the `TypeError: the JSON object must be str, bytes or bytearray, not Sentinel` error that's causing the actions to fail here.