### PR TITLE
Make `part_of` generally `multivalued: true`

### DIFF
--- a/src/demo-research-assets/unreleased.yaml
+++ b/src/demo-research-assets/unreleased.yaml
@@ -241,6 +241,7 @@ classes:
     slot_usage:
       part_of:
         range: XYZDataset
+        multivalued: true
         annotations:
           sh:order: 1.0
       same_as:
@@ -374,6 +375,7 @@ classes:
           sh:order: 7.0
       part_of:
         range: XYZDataset
+        multivalued: true
         annotations:
           sh:order: 8.0
       rules:
@@ -487,6 +489,7 @@ classes:
         annotations:
           sh:order: 4.0
       part_of:
+        multivalued: true
         annotations:
           sh:order: 4.0
       rules:
@@ -568,6 +571,7 @@ classes:
         any_of:
           - range: XYZStudy
           - range: XYZGenesis
+        multivalued: true
         annotations:
           sh:order: 5.0
       target:
@@ -615,6 +619,7 @@ classes:
           dash:singleLine: false
       part_of:
         range: XYZGrant
+        multivalued: true
         annotations:
           sh:order: 5.0
       rules:
@@ -675,6 +680,7 @@ classes:
         description: >-
           An organization that the subject is part of.
         range: XYZOrganization
+        multivalued: true
         annotations:
           sh:order: 4.0
 
@@ -737,6 +743,7 @@ classes:
           sh:order: 4.0
       part_of:
         range: XYZProject
+        multivalued: true
         annotations:
           sh:order: 5.0
       target:
@@ -915,6 +922,7 @@ classes:
           sh:order: 4.0
       part_of:
         range: XYZStudy
+        multivalued: true
         annotations:
           sh:order: 5.0
       associated_with:
@@ -990,6 +998,7 @@ classes:
           dash:singleLine: false
       part_of:
         range: XYZTopic
+        multivalued: true
         annotations:
           sh:order: 2.0
 
@@ -1080,6 +1089,7 @@ classes:
           sh:order: 1.0
       part_of:
         range: XYZProject
+        multivalued: true
         annotations:
           sh:order: 2.0
       depends_on:

--- a/src/demo-rse-group/unreleased.yaml
+++ b/src/demo-rse-group/unreleased.yaml
@@ -388,6 +388,7 @@ classes:
           sh:order: 3.0
           dash:singleLine: false
       part_of:
+        multivalued: true
         annotations:
           sh:order: 4.0
       rules:
@@ -450,6 +451,7 @@ classes:
           dash:singleLine: false
       part_of:
         range: XYZGrant
+        multivalued: true
         annotations:
           sh:order: 4.0
       rules:
@@ -610,6 +612,7 @@ classes:
           dash:singleLine: false
       part_of:
         range: XYZProject
+        multivalued: true
         annotations:
           sh:order: 4.0
       associated_with:
@@ -888,6 +891,7 @@ classes:
           sh:order: 1.0
       part_of:
         range: XYZObjective
+        multivalued: true
         annotations:
           sh:order: 2.0
       depends_on:
@@ -918,6 +922,7 @@ classes:
         description: >-
           An organization that the subject is part of.
         range: XYZOrganization
+        multivalued: true
         annotations:
           sh:order: 4.0
 
@@ -982,6 +987,7 @@ classes:
           dash:singleLine: false
       part_of:
         range: XYZTopic
+        multivalued: true
         annotations:
           sh:order: 2.0
 

--- a/src/demo-rse-group/unreleased/examples/XYZDataset-01-minimal.json
+++ b/src/demo-rse-group/unreleased/examples/XYZDataset-01-minimal.json
@@ -1,0 +1,5 @@
+{
+  "pid": "https://example.com/dataset1",
+  "schema_type": "xyzrse:XYZDataset",
+  "@type": "XYZDataset"
+}

--- a/src/demo-rse-group/unreleased/examples/XYZDataset-01-minimal.yaml
+++ b/src/demo-rse-group/unreleased/examples/XYZDataset-01-minimal.yaml
@@ -1,0 +1,1 @@
+pid: https://example.com/dataset1

--- a/src/demo-rse-group/unreleased/validation/XYZDataset.valid.cfg.yaml
+++ b/src/demo-rse-group/unreleased/validation/XYZDataset.valid.cfg.yaml
@@ -1,0 +1,9 @@
+schema: src/demo-rse-group/unreleased.yaml
+target_class: XYZDataset
+data_sources:
+  - src/demo-rse-group/unreleased/examples/XYZDataset-01-minimal.yaml
+plugins:
+  JsonschemaValidationPlugin:
+    closed: true
+    include_range_class_descendants: false
+  RecommendedSlotsPlugin:

--- a/src/flat-resources/unreleased.yaml
+++ b/src/flat-resources/unreleased.yaml
@@ -121,6 +121,7 @@ classes:
     slot_usage:
       part_of:
         range: Dataset
+        multivalued: true
       same_as:
         title: Qualitative value
         description: >-
@@ -162,6 +163,7 @@ classes:
           sh:order: 3
       part_of:
         range: Dataset
+        multivalued: true
         annotations:
           sh:order: 4
     exact_mappings:
@@ -190,6 +192,7 @@ classes:
           sh:order: 3
       part_of:
         range: Document
+        multivalued: true
         annotations:
           sh:order: 3
     notes:
@@ -230,6 +233,7 @@ classes:
           sh:order: 4
       part_of:
         range: Grant
+        multivalued: true
         annotations:
           sh:order: 5
     exact_mappings:

--- a/src/flat-resources/unreleased/examples/DataItem-02-attributes.json
+++ b/src/flat-resources/unreleased/examples/DataItem-02-attributes.json
@@ -2,7 +2,9 @@
   "pid": "https://example.org/wind-strength-on-20250815",
   "schema_type": "dlflatres:DataItem",
   "kind": "http://purl.obolibrary.org/obo/ENVO_01001362",
-  "part_of": "https://example.org/dataset/windy",
+  "part_of": [
+    "https://example.org/dataset/windy"
+  ],
   "quantitative_unit": "http://purl.obolibrary.org/obo/UO_0000094",
   "quantitative_value": 22.0,
   "same_as": "http://semanticscience.org/resource/SIO_001215",

--- a/src/flat-resources/unreleased/examples/DataItem-02-attributes.yaml
+++ b/src/flat-resources/unreleased/examples/DataItem-02-attributes.yaml
@@ -7,4 +7,5 @@ quantitative_unit: http://purl.obolibrary.org/obo/UO_0000094
 # severe -> beaufort scale 9
 same_as: http://semanticscience.org/resource/SIO_001215
 # containing dataset
-part_of: https://example.org/dataset/windy
+part_of:
+  - https://example.org/dataset/windy

--- a/src/flat-social/unreleased.yaml
+++ b/src/flat-social/unreleased.yaml
@@ -96,6 +96,7 @@ classes:
         description: >-
           An organization that the subject is part of.
         range: Organization
+        multivalued: true
         annotations:
           sh:order: 4
     exact_mappings:
@@ -156,3 +157,5 @@ classes:
       short_name:
         annotations:
           sh:order: 2
+      part_of:
+        multivalued: true

--- a/src/flat-social/unreleased/examples/Organization-02-attributes.json
+++ b/src/flat-social/unreleased/examples/Organization-02-attributes.json
@@ -4,6 +4,8 @@
   "name": "Forschungszentrum Jülich",
   "short_name": "FZJ",
   "at_location": "https://sws.geonames.org/6557321",
-  "part_of": "https://ror.org/0281dp749",
+  "part_of": [
+    "https://ror.org/0281dp749"
+  ],
   "@type": "Organization"
 }

--- a/src/flat-social/unreleased/examples/Organization-02-attributes.yaml
+++ b/src/flat-social/unreleased/examples/Organization-02-attributes.yaml
@@ -2,4 +2,5 @@ pid: https://ror.org/02nv7yv05
 name: Forschungszentrum Jülich
 short_name: FZJ
 at_location: https://sws.geonames.org/6557321
-part_of: https://ror.org/0281dp749
+part_of:
+  - https://ror.org/0281dp749

--- a/src/flat-study/unreleased.yaml
+++ b/src/flat-study/unreleased.yaml
@@ -122,6 +122,7 @@ classes:
           sh:order: 4
       part_of:
         range: Study
+        multivalued: true
         annotations:
           sh:order: 5
       associated_with:


### PR DESCRIPTION
A mismatch between two derived classes (that also added a mixin) brought LinkML to its knees. This made me look through all usage of `part_of`.

It is now made `multivalued: true` everywhere, except for the empirical data demo (for historical reasons).

In general it makes sense to have that in all the present use cases. I could not convince myself that this is true in any and all cases, so I kept the default `false` for now in the slot definition.