### PR TITLE
Define `CiTO` prefix

### DIFF
--- a/src/demo-rse-group/unreleased.yaml
+++ b/src/demo-rse-group/unreleased.yaml
@@ -29,6 +29,7 @@ license: MIT
 
 prefixes:
   ADMS: http://www.w3.org/ns/adms#
+  CiTO: http://purl.org/spar/cito/
   ISSN: http://identifiers.org/issn/
   ODRL: http://www.w3.org/ns/odrl/2/
   bibo: http://purl.org/ontology/bibo/


### PR DESCRIPTION
This is essential for linking publications to the objects they are about.

Closes: https://github.com/psychoinformatics-de/datalad-concepts/issues/422