### PR TITLE
Remove AgentMixin from XYZOrganization

### DIFF
--- a/src/demo-rse-group/unreleased.yaml
+++ b/src/demo-rse-group/unreleased.yaml
@@ -486,8 +486,6 @@ classes:
 
   XYZOrganization:
     is_a: Organization
-    mixins:
-      - AgentMixin
     title: Organization
     description: >-
       A social or legal institution such as a company, a society, or a university.
@@ -507,13 +505,6 @@ classes:
         range: XYZOrganization
         annotations:
           sh:order: 4.0
-      influenced_by:
-        range: XYZInfluence
-        multivalued: true
-        inlined: true
-        inlined_as_list: true
-        annotations:
-          sh:order: 5.0
 
   XYZPerson:
     is_a: Person


### PR DESCRIPTION
In principle, and Organization is an Agent in PROV terms, just as a Person. However, I argue that both classes should be used differently in the context of this schema. A Person should get the full expressiveness of PROV, but an Organization should rather be used as a "tag" (or classifier), without the possibility to express PROV information in the class record itself.

Two reasons:

1) Re-usability: If it is possible to enrich organization records too, the focus on adding reciprocal information to a (e.g.) Person record is reduced. Such enrichments will likely be use case specific, hence the verbatim Organization records cannot be reused in other applications without filtering or tuning. There are 100k+ of such records -- the cost is substantial.

2) Governance: In principle we operate in the domain of triples (subject-predicate-object). Information on the relation between an Organization and a Person isn't in any "record", it is in the edge between two nodes. However, in practice, we are in the world of structured data, with records, and information being here or there. So it makes a difference, if a statement on a Person is made an Organization record (where it may be perceived as "authoritative" , and potentially requiring approval), or in the Person record (which may be more naturally subjected to self-governance, ie. a Person` making claims about their relation with the world).