### PR TITLE
Add `ActivityMixin` to `XYZProject` in demo-rse

### DIFF
--- a/src/demo-rse-group/unreleased.yaml
+++ b/src/demo-rse-group/unreleased.yaml
@@ -371,6 +371,8 @@ classes:
   XYZProject:
     is_a: Project
     title: Project
+    mixins:
+    - ActivityMixin
     description: >-
       A collective endeavour of some kind. Typically it is a planned process that is undertaken or attempted to meet some requirement, or to achieve a particular goal.
     slots:


### PR DESCRIPTION
Grant administration workflow based on PROV requires `Project` to be compatible to PROV-Activity-entities. This PR add the `ActivityMixin` to  `XYZProject`.