### PR TITLE
add prefix `dlcdi` to demo-rse-group

### DIFF
--- a/src/demo-rse-group/unreleased.yaml
+++ b/src/demo-rse-group/unreleased.yaml
@@ -37,6 +37,8 @@ prefixes:
   dash: http://datashapes.org/dash#
   dcterms: http://purl.org/dc/terms/
   dlcommonmx: https://concepts.datalad.org/s/common-mixin/unreleased/
+  # TODO this is also defined in demo_research_assets, but should probably be defined in flat-files
+  dlcdi: https://concepts.datalad.org/ns/content-defined-identifiers/
   # TODO preliminary definition, pointing to a future resolver
   dldi: https://pid.datalad.org/distributions/
   dlfilesmx: https://concepts.datalad.org/s/files-mixin/unreleased/
@@ -88,6 +90,7 @@ prefixes:
 default_prefix: xyzra
 
 emit_prefixes:
+  - dlcdi
   - dlcommonmx
   - dlfilesmx
   - dlflat


### PR DESCRIPTION
The `pool.psychoinformatics`-knowledge base (which uses the schema `demo-rse-group`) imports the `pool.v0.edu.datalad.org-knowledge`-knowledge base. The latter uses the prefix `dlcdi` in instances of `dlflatfiles:Distribution`. The prefix is currently only defined in the schema `demo-research-assets`. 

The PR adds the prefix `dlcdi` to the `demo-rse-group`-schema to limit the changes to the `demo-rse-group`-schema and to leave the other schemas untouched.

In the future the prefix `dlcdi` should probably be added to `flat-files` and be removed from `demo-rse-group` and `demo-research-assets`, which both import `flat-files`.
