### PR TITLE
fix: properly disable schema plot generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,6 @@ build/linkml-docs/s/%: src/%.yaml src/%/extra-docs
 	$(MAKE) imports-local
 	gen-doc \
 		--hierarchical-class-view \
-		--include-top-level-diagram \
-		--diagram-type er_diagram \
 		--metadata \
 		--format markdown \
 		--example-directory src/$*/examples/ \


### PR DESCRIPTION
The mermaid plugin was already disabled in
4f86e06a66a026a86b5bcbbd0c790806574e956b, because the schema are too big for it.

But this left the mermaid code on the pages, and this change removes that too.