### PR TITLE
Use `dump-things-create-merged-schema` to create static schemas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ build/linkml-docs/s/%: src/%.yaml src/%/extra-docs
 			--include-stripped-prefixes \
 			--exclude-order \
 			$< > $@.shacl.ttl ; \
-		gen-yaml \
+		dump-things-create-merged-schema \
 			$< > $@.static.yaml ; \
 	fi
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ classifiers = [
 ]
 dependencies = [
   "linkml",
+  "dump-things-service",
 ]
 
 [project.urls]


### PR DESCRIPTION
`gen-yaml` produces merged schemas that do not align with the unmerged schemas. This PR uses `dump-things-create-merged-schema` to create static schemas that are compatible with the unmerged schemas.