### PR TITLE
Add `display_label` to `XYZPersonAttribution`

### DIFF
--- a/src/demo-research-assets/unreleased.yaml
+++ b/src/demo-research-assets/unreleased.yaml
@@ -968,6 +968,7 @@ classes:
     slots:
       - roles
       - object
+      - display_label
     slot_usage:
       object:
         title: Person
@@ -977,5 +978,8 @@ classes:
       roles:
         range: XYZAgentRole
         multivalued: true
+        annotations:
+          sh:order: 2.0
+      display_label:
         annotations:
           sh:order: 2.0


### PR DESCRIPTION
There is no easy way to derived such a label from an instance of this association class. The least bit we can do is to enable providing such a label.