### PR TITLE
Establish `FlatProperty` with the `FlatThing` curation/UI slots

### DIFF
--- a/src/flat-prov/unreleased/examples/Entity-02-prov-ex1.json
+++ b/src/flat-prov/unreleased/examples/Entity-02-prov-ex1.json
@@ -6,12 +6,12 @@
       "attributes": [
         {
           "predicate": "foaf:givenName",
-          "schema_type": "dlthings:AttributeSpecification",
+          "schema_type": "dlflat:FlatAttributeSpecification",
           "value": "Derek"
         },
         {
           "predicate": "foaf:mbox",
-          "schema_type": "dlthings:AttributeSpecification",
+          "schema_type": "dlflat:FlatAttributeSpecification",
           "value": "<mailto:derek@example.org>"
         }
       ],
@@ -29,7 +29,7 @@
       "attributes": [
         {
           "predicate": "foaf:name",
-          "schema_type": "dlthings:AttributeSpecification",
+          "schema_type": "dlflat:FlatAttributeSpecification",
           "value": "National Newspaper, Inc."
         }
       ],

--- a/src/flat-prov/unreleased/examples/Entity-02-prov-ex2.json
+++ b/src/flat-prov/unreleased/examples/Entity-02-prov-ex2.json
@@ -20,12 +20,12 @@
       "attributes": [
         {
           "predicate": "dcterms:title",
-          "schema_type": "dlthings:AttributeSpecification",
+          "schema_type": "dlflat:FlatAttributeSpecification",
           "value": "More crime happens in cities"
         },
         {
           "predicate": "rdfs:value",
-          "schema_type": "dlthings:AttributeSpecification",
+          "schema_type": "dlflat:FlatAttributeSpecification",
           "value": "I was curious..."
         }
       ],
@@ -63,7 +63,7 @@
   "attributes": [
     {
       "predicate": "rdfs:value",
-      "schema_type": "dlthings:AttributeSpecification",
+      "schema_type": "dlflat:FlatAttributeSpecification",
       "value": "I was curious..."
     }
   ],

--- a/src/flat-prov/unreleased/examples/Entity-02-prov-quotation.json
+++ b/src/flat-prov/unreleased/examples/Entity-02-prov-quotation.json
@@ -3,7 +3,7 @@
   "attributes": [
     {
       "predicate": "rdfs:value",
-      "schema_type": "dlthings:AttributeSpecification",
+      "schema_type": "dlflat:FlatAttributeSpecification",
       "value": "During the workshop, it became clear to me that the consensus based models (which are often graphical in nature) can not only be formalized but also be directly connected to these database focused formalizations. I just needed to get over the differences in syntax.  This could imply that we could have nice way to trace provenance across systems and through databases and be able to understand the mathematical properties of this interconnection."
     }
   ],

--- a/src/flat/unreleased.yaml
+++ b/src/flat/unreleased.yaml
@@ -103,3 +103,45 @@ classes:
       - display_note
       - editorial_note
       - identifiers
+    slot_usage:
+      pid:
+      characterized_by:
+        range: FlatStatement
+      attributes:
+        range: FlatAttributeSpecification
+      relations:
+        range: FlatThing
+
+  FlatStatement:
+    is_a: Statement
+    description: >-
+      An RDF statement that links a `predicate` (a `Property`) with an
+      `object` (a `Thing`) to the subject to form a triple.
+      A `Statement` is used to qualify a relation to a `Thing` referenced
+      by its identifier. For specifying a qualified relation to an
+      attribute that has no dedicated identifier, use
+      an `AttributeSpecification`.
+    slot_usage:
+      predicate:
+        range: FlatProperty
+
+  FlatProperty:
+    is_a: Property
+    description: >-
+      An RDF property, a `Thing` used to define a `predicate`, for example
+      in a `Statement`.
+    slots:
+      - display_label
+      - display_note
+      - editorial_note
+
+  FlatAttributeSpecification:
+    is_a: AttributeSpecification
+    description: >-
+      An attribute is conceptually a thing, but it requires no dedicated
+      identifier (`pid`). Instead, it is linked to a `Thing` via its
+      `attributes` slot and declares a `predicate` on the nature of
+      the relationship.
+    slot_usage:
+      predicate:
+        range: FlatProperty


### PR DESCRIPTION
All other changes are more-or-less consequences.

This is done, because before it was impossible to name properties (custom slots). `things` doesn't have `name`, and `Property` did not have `display_label` either.

This change also prepared for https://github.com/psychoinformatics-de/datalad-concepts/issues/479 which proposed to merge `flat` into `things` and make the result the basis for `things/v2`