### PR TITLE
Add patch to support custom types in TTL-loading

### DIFF
--- a/patches/rdflib_loader_custom_types.diff
+++ b/patches/rdflib_loader_custom_types.diff
@@ -1,0 +1,87 @@
+add type definitions from schema
+
+The rdflib loader now binds type definitions
+from the schema to a generic validator that converts
+the content to strings. This allows explicit type
+clauses in TTL, e.g., `2025-01-01^^w3ctr:NOTE-datetime`.
+
+diff --git a/linkml_runtime/loaders/rdflib_loader.py b/linkml_runtime/loaders/rdflib_loader.py
+index 21b940c..8b11364 100644
+--- a/linkml_runtime/loaders/rdflib_loader.py
++++ b/linkml_runtime/loaders/rdflib_loader.py
+@@ -1,4 +1,5 @@
+ import logging
++import re
+ import urllib
+ from copy import copy
+ from dataclasses import dataclass
+@@ -9,7 +10,13 @@ from hbreader import FileInfo
+ from pydantic import BaseModel
+ from rdflib import Graph, URIRef
+ from rdflib.namespace import RDF
+-from rdflib.term import BNode, Literal
++from rdflib.term import (
++    BNode,
++    Literal,
++    URIRef,
++    _toPythonMapping,
++    bind,
++)
+
+ from linkml_runtime import DataNotFoundError, MappingError
+ from linkml_runtime.linkml_model import (
+@@ -36,6 +43,40 @@ class Pointer:
+     obj: str
+
+
++class _TypeValidator:
++    def __init__(
++            self,
++            type_name: str,
++            pattern: str | None,
++    ):
++        self.type_name = type_name
++        self.matcher = None if pattern is None else re.compile(pattern)
++
++    def validate(
++            self,
++            value: str
++    ) -> str:
++        if self.matcher:
++            match = self.matcher.match(value)
++            if not match:
++                msg = f'Invalid {self.type_name} format: {value}'
++                raise ValueError(msg)
++        return value
++
++
++def _add_type_validator(
++        uri_ref: str,
++        regex: str | None,
++):
++    if URIRef(uri_ref) in _toPythonMapping:
++        return
++    bind(
++        datatype=URIRef(uri_ref),
++        constructor=_TypeValidator(uri_ref, regex).validate,
++        pythontype=str,
++    )
++
++
+ class RDFLibLoader(Loader):
+     """
+     Loads objects from rdflib Graphs into the python target_class structure
+@@ -278,6 +319,13 @@ class RDFLibLoader(Loader):
+         :param kwargs: additional arguments passed to from_rdf_graph
+         :return: Instance of target_class
+         """
++        # Add types defined in the schema to support explicit type clauses in TTL
++        for type_definition in schemaview.all_types().values():
++            uri = schemaview.expand_curie(type_definition.uri)
++            _add_type_validator(
++                uri_ref=uri,
++                regex=type_definition.pattern,
++            )
+         if isinstance(source, Graph):
+             g = source
+         else:

--- a/tools/patch_linkml
+++ b/tools/patch_linkml
@@ -14,3 +14,5 @@ patch -d $(python -c 'import os; import linkml_runtime.utils.yamlutils as m; pri
 patch -d $(python -c 'import os; import linkml.generators.graphqlgen as m; print(os.path.dirname(m.__file__))') < patches/graphqlgen_interface_list.diff
 # Do not emit python/rdflib upper case namespaces in `ifabsent`-default values
 patch -d $(python -c 'import os; import linkml.generators.common.ifabsent_processor as m; print(os.path.dirname(m.__file__))') < patches/linkml_generators_common_ifabsent.diff
+# Support explicit type clauses with schema defined types when loading ttl
+patch -d $(python -c 'import os; import linkml_runtime.loaders as m; print(os.path.dirname(m.__file__))') < patches/rdflib_loader_custom_types.diff


### PR DESCRIPTION
Code in this PR adds a patch for `linkml_runtime`, where the rdflib loader binds type definitions from the schema to a generic validator that converts the content to strings. This allows explicit type clauses in TTL, e.g., `2025-01-01^^w3ctr:NOTE-datetime`.
