### PR TITLE
Hotfix for bug that prevents dumpthings from starting

### DIFF
--- a/src/demo-rse-group/unreleased.yaml
+++ b/src/demo-rse-group/unreleased.yaml
@@ -1084,9 +1084,10 @@ classes:
       Unique persistent identifier for a person, provided by the Open Researcher
       and Contributor ID (ORCID) organisation.
     slot_usage:
-      creator:
-        ifabsent: string(ror:04fa4r544)
-        description: By default, the creator is identified as "ror:04fa4r544".
+      # disable due to a bug in `ifabsent` handling
+      #creator:
+      #  ifabsent: string(ror:04fa4r544)
+      #  description: By default, the creator is identified as "ror:04fa4r544".
       notation:
         description: >-
           The identifier notation is specified without a URL-prefix,


### PR DESCRIPTION
Hint

```
Dec 08 16:11:16  bash[2620165]:     creator: Optional[str] = Field(default=ROR["04fa4r544"], description="""By default, the creator is identified as \"ror:04fa4r544\>
Dec 08 16:11:16  bash[2620165]:          'domain_of': ['Identifier'],
Dec 08 16:11:16  bash[2620165]:          'exact_mappings': ['dcterms:creator'],
Dec 08 16:11:16  bash[2620165]:          'ifabsent': 'string(ror:04fa4r544)',
Dec 08 16:11:16  bash[2620165]:          'notes': ['The `range` is only `uriorcurie` here (and not `Thing`), because '
Dec 08 16:11:16  bash[2620165]:                    'we have an `ifabsent` declaration for DOIs that only work with '
Dec 08 16:11:16  bash[2620165]:                    'this type. And even for that it needs a patch.'],
Dec 08 16:11:16  bash[2620165]:          'slot_uri': 'dlidentifiers:creator'} })
```

See `ROR` ^^^