### PR TITLE
Remove `Factor` and `Dimension`

### DIFF
--- a/src/demo-research-assets/unreleased.yaml
+++ b/src/demo-research-assets/unreleased.yaml
@@ -334,23 +334,6 @@ classes:
         annotations:
           sh:order: 6.0
 
-  XYZDimension:
-    is_a: Dimension
-    title: Dimension
-    description: >-
-      A dependent or outcome variable.
-    slot_usage:
-      name:
-        annotations:
-          sh:order: 1.0
-      description:
-        annotations:
-          sh:order: 2.0
-          dash:singleLine: false
-      part_of:
-        annotations:
-          sh:order: 3.0
-
   XYZDistribution:
     is_a: Distribution
     title: Distribution
@@ -452,22 +435,32 @@ classes:
         annotations:
           sh:order: 5.0
 
-  XYZFactor:
-    is_a: Factor
-    title: Factor
+  XYZConcept:
+    is_a: FlatThing
+    title: Concept
     description: >-
-      A tag associated with a categorical, independent variable in a study design. Factors can have an investigative role (e.g., treatments), or have an organizational nature (e.g., site labels).
+      An idea or notion; a unit of thought.
+
+      In the context of a study, this can be a tag associated with a
+      categorical, independent variable in a study design, an
+      investigative role (e.g., treatments), or an organizational
+      nature (e.g., site labels), or a dependent or outcome variable.
+
+      `Concept` is related to `Topic`. However a concept is more focused
+      and more clearly delineated in comparison.
+    comments:
+      - The relationship of a focused concept with the broader concept
+        can be described via `broader_mappings`.
+    slots:
+      - title
     slot_usage:
-      name:
+      title:
         annotations:
           sh:order: 1.0
       description:
         annotations:
           sh:order: 2.0
           dash:singleLine: false
-      part_of:
-        annotations:
-          sh:order: 3.0
 
   XYZGenesis:
     is_a: FlatThing
@@ -828,7 +821,7 @@ classes:
           sh:order: 1.0
       factors:
         multivalued: true
-        range: XYZFactor
+        range: XYZConcept
         annotations:
           sh:order: 2.0
       instruments:
@@ -838,7 +831,7 @@ classes:
           sh:order: 3.0
       dimensions:
         multivalued: true
-        range: XYZDimension
+        range: XYZConcept
         annotations:
           sh:order: 4.0
       attributed_to:

--- a/src/flat-study/unreleased.yaml
+++ b/src/flat-study/unreleased.yaml
@@ -75,51 +75,6 @@ imports:
   - dlschemas:relations-mixin/unreleased
 
 classes:
-  Dimension:
-    is_a: FlatThing
-    description: >-
-      A dependent or outcome variable.
-    slots:
-      - name
-      - part_of
-    slot_usage:
-      name:
-        annotations:
-          sh:order: 1
-      part_of:
-        range: Dimension
-        annotations:
-          sh:order: 2
-      description:
-        annotations:
-          sh:order: 3
-          dash:singleLine: false
-
-  Factor:
-    is_a: FlatThing
-    description: >-
-      A tag associated with a categorical, independent variable in a study
-      design. Factors can have an investigative role (e.g., treatments), or
-      have an organizational nature (e.g., site labels).
-    slots:
-      - name
-      - part_of
-    comments:
-      - The relationship of a factor "level" with the broader factor can be
-        described via `broader_mappings`.
-    slot_usage:
-      name:
-        annotations:
-          sh:order: 1
-      part_of:
-        range: Factor
-        annotations:
-          sh:order: 2
-      description:
-        annotations:
-          sh:order: 3
-          dash:singleLine: false
-
   Study:
     is_a: FlatThing
     description: >-
@@ -146,7 +101,6 @@ classes:
         annotations:
           sh:order: 1
       factors:
-        range: Factor
         annotations:
           sh:order: 2
       instruments:
@@ -154,7 +108,6 @@ classes:
         annotations:
           sh:order: 3
       dimensions:
-        range: Dimension
         annotations:
           sh:order: 4
       part_of:

--- a/src/study-mixin/unreleased.yaml
+++ b/src/study-mixin/unreleased.yaml
@@ -51,12 +51,14 @@ slots:
     title: Outcomes variables
     description: >-
       Associated outcome variables.
+    range: Thing
     multivalued: true
 
   factors:
     title: Influencing factors
     description: >-
       Factors that influence the subject matter.
+    range: Thing
     multivalued: true
 
   instruments:
@@ -64,9 +66,11 @@ slots:
     description: >-
       Instruments employed in a study activity. This could be physical
       devices, but also software tools.
+    range: Thing
     multivalued: true
 
   study:
     title: Study context
     description: >-
       The study in which the subject took place or existed.
+    range: Thing


### PR DESCRIPTION
This distinction was found to not scale. One an the same thing can be a factor and a dimension at the same time. If that is true, the cannot be instanced of different classes under the same PID.

The semantic distinction can be made via thr respective properties `factors` and `dimensions`.

In the context of the research assets demonstrator these have been replaced by a merged `XYZConcept` class that serves as the `range` type for `factors` and `dimensions`.