### PR TITLE
Add missing `schema`-prefix to things/v1

### DIFF
--- a/src/things/v1.yaml
+++ b/src/things/v1.yaml
@@ -76,6 +76,8 @@ prefixes:
   owl: http://www.w3.org/2002/07/owl#
   rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   rdfs: http://www.w3.org/2000/01/rdf-schema#
+  # Required for `Thing`-definition
+  schema: http://schema.org/
   # form annotations
   sh: http://www.w3.org/ns/shacl#
   # here for alignment of `attributes`


### PR DESCRIPTION
This PR adds the prefix `schema` to `things/v1.yaml`.

`schema` is required in the `Thing` definition.

