### PR TITLE
Revert the `range` change for `relations`

### DIFF
--- a/src/flat/unreleased.yaml
+++ b/src/flat/unreleased.yaml
@@ -109,8 +109,6 @@ classes:
         range: FlatStatement
       attributes:
         range: FlatAttributeSpecification
-      relations:
-        range: FlatThing
       annotations:
         range: FlatAnnotation
 


### PR DESCRIPTION
I changed it to `FlatThing`, but this was unnecessary and caused test breakage.