### PR TITLE
Make `distribution_of` multivalued

### DIFF
--- a/src/demo-research-assets/unreleased.yaml
+++ b/src/demo-research-assets/unreleased.yaml
@@ -212,6 +212,10 @@ classes:
         annotations:
           sh:order: 1.0
       distribution_of:
+        # XXX this should be a superfluous reannotation of the `Distribution.distribution_of`
+        # slot as being multivalued (which it is in `Distribution`). But with linkml 1.9.4
+        # this information is not inherited
+        multivalued: true
         annotations:
           sh:order: 2.0
       byte_size:

--- a/src/demo-research-assets/unreleased/examples/XYZDistribution-02-attributes.json
+++ b/src/demo-research-assets/unreleased/examples/XYZDistribution-02-attributes.json
@@ -1,7 +1,9 @@
 {
   "pid": "https://concepts.datalad.org/ns/gitsha/9a7e16b80140183c9495d549ce117af4eff9de3e",
   "schema_type": "xyzra:XYZDistribution",
-  "distribution_of": "https://concepts.datalad.org/ns/dataset-uuid/fd3b41bb-5d75-4cee-b41c-aac0e0cae7f1",
+  "distribution_of": [
+    "https://concepts.datalad.org/ns/dataset-uuid/fd3b41bb-5d75-4cee-b41c-aac0e0cae7f1"
+  ],
   "kind": "https://example.org/ns/git-commit",
   "parts": {
     "table_221.csv": {

--- a/src/demo-research-assets/unreleased/examples/XYZDistribution-02-attributes.yaml
+++ b/src/demo-research-assets/unreleased/examples/XYZDistribution-02-attributes.yaml
@@ -1,5 +1,6 @@
 pid: https://concepts.datalad.org/ns/gitsha/9a7e16b80140183c9495d549ce117af4eff9de3e
-distribution_of: https://concepts.datalad.org/ns/dataset-uuid/fd3b41bb-5d75-4cee-b41c-aac0e0cae7f1
+distribution_of:
+  - https://concepts.datalad.org/ns/dataset-uuid/fd3b41bb-5d75-4cee-b41c-aac0e0cae7f1
 kind: https://example.org/ns/git-commit
 parts:
   table_221.csv: https://concepts.datalad.org/ns/annex-key/MD5E-s11263--1549566fb97afa879dc9446edcf2015f.csv

--- a/src/flat-files/unreleased.yaml
+++ b/src/flat-files/unreleased.yaml
@@ -99,6 +99,7 @@ classes:
         annotations:
           sh:order: 1
       distribution_of:
+        multivalued: true
         annotations:
           sh:order: 2
       byte_size:

--- a/src/flat-files/unreleased/examples/Distribution-02-attributes.json
+++ b/src/flat-files/unreleased/examples/Distribution-02-attributes.json
@@ -14,6 +14,9 @@
       "schema_type": "dlidentifiers:Checksum"
     }
   ],
+  "distribution_of": [
+    "https://example.com/a_file"
+  ],
   "format": "http://edamontology.org/format_3475",
   "media_type": "application/json",
   "@type": "Distribution"

--- a/src/flat-files/unreleased/examples/Distribution-02-attributes.yaml
+++ b/src/flat-files/unreleased/examples/Distribution-02-attributes.yaml
@@ -9,3 +9,5 @@ media_type: application/json
 # file format specification via custom definition IRI
 # (here effectively also pointing to IANA)
 format: http://edamontology.org/format_3475
+distribution_of:
+  - https://example.com/a_file


### PR DESCRIPTION
In general any file content can appear in more than one context.

Fixes #384 