### PR TITLE
feat: add `depiction` slot to `XYZPerson`

### DIFF
--- a/src/demo-rse-group/unreleased.yaml
+++ b/src/demo-rse-group/unreleased.yaml
@@ -165,6 +165,19 @@ slots:
         range `Thing`. The concrete, initial use case was PROV's
         Communication.
 
+  depiction:
+    title: Depiction
+    description: >-
+      An image, or photograph information, or other visualization that
+      annotates some aspect of the subject (e.g., a digital image of a
+      portrait of a person).
+    range: Thing
+    exact_mappings:
+      - foaf:depiction
+    narrow_mappings:
+      - vcard:photo
+
+
 classes:
   # Classes here are grouped by their nature:
   # - Things with a provenance interface
@@ -607,6 +620,7 @@ classes:
       Person agents are people, alive, dead, or fictional.
     slots:
       - nickname
+      - depiction
     slot_usage:
       family_name:
         annotations:
@@ -630,6 +644,11 @@ classes:
         annotations:
           sh:order: 6.0
           dash:singleLine: false
+      depiction:
+        title: Photo
+        annotations:
+          sh:order: 6.5
+          shaclvue:gitAnnexUpload: true
       delegated_by:
         range: XYZDelegation
         multivalued: true


### PR DESCRIPTION
This keeps the range `Thing`, for now (unlike the issue's proposal).

We will quickly want to be able to have more than one picture of a Thing. And when we do, this needs to be multivalued. And then we need a way to tag which one is, e.g., a portrait, or a schema, or a graphical abstract, etc...

Closes: https://github.com/psychoinformatics-de/datalad-concepts/issues/498