### PR TITLE
fix: clarify additional_names description

### DIFF
--- a/src/social-mixin/unreleased.yaml
+++ b/src/social-mixin/unreleased.yaml
@@ -103,7 +103,7 @@ slots:
     title: Additional names
     description: >-
       Additional name(s) associated with the subject, such as one or more
-      middle names, or a nick name.
+      middle names.
     range: string
     exact_mappings:
       - vcard:additional_name


### PR DESCRIPTION
After a nickname property was added in 3d485d9, it became confusing to have it suggested for additional_names, too.