### PR TITLE
Merge `AssessmentType` and `DistributionType` -> `DataType`

### DIFF
--- a/src/demo-research-assets/unreleased.yaml
+++ b/src/demo-research-assets/unreleased.yaml
@@ -248,20 +248,36 @@ classes:
         annotations:
           sh:order: 6.0
       kind:
-        # think datatype
+        range: XYZDataType
         annotations:
           sh:order: 7.0
 
-  XYZAssessmentType:
+  XYZDataType:
     is_a: FlatThing
-    title: Assessment type
+    title: Data type or format
     description: >-
-      Type of an assessment.
+      Type of an data item.
+    slots:
+      - version_of
     slot_usage:
       description:
         annotations:
           sh:order: 1.0
           dash:singleLine: false
+      version_of:
+        title: Variant of
+        range: XYZDataType
+        annotations:
+          sh:order: 2.0
+    broad_mappings:
+      - dcterms:format
+    narrow_mappings:
+      # Electronic File Format
+      - obo:NCIT_C171252
+      # Data Type
+      - obo:NCIT_C42645
+      # Electronic File Content Type
+      - obo:NCIT_C172272
 
   XYZConvention:
     is_a: Convention
@@ -311,7 +327,7 @@ classes:
       A specific representation of a data item, which may come in the form of an electronic file, or an archive or directory of many files.
     slot_usage:
       kind:
-        range: XYZDistributionType
+        range: XYZDataType
         annotations:
           sh:order: 1.0
       distribution_of:
@@ -347,17 +363,6 @@ classes:
     slot_usage:
       roles:
         range: XYZDistributionPartType
-
-  XYZDistributionType:
-    is_a: FlatThing
-    title: Distribution type
-    description: >-
-      Type of a distribution.
-    slot_usage:
-      description:
-        annotations:
-          sh:order: 1.0
-          dash:singleLine: false
 
   XYZDistributionPartType:
     is_a: FlatThing


### PR DESCRIPTION
While there is a difference between a data type (image, table) and a data format (PNG, CSV), there difference is less relevant here. `DataType` is no more than a class with the purpose to be a type for individuals that form the collection of relevant types and formats in a particular scenario.