### PR TITLE
Adds 'distributions' slot to 'XYZDocument' class

### DIFF
--- a/src/demo-rse-group/unreleased.yaml
+++ b/src/demo-rse-group/unreleased.yaml
@@ -164,7 +164,6 @@ slots:
       - dcat:distribution
     broad_mappings:
       - sio:SIO_000341
-    inverse: distribution_of
 
   entity:
     description: >-


### PR DESCRIPTION
closes https://github.com/psychoinformatics-de/datalad-concepts/issues/502

The need for this originated when the UI/UX for file upload could not intuitively lead a user from the created document to the download link of the related distribution.

Locally generating the SHACL gives a warning regarding the `inverse_of` usage:

```
gen-shacl --include-annotations --include-stripped-prefixes --exclude-order src/demo-rse-group/unreleased.yaml > rsegroup.shacl.ttl

WARNING:linkml.utils.generator:Range of slot 'distributions' (XYZDistribution) does not line with the domain of its inverse (distribution_of)
WARNING:linkml.utils.generator:Range of slot 'distribution_of' (Thing) does not line with the domain of its inverse (distributions)
```

I removed it to avoid the class mismatch and warning.
